### PR TITLE
Include stdlib in usb.c

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <libusb.h>


### PR DESCRIPTION
```text
usb.c: In function ‘usb_init’:
usb.c:295:34: error: implicit declaration of function ‘malloc’ [-Wimplicit-function-declaration]
  295 |         struct qdl_device *qdl = malloc(sizeof(struct qdl_device_usb));
      |                                  ^~~~~~
usb.c:11:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’
   10 | #include "qdl.h"
  +++ |+#include <stdlib.h>
   11 | 
usb.c:295:34: warning: incompatible implicit declaration of built-in function ‘malloc’ [-Wbuiltin-declaration-mismatch]
  295 |         struct qdl_device *qdl = malloc(sizeof(struct qdl_device_usb));
      |                                  ^~~~~~
usb.c:295:34: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’
make: *** [<builtin>: usb.o] Error 1
```

#55 again

`malloc` usage is introduced here <https://github.com/linux-msm/qdl/commit/f06630467682b733cba2f499ba8b9e9121835c1f#diff-2a496ef770ec0d14f986fd35f391cde94cedd8e569f5bfa284eddef2f19c2784R295>