### PR TITLE
usb: Allow building with older libusb

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -10,6 +10,16 @@
 
 #include "qdl.h"
 
+/*
+ * libusb commit f0cce43f882d ("core: Fix definition and use of enum
+ * libusb_transfer_type") split transfer type and endpoint transfer types.
+ * Provide an alias in order to make the code compile with the old (non-split)
+ * definition.
+ */
+#ifndef LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK
+#define LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK LIBUSB_TRANSFER_TYPE_BULK
+#endif
+
 static bool qdl_match_usb_serial(struct libusb_device_handle *handle, const char *serial,
 				 const struct libusb_device_descriptor *desc)
 {


### PR DESCRIPTION
libusb commit f0cce43f882d ("core: Fix definition and use of enum libusb_transfer_type") split the types of split transfer type and endpoint transfer, introducing LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK.

The result is that when building with older libusb, such the one available on Ubuntu 20.04 the build fails with the following error:

usb.c:84:16: error: ‘LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK’ undeclared (first use in this function); did you mean ‘LIBUSB_TRANSFER_TYPE_BULK’?

Introduce an alias using the preprocessor to make available the new define when building against the older version of libusb headers.