### PR TITLE
Add support for <read> operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS := -O2 -Wall -g `pkg-config --cflags libxml-2.0`
 LDFLAGS := `pkg-config --libs libxml-2.0 libudev`
 prefix := /usr/local
 
-SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c ufs.c
+SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c
 OBJS := $(SRCS:.c=.o)
 
 KS_OUT := ks

--- a/qdl.c
+++ b/qdl.c
@@ -62,6 +62,7 @@ enum {
 	QDL_FILE_UNKNOWN,
 	QDL_FILE_PATCH,
 	QDL_FILE_PROGRAM,
+	QDL_FILE_READ,
 	QDL_FILE_UFS,
 	QDL_FILE_CONTENTS,
 };
@@ -91,6 +92,10 @@ static int detect_type(const char *xml_file)
 				continue;
 			if (!xmlStrcmp(node->name, (xmlChar*)"program")) {
 				type = QDL_FILE_PROGRAM;
+				break;
+			}
+			if (!xmlStrcmp(node->name, (xmlChar*)"read")) {
+				type = QDL_FILE_READ;
 				break;
 			}
 			if (!xmlStrcmp(node->name, (xmlChar*)"ufs")) {
@@ -454,6 +459,11 @@ int main(int argc, char **argv)
 			ret = program_load(argv[optind], !strcmp(storage, "nand"));
 			if (ret < 0)
 				errx(1, "program_load %s failed", argv[optind]);
+			break;
+		case QDL_FILE_READ:
+			ret = read_op_load(argv[optind]);
+			if (ret < 0)
+				errx(1, "read_op_load %s failed", argv[optind]);
 			break;
 		case QDL_FILE_UFS:
 			ret = ufs_load(argv[optind],qdl_finalize_provisioning);

--- a/qdl.h
+++ b/qdl.h
@@ -5,6 +5,7 @@
 
 #include "patch.h"
 #include "program.h"
+#include "read.h"
 #include <libxml/tree.h>
 
 #define MAPPING_SZ 64

--- a/read.c
+++ b/read.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016-2017, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include "read.h"
+#include "qdl.h"
+
+static struct read_op *read_ops;
+static struct read_op *read_ops_last;
+
+int read_op_load(const char *read_op_file)
+{
+	struct read_op *read_op;
+	xmlNode *node;
+	xmlNode *root;
+	xmlDoc *doc;
+	int errors;
+
+	doc = xmlReadFile(read_op_file, NULL, 0);
+	if (!doc) {
+		fprintf(stderr, "[READ] failed to parse %s\n", read_op_file);
+		return -EINVAL;
+	}
+
+	root = xmlDocGetRootElement(doc);
+	for (node = root->children; node ; node = node->next) {
+		if (node->type != XML_ELEMENT_NODE)
+			continue;
+
+		if (xmlStrcmp(node->name, (xmlChar*)"read")) {
+			fprintf(stderr, "[READ] unrecognized tag \"%s\", ignoring\n", node->name);
+			continue;
+		}
+
+		errors = 0;
+
+		read_op = calloc(1, sizeof(struct read_op));
+
+		read_op->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
+		read_op->filename = attr_as_string(node, "filename", &errors);
+		read_op->partition = attr_as_unsigned(node, "physical_partition_number", &errors);
+		read_op->num_sectors = attr_as_unsigned(node, "num_partition_sectors", &errors);
+		read_op->start_sector = attr_as_string(node, "start_sector", &errors);
+
+		if (errors) {
+			fprintf(stderr, "[READ] errors while parsing read\n");
+			free(read_op);
+			continue;
+		}
+
+		if (read_ops) {
+			read_ops_last->next = read_op;
+			read_ops_last = read_op;
+		} else {
+			read_ops = read_op;
+			read_ops_last = read_op;
+		}
+	}
+
+	xmlFreeDoc(doc);
+
+	return 0;
+}
+
+int read_op_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct read_op *read_op, int fd),
+				    const char *incdir)
+{
+	struct read_op *read_op;
+	const char *filename;
+	char tmp[PATH_MAX];
+	int ret;
+	int fd;
+
+	for (read_op = read_ops; read_op; read_op = read_op->next) {
+		filename = read_op->filename;
+		if (incdir) {
+			snprintf(tmp, PATH_MAX, "%s/%s", incdir, filename);
+			if (access(tmp, F_OK) != -1)
+				filename = tmp;
+		}
+
+		fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+
+		if (fd < 0) {
+			printf("Unable to open %s...\n", read_op->filename);
+			return ret;
+		}
+
+		ret = apply(qdl, read_op, fd);
+
+		close(fd);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}

--- a/read.h
+++ b/read.h
@@ -1,0 +1,22 @@
+#ifndef __READ_H__
+#define __READ_H__
+
+#include <stdbool.h>
+
+struct qdl_device;
+
+struct read_op {
+	unsigned sector_size;
+	const char *filename;
+	unsigned partition;
+	unsigned num_sectors;
+	const char *start_sector;
+	struct read_op *next;
+};
+
+int read_op_load(const char *read_op_file);
+int read_op_execute(struct qdl_device *qdl,
+					int (*apply)(struct qdl_device *qdl, struct read_op *read_op, int fd),
+					const char *incdir);
+
+#endif


### PR DESCRIPTION
These operations follow a similar syntax to `<program>` operations - just moving data in the other direction.

To avoid shadowing the `read` function, I used `read_op` for types/functions/variables (breaking the existing convention).

Tested on a QCS6490 SoC.