### PR TITLE
Makefile: prefer append on CFLAGS / LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 QDL := qdl
 RAMDUMP := qdl-ramdump
 
-CFLAGS := -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
-LDFLAGS := `pkg-config --libs libxml-2.0 libusb-1.0`
+CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
+LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
 QDL_SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c ufs.c usb.c


### PR DESCRIPTION
Append allows an external build system to pass custom cflags/ldflags to the local build system (make).

Useful with Yocto / OE as additional options can be given besides what is set with a force set in the Makefile.