### PR TITLE
ci/build: Build across different Ubuntu variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The transition to libusb was tested on a few different Linux distros, but apparently not Ubuntu 20.04, which contains a slightly older version of the libusb includes.

Add Ubuntu 20.04 as a CI target to catch more such issues, and for good measure also add 24.04.