### PR TITLE
qdl: introduce allow-fusing parameter 

### DIFF
--- a/program.c
+++ b/program.c
@@ -278,6 +278,27 @@ int program_find_bootable_partition(bool *multiple_found)
 	return part;
 }
 
+/**
+ * program_is_sec_partition_flashed() - find if secdata partition is flashed
+ *
+ * Returns true if filename for secdata is set in program*.xml,
+ * or false otherwise.
+ */
+int program_is_sec_partition_flashed(void)
+{
+	struct program *program;
+
+	program = program_find_partition("secdata");
+	if (!program)
+		return false;
+
+	if (program->filename)
+		return true;
+
+	return false;
+}
+
+
 void free_programs(void)
 {
 	struct program *program = programes;

--- a/program.c
+++ b/program.c
@@ -221,6 +221,23 @@ int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, s
 	return 0;
 }
 
+static struct program *program_find_partition(const char *partition)
+{
+	struct program *program;
+	const char *label;
+
+	for (program = programes; program; program = program->next) {
+		label = program->label;
+		if (!label)
+			continue;
+
+		if (!strcmp(label, partition))
+			return program;
+	}
+
+	return NULL;
+}
+
 /**
  * program_find_bootable_partition() - find one bootable partition
  *
@@ -234,25 +251,28 @@ int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, s
 int program_find_bootable_partition(bool *multiple_found)
 {
 	struct program *program;
-	const char *label;
 	int part = -ENOENT;
 
 	*multiple_found = false;
 
-	for (program = programes; program; program = program->next) {
-		label = program->label;
-		if (!label)
-			continue;
+	program = program_find_partition("xbl");
+	if (program)
+		part = program->partition;
 
-		if (!strcmp(label, "xbl") || !strcmp(label, "xbl_a") ||
-		    !strcmp(label, "sbl1")) {
-			if (part != -ENOENT) {
-				*multiple_found = true;
-				continue;
-			}
-
+	program = program_find_partition("xbl_a");
+	if (program) {
+		if (part != -ENOENT)
+			*multiple_found = true;
+		else
 			part = program->partition;
-		}
+	}
+
+	program = program_find_partition("sbl1");
+	if (program) {
+		if (part != -ENOENT)
+			*multiple_found = true;
+		else
+			part = program->partition;
 	}
 
 	return part;

--- a/program.h
+++ b/program.h
@@ -26,6 +26,8 @@ int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl,
 		    const char *incdir, bool allow_missing);
 int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program));
 int program_find_bootable_partition(bool *multiple_found);
+int program_is_sec_partition_flashed(void);
+
 void free_programs(void);
 
 #endif

--- a/qdl.c
+++ b/qdl.c
@@ -40,6 +40,7 @@
 
 #include "qdl.h"
 #include "patch.h"
+#include "program.h"
 #include "ufs.h"
 #include "oscompat.h"
 
@@ -124,6 +125,7 @@ int main(int argc, char **argv)
 	int ret;
 	int opt;
 	bool qdl_finalize_provisioning = false;
+	bool allow_fusing = false;
 	bool allow_missing = false;
 	long out_chunk_size;
 
@@ -136,6 +138,7 @@ int main(int argc, char **argv)
 		{"serial", required_argument, 0, 'S'},
 		{"storage", required_argument, 0, 's'},
 		{"allow-missing", no_argument, 0, 'f'},
+		{"allow-fusing", no_argument, 0, 'c'},
 		{0, 0, 0, 0}
 	};
 
@@ -155,6 +158,9 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			qdl_finalize_provisioning = true;
+			break;
+		case 'c':
+			allow_fusing = true;
 			break;
 		case OPT_OUT_CHUNK_SIZE:
 			out_chunk_size = strtol(optarg, NULL, 10);
@@ -200,6 +206,10 @@ int main(int argc, char **argv)
 			ret = program_load(argv[optind], !strcmp(storage, "nand"));
 			if (ret < 0)
 				errx(1, "program_load %s failed", argv[optind]);
+
+			if (!allow_fusing && program_is_sec_partition_flashed())
+				errx(1, "secdata partition to be programmed, which can lead to irreversible"
+						" changes. Allow explicitly with --allow-fusing parameter");
 			break;
 		case QDL_FILE_READ:
 			ret = read_op_load(argv[optind]);


### PR DESCRIPTION
Introduce the `--allow-fusing` parameter, which must be explicitly set if the `secdata` partition is programmed, as it will lead to irreversible changes (fuses will be blown during the next boot).