### PR TITLE
Transition to libusb and support targeting device by serial number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 QDL := qdl
 RAMDUMP := qdl-ramdump
 
-CFLAGS := -O2 -Wall -g `pkg-config --cflags libxml-2.0`
-LDFLAGS := `pkg-config --libs libxml-2.0 libudev`
+CFLAGS := -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
+LDFLAGS := `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
 QDL_SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c ufs.c usb.c

--- a/README
+++ b/README
@@ -9,8 +9,8 @@ Usage:
 
 Building
 ========
-In order to build the project you need libxml2 and libudev headers
-and libraries, found in e.g. the libxml2-dev and libudev-dev packages
+In order to build the project you need libxml2 and libusb-1.0 headers
+and libraries, found in e.g. the libxml2-dev and libusb-1.0.0-dev packages
 
 With these installed run:
   make

--- a/qdl.c
+++ b/qdl.c
@@ -105,6 +105,7 @@ int main(int argc, char **argv)
 {
 	char *prog_mbn, *storage="ufs";
 	char *incdir = NULL;
+	char *serial = NULL;
 	int type;
 	int ret;
 	int opt;
@@ -115,11 +116,12 @@ int main(int argc, char **argv)
 		{"debug", no_argument, 0, 'd'},
 		{"include", required_argument, 0, 'i'},
 		{"finalize-provisioning", no_argument, 0, 'l'},
+		{"serial", required_argument, 0, 'S'},
 		{"storage", required_argument, 0, 's'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "di:", options, NULL )) != -1) {
+	while ((opt = getopt_long(argc, argv, "di:S:", options, NULL )) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -132,6 +134,9 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			storage = optarg;
+			break;
+		case 'S':
+			serial = optarg;
 			break;
 		default:
 			print_usage();
@@ -174,7 +179,7 @@ int main(int argc, char **argv)
 		}
 	} while (++optind < argc);
 
-	ret = qdl_open(&qdl);
+	ret = qdl_open(&qdl, serial);
 	if (ret)
 		return 1;
 

--- a/qdl.h
+++ b/qdl.h
@@ -9,7 +9,10 @@
 
 #define MAPPING_SZ 64
 
+struct libusb_device_handle;
+
 struct qdl_device {
+        struct libusb_device_handle *usb_handle;
         int fd;
 
         int in_ep;

--- a/qdl.h
+++ b/qdl.h
@@ -24,7 +24,7 @@ struct qdl_device {
         char *mappings[MAPPING_SZ]; // array index is the id from the device
 };
 
-int qdl_open(struct qdl_device *qdl);
+int qdl_open(struct qdl_device *qdl, const char *serial);
 int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
 int qdl_write(struct qdl_device *qdl, const void *buf, size_t len);
 

--- a/ramdump.c
+++ b/ramdump.c
@@ -21,22 +21,27 @@ int main(int argc, char **argv)
 	struct qdl_device qdl;
 	char *ramdump_path = ".";
 	char *filter = NULL;
+	char *serial = NULL;
 	int ret;
 	int opt;
 
 	static struct option options[] = {
 		{"debug", no_argument, 0, 'd'},
 		{"output", required_argument, 0, 'o'},
+		{"serial", required_argument, 0, 'S'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "do:", options, NULL )) != -1) {
+	while ((opt = getopt_long(argc, argv, "do:S:", options, NULL )) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
 			break;
 		case 'o':
 			ramdump_path = optarg;
+			break;
+		case 'S':
+			serial = optarg;
 			break;
 		default:
 			print_usage();
@@ -49,7 +54,7 @@ int main(int argc, char **argv)
 	if (optind != argc)
 		print_usage();
 
-	ret = qdl_open(&qdl);
+	ret = qdl_open(&qdl, serial);
 	if (ret)
 		return 1;
 


### PR DESCRIPTION
Transitioning to libusb avoids open-coded USB descriptor parsing and removes the strong dependency
on the Linux-specific ioctl-based interface.
This should allow QDL to run on other OSs, it cleans up the code a bit, and it allow us to more conveniently
implement reading of the string descriptors, for a serial number comparison, in the support for selecting a
specific board when more than one is available.