### PR TITLE
firehose: Handle multiple primary bootloaders

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -748,6 +748,7 @@ static int firehose_reset(struct qdl_device *qdl)
 
 int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, bool allow_missing)
 {
+	bool multiple;
 	int bootable;
 	int ret;
 
@@ -789,11 +790,17 @@ int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage
 	if (ret)
 		return ret;
 
-	bootable = program_find_bootable_partition();
-	if (bootable < 0)
+	bootable = program_find_bootable_partition(&multiple);
+	if (bootable < 0) {
 		fprintf(stderr, "no boot partition found\n");
-	else
+	} else {
+		if (multiple) {
+			fprintf(stderr,
+				"WARNING: Multiple candidates for primary bootloader found, using partition %d\n",
+				bootable);
+		}
 		firehose_set_bootable(qdl, bootable);
+	}
 
 	firehose_reset(qdl);
 

--- a/program.h
+++ b/program.h
@@ -25,7 +25,7 @@ int program_load(const char *program_file, bool is_nand);
 int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd),
 		    const char *incdir, bool allow_missing);
 int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program));
-int program_find_bootable_partition(void);
+int program_find_bootable_partition(bool *multiple_found);
 void free_programs(void);
 
 #endif


### PR DESCRIPTION
Builds with multiple copies of the primary bootloader does not make sense, but after successfully flashing all the partitions of such build it makes more sense to make one of them bootable, at least more than skipping the step and saying that none was found.

Pick the first found primary bootloader and warn the user about the situation.