### PR TITLE
Makefile: Generate compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 qdl
 ks
+compile_commands.json
+.cache

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ $(OUT): $(OBJS)
 $(KS_OUT): $(KS_OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
+compile_commands.json: $(SRCS) $(KS_SRCS)
+	@echo -n $^ | jq -snR "[inputs|split(\" \")[]|{directory:\"$(PWD)\", command: \"$(CC) $(CFLAGS) -c \(.)\", file:.}]" > $@
+
 clean:
 	rm -f $(OUT) $(OBJS)
 	rm -f $(KS_OUT) $(KS_OBJS)
+	rm -f compile_commands.json
 
 install: $(OUT) $(KS_OUT)
 	install -d $(DESTDIR)$(prefix)/bin


### PR DESCRIPTION
Introduce a make target for generating compile_commands.json to feed clangd and the Language Server Protocol, to gain better editor integration.

Add the relevant files to .gitignore.