### PR TITLE
.github: use actions/checkout v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Dependencies (Ubuntu)
         if: runner.os == 'Linux'


### PR DESCRIPTION
v2 has been deprecated for a while now, and generates a bunch of warnings each time an action is executed.