### PR TITLE
CI: disable Ubuntu 20.04 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-latest ]
+        os: [ ubuntu-24.04, ubuntu-22.04, macos-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 has been disabled on GitHub. Stop using it for building images.