### PR TITLE
feat: expose read and write timeouts to the user

### DIFF
--- a/patch.c
+++ b/patch.c
@@ -96,7 +96,7 @@ int patch_load(const char *patch_file)
 	return 0;
 }
 	
-int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch))
+int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch, unsigned int timeout))
 {
 	struct patch *patch;
 	int ret;

--- a/patch.h
+++ b/patch.h
@@ -17,6 +17,6 @@ struct patch {
 };
 
 int patch_load(const char *patch_file);
-int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch));
+int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch, unsigned int timeout));
 
 #endif

--- a/program.c
+++ b/program.c
@@ -97,7 +97,7 @@ int program_load(const char *program_file)
 	return 0;
 }
 	
-int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),
+int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd, unsigned int read_timeout, unsigned int write_timeout),
 		    const char *incdir)
 {
 	struct program *program;

--- a/program.h
+++ b/program.h
@@ -17,7 +17,7 @@ struct program {
 };
 
 int program_load(const char *program_file);
-int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),
+int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd, unsigned int read_timeout, unsigned int write_timeout),
 		    const char *incdir);
 int program_find_bootable_partition(void);
 

--- a/qdl.h
+++ b/qdl.h
@@ -10,9 +10,9 @@
 struct qdl_device;
 
 int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, bool eot);
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, bool eot, unsigned int timeout);
 
-int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage);
+int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, unsigned int read_timeout, unsigned int write_timeout);
 int sahara_run(struct qdl_device *qdl, char *prog_mbn);
 void print_hex_dump(const char *prefix, const void *buf, size_t len);
 unsigned attr_as_unsigned(xmlNode *node, const char *attr, int *errors);

--- a/ufs.c
+++ b/ufs.c
@@ -264,9 +264,9 @@ int ufs_load(const char *ufs_file, bool finalize_provisioning)
 }
 
 int ufs_provisioning_execute(struct qdl_device *qdl,
-	int (*apply_ufs_common)(struct qdl_device *, struct ufs_common*),
-	int (*apply_ufs_body)(struct qdl_device *, struct ufs_body*),
-	int (*apply_ufs_epilogue)(struct qdl_device *, struct ufs_epilogue*, bool))
+	int (*apply_ufs_common)(struct qdl_device *, struct ufs_common*, unsigned int, unsigned int),
+	int (*apply_ufs_body)(struct qdl_device *, struct ufs_body*, unsigned int, unsigned int),
+	int (*apply_ufs_epilogue)(struct qdl_device *, struct ufs_epilogue*, bool, unsigned int, unsigned int))
 {
 	int ret;
 	struct ufs_body *body;

--- a/ufs.h
+++ b/ufs.h
@@ -67,9 +67,9 @@ struct ufs_epilogue {
 
 int ufs_load(const char *ufs_file, bool finalize_provisioning);
 int ufs_provisioning_execute(struct qdl_device *qdl,
-	int (*apply_ufs_common)(struct qdl_device *qdl, struct ufs_common *ufs),
-	int (*apply_ufs_body)(struct qdl_device *qdl, struct ufs_body *ufs),
-	int (*apply_ufs_epilogue)(struct qdl_device *qdl, struct ufs_epilogue *ufs, bool commit));
+	int (*apply_ufs_common)(struct qdl_device *qdl, struct ufs_common *ufs, unsigned int read_timeout, unsigned int write_timeout),
+	int (*apply_ufs_body)(struct qdl_device *qdl, struct ufs_body *ufs, unsigned int read_timeout, unsigned int write_timeout),
+	int (*apply_ufs_epilogue)(struct qdl_device *qdl, struct ufs_epilogue *ufs, bool commit, unsigned intread_timeout, unsigned int write_timeout));
 bool ufs_need_provisioning(void);
 
 #endif


### PR DESCRIPTION
Added additional, optional CLI arguments to expose the timeouts
for reading and writing to the end user.  Hardcoded timeouts can
sometimes fail for large flashes.