### PR TITLE
usb: Allow overriding bulk write size and increase default

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -34,6 +34,7 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
@@ -101,6 +102,10 @@ static void print_usage(void)
 		__progname);
 }
 
+enum {
+	OPT_OUT_CHUNK_SIZE = 1000,
+};
+
 int main(int argc, char **argv)
 {
 	char *prog_mbn, *storage="ufs";
@@ -110,12 +115,13 @@ int main(int argc, char **argv)
 	int ret;
 	int opt;
 	bool qdl_finalize_provisioning = false;
-
+	long out_chunk_size;
 
 	static struct option options[] = {
 		{"debug", no_argument, 0, 'd'},
 		{"include", required_argument, 0, 'i'},
 		{"finalize-provisioning", no_argument, 0, 'l'},
+		{"out-chunk-size", required_argument, 0, OPT_OUT_CHUNK_SIZE },
 		{"serial", required_argument, 0, 'S'},
 		{"storage", required_argument, 0, 's'},
 		{0, 0, 0, 0}
@@ -131,6 +137,10 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			qdl_finalize_provisioning = true;
+			break;
+		case OPT_OUT_CHUNK_SIZE:
+			out_chunk_size = strtol(optarg, NULL, 10);
+			qdl_set_out_chunk_size(&qdl, out_chunk_size);
 			break;
 		case 's':
 			storage = optarg;

--- a/qdl.h
+++ b/qdl.h
@@ -20,6 +20,7 @@ struct qdl_device {
 
         size_t in_maxpktsize;
         size_t out_maxpktsize;
+        size_t out_chunk_size;
 
         char *mappings[MAPPING_SZ]; // array index is the id from the device
 };
@@ -27,6 +28,7 @@ struct qdl_device {
 int qdl_open(struct qdl_device *qdl, const char *serial);
 int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
 int qdl_write(struct qdl_device *qdl, const void *buf, size_t len);
+void qdl_set_out_chunk_size(struct qdl_device *qdl, long size);
 
 int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage);
 int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,


### PR DESCRIPTION
Since commit 760b3dffb03d ("qdl: Rework qdl_write to limit write sizes to out_maxpktsize") outgoing transfers has been chunked into blocks of wMaxPacketSize.

As reported by Wiktor Drewniak, Maksim Paimushkin, and Luca Weiss in [1] there's huge benefits to be found in reverting this change, but out of caution the limit was untouched.

With the transition to libusb, the throughput dropped another ~15% on my machine. The numbers for HighSpeed and SuperSpeed are also in the same ballpark.

With SuperSpeed, benchmarking of different chunk sizes in the megabyte range shows improvement over these numbers in the range of 15-20x on the same machine/board combination.

The bug report related to the reduction in size describes a host machine running out of swiotlb, from the fact that we requested 1MB physically contiguous memory. It's unclear if attempts was made to correct the kernel's behavior. libusb does inquiry the capabilities of the kernel and will split the buffer and submitting multiple URBs at once, as needed.  While no definitive guidance has been found, multiple sources seems to recommend passing 1-2MB of buffer to libusb at a time.  So, let's move the default chunk size back up to 1MB and hope that libusb resolves the reported problem.

Additionally, introduce a new option --out-chunk-size, which allow the user to override the chunk size. This would allow any user to reduce the size if needed, but also allow the value to be increased as needed.

[1] https://github.com/linux-msm/qdl/pull/39

Reported-by: Wiktor Drewniak
Reported-by: Maksim Paimushkin
Reported-by: Luca Weiss