### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
         include:
           - { arch: x64, os: 24, runner: ubuntu-24.04 }
           - { arch: x64, os: 22, runner: ubuntu-22.04 }
-          - { arch: arm64, os: 24, runner: ubuntu-24.04-arm64 }
-          - { arch: arm64, os: 22, runner: ubuntu-22.04-arm64 }
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -48,7 +46,6 @@ jobs:
       matrix:
         include:
           - { sys: macos-14, arch: arm64 }
-          - { sys: macos-14, arch: x64 }
     runs-on: ${{ matrix.sys }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         include:
           - { arch: x64, os: 24, runner: ubuntu-24.04 }
+          - { arch: arm64, os: 24, runner: ubuntu-24.04-arm }
           - { arch: x64, os: 22, runner: ubuntu-22.04 }
+          - { arch: arm64, os: 22, runner: ubuntu-22.04-arm }
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -46,6 +48,7 @@ jobs:
       matrix:
         include:
           - { sys: macos-14, arch: arm64 }
+          - { sys: macos-13, arch: intel }
     runs-on: ${{ matrix.sys }}
 
     steps:
@@ -94,6 +97,7 @@ jobs:
       matrix:
         include:
           - { sys: windows-latest, arch: x64 }
+          - { sys: windows-11-arm, arch: arm64 }
     runs-on: ${{ matrix.sys }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,28 +5,140 @@ on:
   push:
 
 jobs:
-  build:
+  build-linux:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04, macos-latest ]
-    runs-on: ${{ matrix.os }}
+        include:
+          - { arch: x64, os: 24, runner: ubuntu-24.04 }
+          - { arch: x64, os: 22, runner: ubuntu-22.04 }
+          - { arch: arm64, os: 24, runner: ubuntu-24.04-arm64 }
+          - { arch: arm64, os: 22, runner: ubuntu-22.04-arm64 }
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev
+
+      - name: Build
+        run: make
+
+      - name: Package
+        run: |
+          mkdir dist
+          cp `pkg-config --variable=libdir libusb-1.0`/libusb-1.0.so.0 dist
+          chmod 0644 dist/*
+          cp qdl dist
+          patchelf --set-rpath '$ORIGIN' dist/qdl
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdl-binary-ubuntu-${{matrix.os}}-${{ matrix.arch }}
+          path: dist/*
+
+
+  build-mac:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: macos-14, arch: arm64 }
+          - { sys: macos-14, arch: x64 }
+    runs-on: ${{ matrix.sys }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev
-
-      - name: Dependencies (macOS)
-        if: runner.os == 'macOS'
+      - name: Dependencies
         run: |
           brew install libxml2
-          brew install libusb
 
       - name: Build
         run: make
+
+      - name: Package
+        run: |
+          set -x
+          mkdir dist
+          cp `pkg-config --variable=libdir libusb-1.0`/libusb-1.0.0.dylib dist
+          cp `pkg-config --variable=libdir liblzma`/liblzma.5.dylib dist
+          chmod 0644 dist/*
+          cp qdl dist
+
+          if uname -a | grep -q arm64; then
+            LIBUSB_DIR=/opt/homebrew/opt/libusb/lib
+            LIBLZMA_DIR=/usr/lib
+          else
+            LIBUSB_DIR=/usr/local/opt/libusb/lib
+            LIBLZMA_DIR=/usr/local/opt/xz/lib
+          fi
+
+          install_name_tool -add_rpath @executable_path dist/qdl
+          install_name_tool -change $LIBUSB_DIR/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib dist/qdl
+          install_name_tool -change $LIBLZMA_DIR/liblzma.5.dylib @rpath/liblzma.5.dylib dist/qdl
+          otool -L dist/qdl
+          dist/qdl || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdl-binary-macos-${{ matrix.arch }}
+          path: dist/*
+
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: windows-latest, arch: x64 }
+    runs-on: ${{ matrix.sys }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: >
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-libxml2
+            mingw-w64-x86_64-libusb
+
+      - name: Build
+        run: mingw32-make
+        shell: msys2 {0}
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $MSYS2_LOCATION = "${{ steps.msys2.outputs.msys2-location }}"
+          $BIN_DIR = Join-Path $MSYS2_LOCATION "mingw64\bin"
+          $DistDir = "dist"
+          New-Item -ItemType Directory -Path $DistDir | Out-Null
+
+          Copy-Item (Join-Path $BIN_DIR "zlib1.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libxml2-2.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libusb-1.0.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "liblzma-5.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libiconv-2.dll") $DistDir
+
+          Copy-Item "qdl.exe" $DistDir
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdl-binary-windows-${{ matrix.arch }}
+          path: dist/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 qdl
 qdl-ramdump
 ks
+*.exe
 compile_commands.json
 .cache
 .version.h

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
-QDL_SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c usb.c ux.c
+QDL_SRCS := firehose.c qdl.c sahara.c util.c patch.c program.c read.c ufs.c usb.c ux.c oscompat.c
 QDL_OBJS := $(QDL_SRCS:.c=.o)
 
-RAMDUMP_SRCS := ramdump.c sahara.c usb.c util.c ux.c
+RAMDUMP_SRCS := ramdump.c sahara.c usb.c util.c ux.c oscompat.c
 RAMDUMP_OBJS := $(RAMDUMP_SRCS:.c=.o)
 
 KS_OUT := ks
-KS_SRCS := ks.c sahara.c util.c ux.c
+KS_SRCS := ks.c sahara.c util.c ux.c oscompat.c
 KS_OBJS := $(KS_SRCS:.c=.o)
 
 default: $(QDL) $(RAMDUMP) $(KS_OUT)

--- a/firehose.c
+++ b/firehose.c
@@ -448,11 +448,11 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	if (ret) {
 		ux_err("flashing of %s failed\n", program->label);
 	} else if (t) {
-		ux_err("flashed \"%s\" successfully at %lukB/s\n",
+		ux_info("flashed \"%s\" successfully at %lukB/s\n",
 			program->label,
 			(unsigned long)program->sector_size * num_sectors / t / 1024);
 	} else {
-		ux_err("flashed \"%s\" successfully\n",
+		ux_info("flashed \"%s\" successfully\n",
 			program->label);
 	}
 
@@ -546,11 +546,11 @@ static int firehose_read_op(struct qdl_device *qdl, struct read_op *read_op, int
 	t = time(NULL) - t0;
 
 	if (t) {
-		ux_err("read \"%s\" successfully at %ldkB/s\n",
+		ux_info("read \"%s\" successfully at %ldkB/s\n",
 			read_op->filename,
 			(unsigned long)read_op->sector_size * read_op->num_sectors / t / 1024);
 	} else {
-		ux_err("read \"%s\" successfully\n",
+		ux_info("read \"%s\" successfully\n",
 			read_op->filename);
 	}
 

--- a/firehose.c
+++ b/firehose.c
@@ -36,22 +36,20 @@
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <poll.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <termios.h>
 #include <time.h>
 #include <unistd.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include "qdl.h"
 #include "ufs.h"
+#include "oscompat.h"
 
 enum {
 	FIREHOSE_ACK = 0,
@@ -534,7 +532,10 @@ static int firehose_read_op(struct qdl_device *qdl, struct read_op *read_op, int
 		}
 
 		left -= chunk_size;
+#ifndef _WIN32
+		// on mac/linux, every other response is empty
 		expect_empty = true;
+#endif
 	}
 
 	ret = firehose_read(qdl, 10000, firehose_generic_parser, NULL);

--- a/firehose.c
+++ b/firehose.c
@@ -150,7 +150,7 @@ static int firehose_read(struct qdl_device *qdl, int timeout_ms,
 
 	do {
 		n = qdl_read(qdl, buf, sizeof(buf), 100);
-		if (n < 0) {
+		if (n <= 0) {
 			gettimeofday(&now, NULL);
 			if (timercmp(&now, &timeout, <))
 				continue;

--- a/ks.c
+++ b/ks.c
@@ -2,20 +2,22 @@
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <poll.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <termios.h>
 #include <unistd.h>
 
 #include "qdl.h"
+#include "oscompat.h"
+
+#ifdef _WIN32
+const char *__progname = "ks";
+#endif
 
 static struct qdl_device qdl;
 

--- a/oscompat.c
+++ b/oscompat.c
@@ -1,0 +1,16 @@
+#include "oscompat.h"
+
+#ifdef _WIN32
+
+const char *__progname = "qdl";
+
+void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *result) {
+    result->tv_sec = a->tv_sec + b->tv_sec;
+    result->tv_usec = a->tv_usec + b->tv_usec;
+    if (result->tv_usec >= 1000000) {
+        result->tv_sec += 1;
+        result->tv_usec -= 1000000;
+    }
+}
+
+#endif // _WIN32

--- a/oscompat.c
+++ b/oscompat.c
@@ -1,8 +1,12 @@
-#include "oscompat.h"
-
 #ifdef _WIN32
 
-const char *__progname = "qdl";
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include "oscompat.h"
+
+extern const char *__progname;
 
 void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *result) {
     result->tv_sec = a->tv_sec + b->tv_sec;
@@ -11,6 +15,52 @@ void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *
         result->tv_sec += 1;
         result->tv_usec -= 1000000;
     }
+}
+
+void err(int eval, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "%s: ", __progname);
+    if (fmt) {
+        vfprintf(stderr, fmt, ap);
+        fprintf(stderr, ": ");
+    }
+    fprintf(stderr, "%s\n", strerror(errno));
+    va_end(ap);
+    exit(eval);
+}
+
+void errx(int eval, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "%s: ", __progname);
+    if (fmt)
+        vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+    exit(eval);
+}
+
+void warn(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "%s: ", __progname);
+    if (fmt) {
+        vfprintf(stderr, fmt, ap);
+        fprintf(stderr, ": ");
+    }
+    fprintf(stderr, "%s\n", strerror(errno));
+    va_end(ap);
+}
+
+void warnx(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "%s: ", __progname);
+    if (fmt)
+        vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
 }
 
 #endif // _WIN32

--- a/oscompat.h
+++ b/oscompat.h
@@ -12,15 +12,12 @@
 #include <sys/time.h>
 #include <stdbool.h>
 
-// TODO: improve err functions
-
-#define err(code, ...) do { ux_err(__VA_ARGS__); exit(code); } while(false)
-#define errx(code, ...) do { ux_err(__VA_ARGS__); exit(code); } while(false)
-#define warn(...) ux_info(__VA_ARGS__)
-#define warnx(...) ux_info(__VA_ARGS__)
-
-
 void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *result);
+
+void err(int eval, const char *fmt, ...);
+void errx(int eval, const char *fmt, ...);
+void warn(const char *fmt, ...);
+void warnx(const char *fmt, ...);
 
 #endif
 

--- a/oscompat.h
+++ b/oscompat.h
@@ -5,6 +5,8 @@
 
 #include <err.h>
 
+#define O_BINARY 0
+
 #else // _WIN32
 
 #include <sys/time.h>

--- a/oscompat.h
+++ b/oscompat.h
@@ -1,0 +1,25 @@
+#ifndef __OSCOMPAT_H__
+#define __OSCOMPAT_H__
+
+#ifndef _WIN32
+
+#include <err.h>
+
+#else // _WIN32
+
+#include <sys/time.h>
+#include <stdbool.h>
+
+// TODO: improve err functions
+
+#define err(code, ...) do { ux_err(__VA_ARGS__); exit(code); } while(false)
+#define errx(code, ...) do { ux_err(__VA_ARGS__); exit(code); } while(false)
+#define warn(...) ux_info(__VA_ARGS__)
+#define warnx(...) ux_info(__VA_ARGS__)
+
+
+void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *result);
+
+#endif
+
+#endif

--- a/program.c
+++ b/program.c
@@ -39,6 +39,7 @@
 
 #include "program.h"
 #include "qdl.h"
+#include "oscompat.h"
 
 static struct program *programes;
 static struct program *programes_last;
@@ -180,7 +181,7 @@ int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl,
 				filename = tmp;
 		}
 
-		fd = open(filename, O_RDONLY);
+		fd = open(filename, O_RDONLY | O_BINARY);
 
 		if (fd < 0) {
 			ux_info("unable to open %s", program->filename);

--- a/program.c
+++ b/program.c
@@ -28,6 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#define _FILE_OFFSET_BITS 64
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>

--- a/qdl.c
+++ b/qdl.c
@@ -29,7 +29,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <err.h>
 #include <errno.h>
 #include <getopt.h>
 #include <stdbool.h>
@@ -42,6 +41,11 @@
 #include "qdl.h"
 #include "patch.h"
 #include "ufs.h"
+#include "oscompat.h"
+
+#ifdef _WIN32
+const char *__progname = "qdl";
+#endif
 
 #define MAX_USBFS_BULK_SIZE	(16*1024)
 

--- a/ramdump.c
+++ b/ramdump.c
@@ -5,6 +5,11 @@
 
 #include "qdl.h"
 
+#ifdef _WIN32
+const char *__progname = "ramdump";
+#endif
+
+
 bool qdl_debug;
 
 static void print_usage(void)

--- a/read.c
+++ b/read.c
@@ -38,6 +38,7 @@
 
 #include "read.h"
 #include "qdl.h"
+#include "oscompat.h"
 
 static struct read_op *read_ops;
 static struct read_op *read_ops_last;
@@ -114,7 +115,7 @@ int read_op_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl,
 				filename = tmp;
 		}
 
-		fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+		fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644);
 
 		if (fd < 0) {
 			ux_info("unable to open %s...\n", read_op->filename);

--- a/sahara.c
+++ b/sahara.c
@@ -218,7 +218,7 @@ static void sahara_read(struct qdl_device *qdl, struct sahara_pkt *pkt, char *im
 		return;
 	}
 
-	fd = open(img_arr[image], O_RDONLY);
+	fd = open(img_arr[image], O_RDONLY | O_BINARY);
 	if (fd < 0) {
 		ux_err("Can not open \"%s\": %s\n", img_arr[image], strerror(errno));
 		// Maybe this read was optional.  Notify device of error and let
@@ -255,7 +255,7 @@ static void sahara_read64(struct qdl_device *qdl, struct sahara_pkt *pkt, char *
 		sahara_send_reset(qdl);
 		return;
 	}
-	fd = open(img_arr[image], O_RDONLY);
+	fd = open(img_arr[image], O_RDONLY | O_BINARY);
 	if (fd < 0) {
 		ux_err("Can not open \"%s\": %s\n", img_arr[image], strerror(errno));
 		// Maybe this read was optional.  Notify device of error and let
@@ -319,7 +319,7 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 	char path[PATH_MAX];
 	snprintf(path, sizeof(path), "%s/%s", ramdump_path, region.filename);
 	
-	fd = open(path, O_WRONLY | O_CREAT, 0644);
+	fd = open(path, O_WRONLY | O_CREAT | O_BINARY, 0644);
 	if (fd < 0) {
 		warn("failed to open \"%s\"", region.filename);
 		return -1;

--- a/sahara.c
+++ b/sahara.c
@@ -32,20 +32,17 @@
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <fnmatch.h>
 #include <inttypes.h>
-#include <poll.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <termios.h>
 #include <unistd.h>
 #include "qdl.h"
+#include "oscompat.h"
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
@@ -305,7 +302,7 @@ static int sahara_done(struct qdl_device *qdl, struct sahara_pkt *pkt)
 
 static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 				  struct sahara_debug_region64 region,
-				  int ramdump_dir)
+				  const char *ramdump_path)
 {
 	struct sahara_pkt read_req;
 	uint64_t remain;
@@ -319,7 +316,10 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 	if (!buf)
 		return -1;
 
-	fd = openat(ramdump_dir, region.filename, O_WRONLY | O_CREAT, 0644);
+	char path[PATH_MAX];
+	snprintf(path, sizeof(path), "%s/%s", ramdump_path, region.filename);
+	
+	fd = open(path, O_WRONLY | O_CREAT, 0644);
 	if (fd < 0) {
 		warn("failed to open \"%s\"", region.filename);
 		return -1;
@@ -361,6 +361,27 @@ out:
 	return 0;
 }
 
+// simple pattern matching function supporting * and ?
+bool pattern_match(const char *pattern, const char *string) {
+    if (*pattern == '\0' && *string == '\0')
+        return true;
+
+    if (*pattern == '*') {
+        return pattern_match(pattern + 1, string) ||
+               (*string != '\0' && pattern_match(pattern, string + 1));
+    }
+
+    if (*pattern == '?') {
+        return (*string != '\0') && pattern_match(pattern + 1, string + 1);
+    }
+
+    if (*pattern == *string) {
+        return pattern_match(pattern + 1, string + 1);
+    }
+
+    return false;
+}
+
 static bool sahara_debug64_filter(const char *filename, const char *filter)
 {
 	bool anymatch = false;
@@ -373,7 +394,7 @@ static bool sahara_debug64_filter(const char *filename, const char *filter)
 
 	tmp = strdup(filter);
 	for (s = strtok_r(tmp, ",", &ptr); s; s = strtok_r(NULL, ",", &ptr)) {
-		if (fnmatch(s, filename, 0) == 0) {
+		if (pattern_match(s, filename)) {
 			anymatch = true;
 			break;
 		}
@@ -384,7 +405,7 @@ static bool sahara_debug64_filter(const char *filename, const char *filter)
 }
 
 static void sahara_debug64(struct qdl_device *qdl, struct sahara_pkt *pkt,
-			   int ramdump_dir, const char *filter)
+			  const char *ramdump_path, const char *filter)
 {
 	struct sahara_debug_region64 *table;
 	struct sahara_pkt read_req;
@@ -418,7 +439,8 @@ static void sahara_debug64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 		ux_debug("%-2d: type 0x%" PRIx64 " address: 0x%" PRIx64 " length: 0x%" PRIx64 " region: %s filename: %s\n",
 			 i, table[i].type, table[i].addr, table[i].length, table[i].region, table[i].filename);
 
-		n = sahara_debug64_one(qdl, table[i], ramdump_dir);
+
+		n = sahara_debug64_one(qdl, table[i], ramdump_path);
 		if (n < 0)
 			break;
 	}
@@ -432,17 +454,10 @@ int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 	       const char *ramdump_path, const char *ramdump_filter)
 {
 	struct sahara_pkt *pkt;
-	int ramdump_dir = -1;
 	char buf[4096];
 	char tmp[32];
 	bool done = false;
 	int n;
-
-	if (ramdump_path) {
-		ramdump_dir = open(ramdump_path, O_DIRECTORY);
-		if (ramdump_dir < 0)
-			err(1, "failed to open directory for ramdump output");
-	}
 
 	while (!done) {
 		n = qdl_read(qdl, buf, sizeof(buf), 1000);
@@ -473,7 +488,7 @@ int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 				done = true;
 			break;
 		case SAHARA_MEM_DEBUG64_CMD:
-			sahara_debug64(qdl, pkt, ramdump_dir, ramdump_filter);
+			sahara_debug64(qdl, pkt, ramdump_path, ramdump_filter);
 			break;
 		case SAHARA_READ_DATA64_CMD:
 			sahara_read64(qdl, pkt, img_arr, single_image);
@@ -489,9 +504,6 @@ int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 			break;
 		}
 	}
-
-	if (ramdump_dir >= 0)
-		close(ramdump_dir);
 
 	return done ? 0 : -1;
 }

--- a/usb.c
+++ b/usb.c
@@ -1,12 +1,11 @@
-#include <sys/ioctl.h>
 #include <sys/types.h>
-#include <err.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <libusb.h>
+#include "oscompat.h"
 
 #include "qdl.h"
 

--- a/ux.c
+++ b/ux.c
@@ -1,5 +1,9 @@
 #include <stdarg.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/ioctl.h>
+#endif
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -36,6 +40,22 @@ static void ux_clear_line(void)
 	ux_cur_line_length = 0;
 }
 
+#ifdef _WIN32
+
+void ux_init(void)
+{
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+	int columns;
+
+    HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (GetConsoleScreenBufferInfo(stdoutHandle, &csbi)) {
+		columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+		ux_width = MIN(columns, UX_PROGRESS_SIZE_MAX);
+    }
+}
+
+#else
+
 void ux_init(void)
 {
 	struct winsize w;
@@ -45,6 +65,8 @@ void ux_init(void)
 	if (!ret)
 		ux_width = MIN(w.ws_col, UX_PROGRESS_SIZE_MAX);
 }
+
+#endif
 
 void ux_err(const char *fmt, ...)
 {


### PR DESCRIPTION
This adds the ability to build and run qdl on Windows. It's an alternative approach to #94 using MSYS2 MINGW64 instead of Visual Studio in order to have a smaller OS compatibility layer.

The CI job also uploads artifacts to make it easier to validate on different systems.

I wanted to open this for feedback before it's ready to merge.

The main gap right now are the [err functions](https://man7.org/linux/man-pages/man3/err.3.html) that are not available on MINGW64. This is something other projects had to deal with https://github.com/YosysHQ/icestorm/issues/85. Before implementing a solution to this, I wanted to get opinions on these options: replace `err` functions in the project with a portable alternative, or implement compatible versions in `oscompat.c`.
- I ended up implementing portable versions of err, errx, warn and warnx
