### PR TITLE
firehose: Allow bConfigDescrLock to be passed as 1

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -613,7 +613,7 @@ int firehose_apply_ufs_common(struct qdl_device *qdl, struct ufs_common *ufs)
 	xml_setpropf(node_to_send, "bSecureRemovalType", "%d", ufs->bSecureRemovalType);
 	xml_setpropf(node_to_send, "bInitActiveICCLevel", "%d", ufs->bInitActiveICCLevel);
 	xml_setpropf(node_to_send, "wPeriodicRTCUpdate", "%d", ufs->wPeriodicRTCUpdate);
-	xml_setpropf(node_to_send, "bConfigDescrLock", "%d", 0/*ufs->bConfigDescrLock*/); //Safety, remove before fly
+	xml_setpropf(node_to_send, "bConfigDescrLock", "%d", ufs->bConfigDescrLock);
 
 	ret = firehose_send_single_tag(qdl, node_to_send);
 	if (ret)


### PR DESCRIPTION
During the introduction of UFS provisioning, the author left behind an additional safety measure of forcing the user to explicitly modify the source and recompile QDL in order to be able to lock the provisioning, to avoid users accidentally doing so.

While it does reduce the risk of irreversable mistakes, it's not suitable when QDL is distributed as a binary - and the user already need to set bConfigDescrLock both in provided XML files and on command line.

So, let's remove the safety net...