### PR TITLE
Fix gcc-14 compile errors

### DIFF
--- a/patch.c
+++ b/patch.c
@@ -30,6 +30,7 @@
  */
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 

--- a/program.c
+++ b/program.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>

--- a/util.c
+++ b/util.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 


### PR DESCRIPTION
this fails to compile using gcc-14 without including stdlib.h in the following files.  