### PR TITLE
qdl: add support for dry run execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
-QDL_SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c usb.c ux.c oscompat.c
+QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c usb.c ux.c oscompat.c
 QDL_OBJS := $(QDL_SRCS:.c=.o)
 
-RAMDUMP_SRCS := ramdump.c sahara.c usb.c util.c ux.c oscompat.c
+RAMDUMP_SRCS := ramdump.c sahara.c io.c usb.c util.c ux.c oscompat.c
 RAMDUMP_OBJS := $(RAMDUMP_SRCS:.c=.o)
 
 KS_OUT := ks

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
-QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c usb.c ux.c oscompat.c
+QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sim.c ufs.c usb.c ux.c oscompat.c
 QDL_OBJS := $(QDL_SRCS:.c=.o)
 
-RAMDUMP_SRCS := ramdump.c sahara.c io.c usb.c util.c ux.c oscompat.c
+RAMDUMP_SRCS := ramdump.c sahara.c io.c sim.c usb.c util.c ux.c oscompat.c
 RAMDUMP_OBJS := $(RAMDUMP_SRCS:.c=.o)
 
 KS_OUT := ks

--- a/firehose.c
+++ b/firehose.c
@@ -146,6 +146,10 @@ static int firehose_read(struct qdl_device *qdl, int timeout_ms,
 	gettimeofday(&now, NULL);
 	timeradd(&now, &delta, &timeout);
 
+	/* In simulation mode we don't expent to read and parse any responses */
+	if (qdl->dev_type == QDL_DEVICE_SIM)
+		return 0;
+
 	do {
 		n = qdl_read(qdl, buf, sizeof(buf), 100);
 		if (n <= 0) {
@@ -298,7 +302,12 @@ static int firehose_configure(struct qdl_device *qdl, bool skip_storage_init, co
 			return -1;
 		}
 
-		max_payload_size = size;
+		/*
+		 * Simulated target doesn't provide any valid payload size, so
+		 * for QDL_DEVICE_SIM dev type we keep old max_payload_size value
+		 */
+		if (qdl->dev_type != QDL_DEVICE_SIM)
+			max_payload_size = size;
 	}
 
 	ux_debug("accepted max payload size: %zu\n", max_payload_size);

--- a/io.c
+++ b/io.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdlib.h>
+
+#include "qdl.h"
+
+struct qdl_device *qdl_init(enum QDL_DEVICE_TYPE type)
+{
+	if (type == QDL_DEVICE_USB)
+		return usb_init();
+
+	return NULL;
+}
+
+void qdl_deinit(struct qdl_device *qdl)
+{
+	if (qdl)
+		free(qdl);
+}
+
+void qdl_set_out_chunk_size(struct qdl_device *qdl, long size)
+{
+	qdl->set_out_chunk_size(qdl, size);
+}
+
+int qdl_open(struct qdl_device *qdl, const char *serial)
+{
+	return qdl->open(qdl, serial);
+}
+
+void qdl_close(struct qdl_device *qdl)
+{
+	qdl->close(qdl);
+}
+
+int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
+{
+	return qdl->read(qdl, buf, len, timeout);
+}
+
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
+{
+	return qdl->write(qdl, buf, len);
+}

--- a/qdl.c
+++ b/qdl.c
@@ -107,7 +107,7 @@ static void print_usage(void)
 {
 	extern const char *__progname;
 	fprintf(stderr,
-		"%s [--debug] [--version] [--allow-missing] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--include <PATH>] [--serial <NUM>] [--out-chunk-size <SIZE>] <prog.mbn> [<program> <patch> ...]\n",
+		"%s [--debug] [--dry-run] [--version] [--allow-missing] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--include <PATH>] [--serial <NUM>] [--out-chunk-size <SIZE>] <prog.mbn> [<program> <patch> ...]\n",
 		__progname);
 }
 
@@ -140,6 +140,7 @@ int main(int argc, char **argv)
 		{"storage", required_argument, 0, 's'},
 		{"allow-missing", no_argument, 0, 'f'},
 		{"allow-fusing", no_argument, 0, 'c'},
+		{"dry-run", no_argument, 0, 'n'},
 		{0, 0, 0, 0}
 	};
 
@@ -147,6 +148,9 @@ int main(int argc, char **argv)
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
+			break;
+		case 'n':
+			qdl_dev_type = QDL_DEVICE_SIM;
 			break;
 		case 'v':
 			print_version();

--- a/qdl.h
+++ b/qdl.h
@@ -13,6 +13,7 @@
 enum QDL_DEVICE_TYPE
 {
 	QDL_DEVICE_USB,
+        QDL_DEVICE_SIM,
 };
 
 struct qdl_device
@@ -40,6 +41,7 @@ int qdl_write(struct qdl_device *qdl, const void *buf, size_t len);
 void qdl_set_out_chunk_size(struct qdl_device *qdl, long size);
 
 struct qdl_device *usb_init(void);
+struct qdl_device *sim_init(void);
 
 int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, bool allow_missing);
 int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,

--- a/sahara.c
+++ b/sahara.c
@@ -469,6 +469,13 @@ int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 	bool done = false;
 	int n;
 
+	/*
+	 * Don't need to do anything in simulation mode with Sahara,
+	 * we care only about Firehose protocol
+	 */
+	if (qdl->dev_type == QDL_DEVICE_SIM)
+		return 0;
+
 	while (!done) {
 		n = qdl_read(qdl, buf, sizeof(buf), 1000);
 		if (n < 0)

--- a/sim.c
+++ b/sim.c
@@ -28,47 +28,56 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <stdlib.h>
+#include <string.h>
 
 #include "qdl.h"
 
-struct qdl_device *qdl_init(enum QDL_DEVICE_TYPE type)
+struct qdl_device_sim
 {
-	if (type == QDL_DEVICE_USB)
-		return usb_init();
+	struct qdl_device base;
+};
 
-	if (type == QDL_DEVICE_SIM)
-		return sim_init();
+static int sim_open(struct qdl_device *qdl, const char *serial)
+{
+	ux_info("This is a dry-run execution of QDL. No actual flashing has been performed\n");
 
-	return NULL;
+	return 0;
 }
 
-void qdl_deinit(struct qdl_device *qdl)
+static void sim_close(struct qdl_device *qdl)
 {
-	if (qdl)
-		free(qdl);
+	return;
 }
 
-void qdl_set_out_chunk_size(struct qdl_device *qdl, long size)
+static int sim_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
 {
-	qdl->set_out_chunk_size(qdl, size);
+	return len;
 }
 
-int qdl_open(struct qdl_device *qdl, const char *serial)
+static int sim_write(struct qdl_device *qdl, const void *buf, size_t len)
 {
-	return qdl->open(qdl, serial);
+	return len;
 }
 
-void qdl_close(struct qdl_device *qdl)
+static void sim_set_out_chunk_size(struct qdl_device *qdl, long size)
 {
-	qdl->close(qdl);
+	return;
 }
 
-int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
+struct qdl_device *sim_init(void)
 {
-	return qdl->read(qdl, buf, len, timeout);
-}
+	struct qdl_device *qdl = malloc(sizeof(struct qdl_device_sim));
+	if (!qdl)
+		return NULL;
 
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
-{
-	return qdl->write(qdl, buf, len);
+	memset(qdl, 0, sizeof(struct qdl_device_sim));
+
+	qdl->dev_type = QDL_DEVICE_SIM;
+	qdl->open = sim_open;
+	qdl->read = sim_read;
+	qdl->write = sim_write;
+	qdl->close = sim_close;
+	qdl->set_out_chunk_size = sim_set_out_chunk_size;
+
+	return qdl;
 }

--- a/usb.c
+++ b/usb.c
@@ -9,7 +9,24 @@
 
 #include "qdl.h"
 
+#define container_of(ptr, typecast, member) ({                  \
+	void *_ptr = (void *)(ptr);		                \
+	((typecast *)(_ptr - offsetof(typecast, member))); })
+
 #define DEFAULT_OUT_CHUNK_SIZE (1024 * 1024)
+
+struct qdl_device_usb
+{
+	struct qdl_device base;
+	struct libusb_device_handle *usb_handle;
+
+	int in_ep;
+	int out_ep;
+
+	size_t in_maxpktsize;
+	size_t out_maxpktsize;
+	size_t out_chunk_size;
+};
 
 /*
  * libusb commit f0cce43f882d ("core: Fix definition and use of enum
@@ -21,7 +38,7 @@
 #define LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK LIBUSB_TRANSFER_TYPE_BULK
 #endif
 
-static bool qdl_match_usb_serial(struct libusb_device_handle *handle, const char *serial,
+static bool usb_match_usb_serial(struct libusb_device_handle *handle, const char *serial,
 				 const struct libusb_device_descriptor *desc)
 {
 	char buf[128];
@@ -48,7 +65,7 @@ static bool qdl_match_usb_serial(struct libusb_device_handle *handle, const char
 	return strcmp(p, serial) == 0;
 }
 
-static int qdl_try_open(libusb_device *dev, struct qdl_device *qdl, const char *serial)
+static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
 {
 	const struct libusb_endpoint_descriptor *endpoint;
 	const struct libusb_interface_descriptor *ifc;
@@ -122,7 +139,7 @@ static int qdl_try_open(libusb_device *dev, struct qdl_device *qdl, const char *
 			continue;
 		}
 
-		if (!qdl_match_usb_serial(handle, serial, &desc)) {
+		if (!usb_match_usb_serial(handle, serial, &desc)) {
 			libusb_close(handle);
 			continue;
 		}
@@ -160,10 +177,11 @@ static int qdl_try_open(libusb_device *dev, struct qdl_device *qdl, const char *
 	return !!qdl->usb_handle;
 }
 
-int qdl_open(struct qdl_device *qdl, const char *serial)
+static int usb_open(struct qdl_device *qdl, const char *serial)
 {
 	struct libusb_device **devs;
 	struct libusb_device *dev;
+	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
 	bool wait_printed = false;
 	bool found = false;
 	ssize_t n;
@@ -182,7 +200,7 @@ int qdl_open(struct qdl_device *qdl, const char *serial)
 		for (i = 0; devs[i]; i++) {
 			dev = devs[i];
 
-			ret = qdl_try_open(dev, qdl, serial);
+			ret = usb_try_open(dev, qdl_usb, serial);
 			if (ret == 1) {
 				found = true;
 				break;
@@ -205,18 +223,21 @@ int qdl_open(struct qdl_device *qdl, const char *serial)
 	return -1;
 }
 
-void qdl_close(struct qdl_device *qdl)
+static void usb_close(struct qdl_device *qdl)
 {
-	libusb_close(qdl->usb_handle);
+	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
+
+	libusb_close(qdl_usb->usb_handle);
 	libusb_exit(NULL);
 }
 
-int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
+static int usb_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
 {
+	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
 	int actual;
 	int ret;
 
-	ret = libusb_bulk_transfer(qdl->usb_handle, qdl->in_ep, buf, len, &actual, timeout);
+	ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->in_ep, buf, len, &actual, timeout);
 	if ((ret != 0 && ret != LIBUSB_ERROR_TIMEOUT) ||
 	    (ret == LIBUSB_ERROR_TIMEOUT && actual == 0))
 		return -1;
@@ -224,9 +245,10 @@ int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout
 	return actual;
 }
 
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
+static int usb_write(struct qdl_device *qdl, const void *buf, size_t len)
 {
 	unsigned char *data = (unsigned char*) buf;
+	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
 	unsigned int count = 0;
 	size_t len_orig = len;
 	int actual;
@@ -234,9 +256,9 @@ int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
 	int ret;
 
 	while (len > 0) {
-		xfer = (len > qdl->out_chunk_size) ? qdl->out_chunk_size : len;
+		xfer = (len > qdl_usb->out_chunk_size) ? qdl_usb->out_chunk_size : len;
 
-		ret = libusb_bulk_transfer(qdl->usb_handle, qdl->out_ep, data,
+		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->out_ep, data,
 					   xfer, &actual, 1000);
 		if ((ret != 0 && ret != LIBUSB_ERROR_TIMEOUT) ||
 		    (ret == LIBUSB_ERROR_TIMEOUT && actual == 0)) {
@@ -249,8 +271,8 @@ int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
 		data += actual;
 	}
 
-	if (len_orig % qdl->out_maxpktsize == 0) {
-		ret = libusb_bulk_transfer(qdl->usb_handle, qdl->out_ep, NULL,
+	if (len_orig % qdl_usb->out_maxpktsize == 0) {
+		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->out_ep, NULL,
 					   0, &actual, 1000);
 		if (ret < 0)
 			return -1;
@@ -259,7 +281,25 @@ int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
 	return count;
 }
 
-void qdl_set_out_chunk_size(struct qdl_device *qdl, long size)
+static void usb_set_out_chunk_size(struct qdl_device *qdl, long size)
 {
-	qdl->out_chunk_size = size;
+	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
+
+	qdl_usb->out_chunk_size = size;
+}
+
+struct qdl_device *usb_init(void)
+{
+	struct qdl_device *qdl = malloc(sizeof(struct qdl_device_usb));
+	if (!qdl)
+		return NULL;
+
+	qdl->dev_type = QDL_DEVICE_USB;
+	qdl->open = usb_open;
+	qdl->read = usb_read;
+	qdl->write = usb_write;
+	qdl->close = usb_close;
+	qdl->set_out_chunk_size = usb_set_out_chunk_size;
+
+	return qdl;
 }


### PR DESCRIPTION
This mode assists in validating the `rawprogram_.xml` and `patch_.xml` files,  as well as the Firehose commands that are expected to be sent to the Firehose programmer.

Dry run implementation is also expected to be extended for the Digests Table generation required for Firehose Validated Image Programming (VIP).

Example of usage:

```
$ qdl --dry-run --serial=0AA94EFD --debug prog_firehose_ddr.elf rawprogram*.xml patch*.xml qdl version v2.1-24-g30ac3a8-dirty
This is a dry-run execution of QDL. No actual flashing has been performed waiting for programmer...
FIREHOSE WRITE: <?xml version="1.0"?>
<data><configure MemoryName="ufs" MaxPayloadSizeToTargetInBytes="1048576" verbose="0" ZLPAwareHost="1" SkipStorageInit="0"/></data>

FIREHOSE WRITE: <?xml version="1.0"?>
<data><configure MemoryName="ufs" MaxPayloadSizeToTargetInBytes="0" verbose="0" ZLPAwareHost="1" SkipStorageInit="0"/></data>

accepted max payload size: 0
FIREHOSE WRITE: <?xml version="1.0"?>
<data><program SECTOR_SIZE_IN_BYTES="4096" num_partition_sectors="131072" physical_partition_number="0" start_sector="6" filename="efi.bin"/></data>
```