### PR TITLE
Allow erasing all storage types

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -323,10 +323,13 @@ static int firehose_erase(struct qdl_device *qdl, struct program *program)
 	xmlDocSetRootElement(doc, root);
 
 	node = xmlNewChild(root, NULL, (xmlChar*)"erase", NULL);
-	xml_setpropf(node, "PAGES_PER_BLOCK", "%d", program->pages_per_block);
 	xml_setpropf(node, "SECTOR_SIZE_IN_BYTES", "%d", program->sector_size);
 	xml_setpropf(node, "num_partition_sectors", "%d", program->num_sectors);
+	xml_setpropf(node, "physical_partition_number", "%d", program->partition);
 	xml_setpropf(node, "start_sector", "%s", program->start_sector);
+	if (program->is_nand) {
+		xml_setpropf(node, "PAGES_PER_BLOCK", "%d", program->pages_per_block);
+	}
 
 	ret = firehose_write(qdl, doc);
 	if (ret < 0) {

--- a/program.c
+++ b/program.c
@@ -47,21 +47,18 @@ static int load_erase_tag(xmlNode *node, bool is_nand)
 	struct program *program;
 	int errors = 0;
 
-	if (!is_nand) {
-		ux_err("found \"erase\" tag for non-NAND storage\n");
-		return -EINVAL;
-	}
-
 	program = calloc(1, sizeof(struct program));
 
-
-	program->is_nand = true;
+	program->is_nand = is_nand;
 	program->is_erase = true;
 
-	program->pages_per_block = attr_as_unsigned(node, "PAGES_PER_BLOCK", &errors);
 	program->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 	program->num_sectors = attr_as_unsigned(node, "num_partition_sectors", &errors);
+	program->partition = attr_as_unsigned(node, "physical_partition_number", &errors);
 	program->start_sector = attr_as_string(node, "start_sector", &errors);
+	if (is_nand) {
+		program->pages_per_block = attr_as_unsigned(node, "PAGES_PER_BLOCK", &errors);
+	}
 
 	if (errors) {
 		ux_err("errors while parsing erase tag\n");


### PR DESCRIPTION
Erase operations are currently only supported on devices using NAND storage. With this change, erase operations also work on devices with UFS storage.