### PR TITLE
qdl: firehose: program: fail on missing file

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -725,7 +725,7 @@ static int firehose_reset(struct qdl_device *qdl)
 	return ret == FIREHOSE_ACK ? 0 : -1;
 }
 
-int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage)
+int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, bool allow_missing)
 {
 	int bootable;
 	int ret;
@@ -756,7 +756,7 @@ int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage
 	if (ret)
 		return ret;
 
-	ret = program_execute(qdl, firehose_program, incdir);
+	ret = program_execute(qdl, firehose_program, incdir, allow_missing);
 	if (ret)
 		return ret;
 

--- a/program.c
+++ b/program.c
@@ -160,7 +160,7 @@ out:
 }
 
 int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),
-		    const char *incdir)
+		    const char *incdir, bool allow_missing)
 {
 	struct program *program;
 	const char *filename;
@@ -182,7 +182,12 @@ int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl,
 		fd = open(filename, O_RDONLY);
 
 		if (fd < 0) {
-			printf("Unable to open %s...ignoring\n", program->filename);
+			printf("Unable to open %s", program->filename);
+			if (!allow_missing) {
+				printf("...failing\n");
+				return -1;
+			}
+			printf("...ignoring\n");
 			continue;
 		}
 

--- a/program.h
+++ b/program.h
@@ -23,7 +23,7 @@ struct program {
 
 int program_load(const char *program_file, bool is_nand);
 int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),
-		    const char *incdir);
+		    const char *incdir, bool allow_missing);
 int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program));
 int program_find_bootable_partition(void);
 

--- a/qdl.c
+++ b/qdl.c
@@ -103,7 +103,7 @@ static void print_usage(void)
 {
 	extern const char *__progname;
 	fprintf(stderr,
-		"%s [--debug] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--include <PATH>] <prog.mbn> [<program> <patch> ...]\n",
+		"%s [--debug] [--allow-missing] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--include <PATH>] <prog.mbn> [<program> <patch> ...]\n",
 		__progname);
 }
 
@@ -120,6 +120,7 @@ int main(int argc, char **argv)
 	int ret;
 	int opt;
 	bool qdl_finalize_provisioning = false;
+	bool allow_missing = false;
 	long out_chunk_size;
 
 	static struct option options[] = {
@@ -129,13 +130,17 @@ int main(int argc, char **argv)
 		{"out-chunk-size", required_argument, 0, OPT_OUT_CHUNK_SIZE },
 		{"serial", required_argument, 0, 'S'},
 		{"storage", required_argument, 0, 's'},
+		{"allow-missing", no_argument, 0, 'f'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "di:S:", options, NULL )) != -1) {
+	while ((opt = getopt_long(argc, argv, "dfi:S:", options, NULL )) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
+			break;
+		case 'f':
+			allow_missing = true;
 			break;
 		case 'i':
 			incdir = optarg;
@@ -208,7 +213,7 @@ int main(int argc, char **argv)
 	if (ret < 0)
 		return 1;
 
-	ret = firehose_run(&qdl, incdir, storage);
+	ret = firehose_run(&qdl, incdir, storage, allow_missing);
 	if (ret < 0)
 		return 1;
 

--- a/qdl.h
+++ b/qdl.h
@@ -31,7 +31,7 @@ int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout
 int qdl_write(struct qdl_device *qdl, const void *buf, size_t len);
 void qdl_set_out_chunk_size(struct qdl_device *qdl, long size);
 
-int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage);
+int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, bool allow_missing);
 int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 	       const char *ramdump_path, const char *ramdump_filter);
 void print_hex_dump(const char *prefix, const void *buf, size_t len);


### PR DESCRIPTION
When parsing XML files the specified binary to be flashed may not be present. The default behaviour of QDL is to ignore missing file. This is sometimes undesireble.

This patch introduces optional flag --fail-on-missing which will enforce failure of flashing procedure if there is a missing file name.