### PR TITLE
ufs: add support for UFS WriteBooster feature

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -615,6 +615,12 @@ int firehose_apply_ufs_common(struct qdl_device *qdl, struct ufs_common *ufs)
 	xml_setpropf(node_to_send, "wPeriodicRTCUpdate", "%d", ufs->wPeriodicRTCUpdate);
 	xml_setpropf(node_to_send, "bConfigDescrLock", "%d", ufs->bConfigDescrLock);
 
+	if (ufs->wb) {
+		xml_setpropf(node_to_send, "bWriteBoosterBufferPreserveUserSpaceEn", "%d", ufs->bWriteBoosterBufferPreserveUserSpaceEn);
+		xml_setpropf(node_to_send, "bWriteBoosterBufferType", "%d", ufs->bWriteBoosterBufferType);
+		xml_setpropf(node_to_send, "shared_wb_buffer_size_in_kb", "%d", ufs->shared_wb_buffer_size_in_kb);
+	}
+
 	ret = firehose_send_single_tag(qdl, node_to_send);
 	if (ret)
 		fprintf(stderr, "[APPLY UFS common] %d\n", ret);

--- a/ufs.c
+++ b/ufs.c
@@ -86,6 +86,13 @@ struct ufs_common *ufs_parse_common_params(xmlNode *node, bool finalize_provisio
 		return NULL;
 	}
 
+	/* These parameters are optional */
+	errors = 0;
+	result->bWriteBoosterBufferPreserveUserSpaceEn = !!attr_as_unsigned(node, "bWriteBoosterBufferPreserveUserSpaceEn", &errors);
+	result->bWriteBoosterBufferType = !!attr_as_unsigned(node, "bWriteBoosterBufferType", &errors);
+	result->shared_wb_buffer_size_in_kb = attr_as_unsigned(node, "shared_wb_buffer_size_in_kb", &errors);
+	result->wb = !errors;
+
 	return result;
 }
 

--- a/ufs.h
+++ b/ufs.h
@@ -42,6 +42,10 @@ struct ufs_common {
 	unsigned	bInitActiveICCLevel;
 	unsigned	wPeriodicRTCUpdate;
 	bool		bConfigDescrLock;
+	bool            wb;
+	bool            bWriteBoosterBufferPreserveUserSpaceEn;
+	bool            bWriteBoosterBufferType;
+	unsigned        shared_wb_buffer_size_in_kb;
 };
 
 struct ufs_body {


### PR DESCRIPTION
WriteBooster is a new feature added in UFS3.1. There are new paramaters in the UFS header config. Trying to provision a 3.1+ device without these parameters fail.

Also make sure that we don't send them on older devices.