### PR TITLE
program: fail correctly on unrecognized tags

### DIFF
--- a/program.c
+++ b/program.c
@@ -127,7 +127,7 @@ int program_load(const char *program_file, bool is_nand)
 	xmlNode *node;
 	xmlNode *root;
 	xmlDoc *doc;
-	int errors;
+	int errors = 0;
 
 	doc = xmlReadFile(program_file, NULL, 0);
 	if (!doc) {
@@ -140,8 +140,6 @@ int program_load(const char *program_file, bool is_nand)
 		if (node->type != XML_ELEMENT_NODE)
 			continue;
 
-		errors = -EINVAL;
-
 		if (!xmlStrcmp(node->name, (xmlChar *)"erase"))
 			errors = load_erase_tag(node, is_nand);
 		else if (!xmlStrcmp(node->name, (xmlChar *)"program"))
@@ -152,12 +150,13 @@ int program_load(const char *program_file, bool is_nand)
 		}
 
 		if (errors)
-			return errors;
+			goto out;
 	}
 
+out:
 	xmlFreeDoc(doc);
 
-	return 0;
+	return errors;
 }
 
 int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),

--- a/program.c
+++ b/program.c
@@ -146,8 +146,10 @@ int program_load(const char *program_file, bool is_nand)
 			errors = load_erase_tag(node, is_nand);
 		else if (!xmlStrcmp(node->name, (xmlChar *)"program"))
 			errors = load_program_tag(node, is_nand);
-		else
-			fprintf(stderr, "[PROGRAM] unrecognized tag \"%s\", ignoring\n", node->name);
+		else {
+			fprintf(stderr, "[PROGRAM] unrecognized tag \"%s\"\n", node->name);
+			errors = -EINVAL;
+		}
 
 		if (errors)
 			return errors;


### PR DESCRIPTION
Previously the message would be printed that the tag gets ignored but in reality the 'errors' variable will still be initialized as -EINVAL so the if below would return an error.

    [PROGRAM] unrecognized tag "zeroout", ignoring
    qdl: program_load rawprogram0.xml failed

Fix this.