### PR TITLE
usb: Attempt detaching kernel driver

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -126,6 +126,8 @@ static int qdl_try_open(libusb_device *dev, struct qdl_device *qdl, const char *
 			continue;
 		}
 
+		libusb_detach_kernel_driver(handle, ifc->bInterfaceNumber);
+
 		ret = libusb_claim_interface(handle, ifc->bInterfaceNumber);
 		if (ret < 0) {
 			warnx("failed to claim USB interface");


### PR DESCRIPTION
In the event that the kernel have some other driver attached to the device the attempt claim of the interface will fail.

Lost in the libusb conversion was a call to USBDEVFS_DISCONNECT to first detach any such drivers. Reintroduce this by invoking libusb_detach_kernel_driver().

As with some other libusb functions there are multiple return values denoting "success", so rely on libusb_claim_interface() to catch the actual errors.

Reported-by: Maxim Akristiniy
Suggested-by: Maxim Akristiniy