### PR TITLE
VIP table generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 prefix := /usr/local
 
-QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sim.c ufs.c usb.c ux.c oscompat.c
+QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sha2.c sim.c ufs.c usb.c ux.c oscompat.c vip.c
 QDL_OBJS := $(QDL_SRCS:.c=.o)
 
 RAMDUMP_SRCS := ramdump.c sahara.c io.c sim.c usb.c util.c ux.c oscompat.c

--- a/firehose.c
+++ b/firehose.c
@@ -423,6 +423,10 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 
 	lseek(fd, (off_t) program->file_offset * program->sector_size, SEEK_SET);
 	left = num_sectors;
+
+	ux_debug("FIREHOSE RAW BINARY WRITE: %s, %d bytes\n",
+		 program->filename, program->sector_size * num_sectors);
+
 	while (left > 0) {
 		chunk_size = MIN(max_payload_size / program->sector_size, left);
 

--- a/qdl.h
+++ b/qdl.h
@@ -8,6 +8,10 @@
 #include "read.h"
 #include <libxml/tree.h>
 
+#define container_of(ptr, typecast, member) ({                  \
+	void *_ptr = (void *)(ptr);		                \
+	((typecast *)(_ptr - offsetof(typecast, member))); })
+
 #define MAPPING_SZ 64
 
 enum QDL_DEVICE_TYPE

--- a/qdl.h
+++ b/qdl.h
@@ -13,7 +13,7 @@
 enum QDL_DEVICE_TYPE
 {
 	QDL_DEVICE_USB,
-        QDL_DEVICE_SIM,
+	QDL_DEVICE_SIM,
 };
 
 struct qdl_device

--- a/sha2.c
+++ b/sha2.c
@@ -1,0 +1,475 @@
+/*	$OpenBSD: sha2.c,v 1.28 2019/07/23 12:35:22 dtucker Exp $	*/
+
+/*
+ * FILE:	sha2.c
+ * AUTHOR:	Aaron D. Gifford <me@aarongifford.com>
+ *
+ * Copyright (c) 2000-2001, Aaron D. Gifford
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTOR(S) ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTOR(S) BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $From: sha2.c,v 1.1 2001/11/08 00:01:51 adg Exp adg $
+ */
+
+#include <sys/types.h>
+
+#include <string.h>
+#include "sha2.h"
+
+/*
+ * UNROLLED TRANSFORM LOOP NOTE:
+ * You can define SHA2_UNROLL_TRANSFORM to use the unrolled transform
+ * loop version for the hash transform rounds (defined using macros
+ * later in this file).  Either define on the command line, for example:
+ *
+ *   cc -DSHA2_UNROLL_TRANSFORM -o sha2 sha2.c sha2prog.c
+ *
+ * or define below:
+ *
+ *   #define SHA2_UNROLL_TRANSFORM
+ *
+ */
+#ifndef SHA2_SMALL
+#if defined(__amd64__) || defined(__i386__)
+#define SHA2_UNROLL_TRANSFORM
+#endif
+#endif
+
+/*** SHA-224/256/384/512 Machine Architecture Definitions *****************/
+/*
+ * BYTE_ORDER NOTE:
+ *
+ * Please make sure that your system defines BYTE_ORDER.  If your
+ * architecture is little-endian, make sure it also defines
+ * LITTLE_ENDIAN and that the two (BYTE_ORDER and LITTLE_ENDIAN) are
+ * equivalent.
+ *
+ * If your system does not define the above, then you can do so by
+ * hand like this:
+ *
+ *   #define LITTLE_ENDIAN 1234
+ *   #define BIG_ENDIAN    4321
+ *
+ * And for little-endian machines, add:
+ *
+ *   #define BYTE_ORDER LITTLE_ENDIAN
+ *
+ * Or for big-endian machines:
+ *
+ *   #define BYTE_ORDER BIG_ENDIAN
+ *
+ * The FreeBSD machine this was written on defines BYTE_ORDER
+ * appropriately by including <sys/types.h> (which in turn includes
+ * <machine/endian.h> where the appropriate definitions are actually
+ * made).
+ */
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <sys/param.h>
+#endif
+#if !defined(BYTE_ORDER) || (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN)
+#error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
+#endif
+
+
+/*** SHA-224/256/384/512 Various Length Definitions ***********************/
+/* NOTE: Most of these are in sha2.h */
+#define SHA256_SHORT_BLOCK_LENGTH	(SHA256_BLOCK_LENGTH - 8)
+
+/*** ENDIAN SPECIFIC COPY MACROS **************************************/
+#define BE_8_TO_32(dst, cp) do {					\
+	(dst) = (uint32_t)(cp)[3] | ((uint32_t)(cp)[2] << 8) |	\
+	    ((uint32_t)(cp)[1] << 16) | ((uint32_t)(cp)[0] << 24);	\
+} while(0)
+
+#define BE_8_TO_64(dst, cp) do {					\
+	(dst) = (uint64_t)(cp)[7] | ((uint64_t)(cp)[6] << 8) |	\
+	    ((uint64_t)(cp)[5] << 16) | ((uint64_t)(cp)[4] << 24) |	\
+	    ((uint64_t)(cp)[3] << 32) | ((uint64_t)(cp)[2] << 40) |	\
+	    ((uint64_t)(cp)[1] << 48) | ((uint64_t)(cp)[0] << 56);	\
+} while (0)
+
+#define BE_64_TO_8(cp, src) do {					\
+	(cp)[0] = (src) >> 56;						\
+        (cp)[1] = (src) >> 48;						\
+	(cp)[2] = (src) >> 40;						\
+	(cp)[3] = (src) >> 32;						\
+	(cp)[4] = (src) >> 24;						\
+	(cp)[5] = (src) >> 16;						\
+	(cp)[6] = (src) >> 8;						\
+	(cp)[7] = (src);						\
+} while (0)
+
+#define BE_32_TO_8(cp, src) do {					\
+	(cp)[0] = (src) >> 24;						\
+	(cp)[1] = (src) >> 16;						\
+	(cp)[2] = (src) >> 8;						\
+	(cp)[3] = (src);						\
+} while (0)
+
+/*
+ * Macro for incrementally adding the unsigned 64-bit integer n to the
+ * unsigned 128-bit integer (represented using a two-element array of
+ * 64-bit words):
+ */
+#define ADDINC128(w,n) do {						\
+	(w)[0] += (uint64_t)(n);					\
+	if ((w)[0] < (n)) {						\
+		(w)[1]++;						\
+	}								\
+} while (0)
+
+/*** THE SIX LOGICAL FUNCTIONS ****************************************/
+/*
+ * Bit shifting and rotation (used by the six SHA-XYZ logical functions:
+ *
+ *   NOTE:  The naming of R and S appears backwards here (R is a SHIFT and
+ *   S is a ROTATION) because the SHA-224/256/384/512 description document
+ *   (see http://csrc.nist.gov/cryptval/shs/sha256-384-512.pdf) uses this
+ *   same "backwards" definition.
+ */
+/* Shift-right (used in SHA-224, SHA-256, SHA-384, and SHA-512): */
+#define R(b,x) 		((x) >> (b))
+/* 32-bit Rotate-right (used in SHA-224 and SHA-256): */
+#define S32(b,x)	(((x) >> (b)) | ((x) << (32 - (b))))
+
+/* Two of six logical functions used in SHA-224, SHA-256, SHA-384, and SHA-512: */
+#define Ch(x,y,z)	(((x) & (y)) ^ ((~(x)) & (z)))
+#define Maj(x,y,z)	(((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+
+/* Four of six logical functions used in SHA-224 and SHA-256: */
+#define Sigma0_256(x)	(S32(2,  (x)) ^ S32(13, (x)) ^ S32(22, (x)))
+#define Sigma1_256(x)	(S32(6,  (x)) ^ S32(11, (x)) ^ S32(25, (x)))
+#define sigma0_256(x)	(S32(7,  (x)) ^ S32(18, (x)) ^ R(3 ,   (x)))
+#define sigma1_256(x)	(S32(17, (x)) ^ S32(19, (x)) ^ R(10,   (x)))
+
+
+/*** SHA-XYZ INITIAL HASH VALUES AND CONSTANTS ************************/
+/* Hash constant words K for SHA-224 and SHA-256: */
+static const uint32_t K256[64] = {
+	0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL,
+	0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL,
+	0xd807aa98UL, 0x12835b01UL, 0x243185beUL, 0x550c7dc3UL,
+	0x72be5d74UL, 0x80deb1feUL, 0x9bdc06a7UL, 0xc19bf174UL,
+	0xe49b69c1UL, 0xefbe4786UL, 0x0fc19dc6UL, 0x240ca1ccUL,
+	0x2de92c6fUL, 0x4a7484aaUL, 0x5cb0a9dcUL, 0x76f988daUL,
+	0x983e5152UL, 0xa831c66dUL, 0xb00327c8UL, 0xbf597fc7UL,
+	0xc6e00bf3UL, 0xd5a79147UL, 0x06ca6351UL, 0x14292967UL,
+	0x27b70a85UL, 0x2e1b2138UL, 0x4d2c6dfcUL, 0x53380d13UL,
+	0x650a7354UL, 0x766a0abbUL, 0x81c2c92eUL, 0x92722c85UL,
+	0xa2bfe8a1UL, 0xa81a664bUL, 0xc24b8b70UL, 0xc76c51a3UL,
+	0xd192e819UL, 0xd6990624UL, 0xf40e3585UL, 0x106aa070UL,
+	0x19a4c116UL, 0x1e376c08UL, 0x2748774cUL, 0x34b0bcb5UL,
+	0x391c0cb3UL, 0x4ed8aa4aUL, 0x5b9cca4fUL, 0x682e6ff3UL,
+	0x748f82eeUL, 0x78a5636fUL, 0x84c87814UL, 0x8cc70208UL,
+	0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL
+};
+
+/* Initial hash value H for SHA-256: */
+static const uint32_t sha256_initial_hash_value[8] = {
+	0x6a09e667UL,
+	0xbb67ae85UL,
+	0x3c6ef372UL,
+	0xa54ff53aUL,
+	0x510e527fUL,
+	0x9b05688cUL,
+	0x1f83d9abUL,
+	0x5be0cd19UL
+};
+
+/*** SHA-256: *********************************************************/
+void
+SHA256Init(SHA2_CTX *context)
+{
+	memcpy(context->state.st32, sha256_initial_hash_value,
+	    sizeof(sha256_initial_hash_value));
+	memset(context->buffer, 0, sizeof(context->buffer));
+	context->bitcount[0] = 0;
+}
+
+#ifdef SHA2_UNROLL_TRANSFORM
+
+/* Unrolled SHA-256 round macros: */
+
+#define ROUND256_0_TO_15(a,b,c,d,e,f,g,h) do {				    \
+	BE_8_TO_32(W256[j], data);					    \
+	data += 4;							    \
+	T1 = (h) + Sigma1_256((e)) + Ch((e), (f), (g)) + K256[j] + W256[j]; \
+	(d) += T1;							    \
+	(h) = T1 + Sigma0_256((a)) + Maj((a), (b), (c));		    \
+	j++;								    \
+} while(0)
+
+#define ROUND256(a,b,c,d,e,f,g,h) do {					    \
+	s0 = W256[(j+1)&0x0f];						    \
+	s0 = sigma0_256(s0);						    \
+	s1 = W256[(j+14)&0x0f];						    \
+	s1 = sigma1_256(s1);						    \
+	T1 = (h) + Sigma1_256((e)) + Ch((e), (f), (g)) + K256[j] +	    \
+	     (W256[j&0x0f] += s1 + W256[(j+9)&0x0f] + s0);		    \
+	(d) += T1;							    \
+	(h) = T1 + Sigma0_256((a)) + Maj((a), (b), (c));		    \
+	j++;								    \
+} while(0)
+
+void
+SHA256Transform(uint32_t state[8], const uint8_t data[SHA256_BLOCK_LENGTH])
+{
+	uint32_t	a, b, c, d, e, f, g, h, s0, s1;
+	uint32_t	T1, W256[16];
+	int		j;
+
+	/* Initialize registers with the prev. intermediate value */
+	a = state[0];
+	b = state[1];
+	c = state[2];
+	d = state[3];
+	e = state[4];
+	f = state[5];
+	g = state[6];
+	h = state[7];
+
+	j = 0;
+	do {
+		/* Rounds 0 to 15 (unrolled): */
+		ROUND256_0_TO_15(a,b,c,d,e,f,g,h);
+		ROUND256_0_TO_15(h,a,b,c,d,e,f,g);
+		ROUND256_0_TO_15(g,h,a,b,c,d,e,f);
+		ROUND256_0_TO_15(f,g,h,a,b,c,d,e);
+		ROUND256_0_TO_15(e,f,g,h,a,b,c,d);
+		ROUND256_0_TO_15(d,e,f,g,h,a,b,c);
+		ROUND256_0_TO_15(c,d,e,f,g,h,a,b);
+		ROUND256_0_TO_15(b,c,d,e,f,g,h,a);
+	} while (j < 16);
+
+	/* Now for the remaining rounds up to 63: */
+	do {
+		ROUND256(a,b,c,d,e,f,g,h);
+		ROUND256(h,a,b,c,d,e,f,g);
+		ROUND256(g,h,a,b,c,d,e,f);
+		ROUND256(f,g,h,a,b,c,d,e);
+		ROUND256(e,f,g,h,a,b,c,d);
+		ROUND256(d,e,f,g,h,a,b,c);
+		ROUND256(c,d,e,f,g,h,a,b);
+		ROUND256(b,c,d,e,f,g,h,a);
+	} while (j < 64);
+
+	/* Compute the current intermediate hash value */
+	state[0] += a;
+	state[1] += b;
+	state[2] += c;
+	state[3] += d;
+	state[4] += e;
+	state[5] += f;
+	state[6] += g;
+	state[7] += h;
+
+	/* Clean up */
+	a = b = c = d = e = f = g = h = T1 = 0;
+}
+
+#else /* SHA2_UNROLL_TRANSFORM */
+
+void
+SHA256Transform(uint32_t state[8], const uint8_t data[SHA256_BLOCK_LENGTH])
+{
+	uint32_t	a, b, c, d, e, f, g, h, s0, s1;
+	uint32_t	T1, T2, W256[16];
+	int		j;
+
+	/* Initialize registers with the prev. intermediate value */
+	a = state[0];
+	b = state[1];
+	c = state[2];
+	d = state[3];
+	e = state[4];
+	f = state[5];
+	g = state[6];
+	h = state[7];
+
+	j = 0;
+	do {
+		BE_8_TO_32(W256[j], data);
+		data += 4;
+		/* Apply the SHA-256 compression function to update a..h */
+		T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + W256[j];
+		T2 = Sigma0_256(a) + Maj(a, b, c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + T1;
+		d = c;
+		c = b;
+		b = a;
+		a = T1 + T2;
+
+		j++;
+	} while (j < 16);
+
+	do {
+		/* Part of the message block expansion: */
+		s0 = W256[(j+1)&0x0f];
+		s0 = sigma0_256(s0);
+		s1 = W256[(j+14)&0x0f];
+		s1 = sigma1_256(s1);
+
+		/* Apply the SHA-256 compression function to update a..h */
+		T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] +
+		     (W256[j&0x0f] += s1 + W256[(j+9)&0x0f] + s0);
+		T2 = Sigma0_256(a) + Maj(a, b, c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + T1;
+		d = c;
+		c = b;
+		b = a;
+		a = T1 + T2;
+
+		j++;
+	} while (j < 64);
+
+	/* Compute the current intermediate hash value */
+	state[0] += a;
+	state[1] += b;
+	state[2] += c;
+	state[3] += d;
+	state[4] += e;
+	state[5] += f;
+	state[6] += g;
+	state[7] += h;
+
+	/* Clean up */
+	a = b = c = d = e = f = g = h = T1 = T2 = 0;
+}
+
+#endif /* SHA2_UNROLL_TRANSFORM */
+
+void
+SHA256Update(SHA2_CTX *context, const uint8_t *data, size_t len)
+{
+	uint64_t	freespace, usedspace;
+
+	/* Calling with no data is valid (we do nothing) */
+	if (len == 0)
+		return;
+
+	usedspace = (context->bitcount[0] >> 3) % SHA256_BLOCK_LENGTH;
+	if (usedspace > 0) {
+		/* Calculate how much free space is available in the buffer */
+		freespace = SHA256_BLOCK_LENGTH - usedspace;
+
+		if (len >= freespace) {
+			/* Fill the buffer completely and process it */
+			memcpy(&context->buffer[usedspace], data, freespace);
+			context->bitcount[0] += freespace << 3;
+			len -= freespace;
+			data += freespace;
+			SHA256Transform(context->state.st32, context->buffer);
+		} else {
+			/* The buffer is not yet full */
+			memcpy(&context->buffer[usedspace], data, len);
+			context->bitcount[0] += (uint64_t)len << 3;
+			/* Clean up: */
+			usedspace = freespace = 0;
+			return;
+		}
+	}
+	while (len >= SHA256_BLOCK_LENGTH) {
+		/* Process as many complete blocks as we can */
+		SHA256Transform(context->state.st32, data);
+		context->bitcount[0] += SHA256_BLOCK_LENGTH << 3;
+		len -= SHA256_BLOCK_LENGTH;
+		data += SHA256_BLOCK_LENGTH;
+	}
+	if (len > 0) {
+		/* There's left-overs, so save 'em */
+		memcpy(context->buffer, data, len);
+		context->bitcount[0] += len << 3;
+	}
+	/* Clean up: */
+	usedspace = freespace = 0;
+}
+
+void
+SHA256Pad(SHA2_CTX *context)
+{
+	unsigned int	usedspace;
+
+	usedspace = (context->bitcount[0] >> 3) % SHA256_BLOCK_LENGTH;
+	if (usedspace > 0) {
+		/* Begin padding with a 1 bit: */
+		context->buffer[usedspace++] = 0x80;
+
+		if (usedspace <= SHA256_SHORT_BLOCK_LENGTH) {
+			/* Set-up for the last transform: */
+			memset(&context->buffer[usedspace], 0,
+			    SHA256_SHORT_BLOCK_LENGTH - usedspace);
+		} else {
+			if (usedspace < SHA256_BLOCK_LENGTH) {
+				memset(&context->buffer[usedspace], 0,
+				    SHA256_BLOCK_LENGTH - usedspace);
+			}
+			/* Do second-to-last transform: */
+			SHA256Transform(context->state.st32, context->buffer);
+
+			/* Prepare for last transform: */
+			memset(context->buffer, 0, SHA256_SHORT_BLOCK_LENGTH);
+		}
+	} else {
+		/* Set-up for the last transform: */
+		memset(context->buffer, 0, SHA256_SHORT_BLOCK_LENGTH);
+
+		/* Begin padding with a 1 bit: */
+		*context->buffer = 0x80;
+	}
+	/* Store the length of input data (in bits) in big endian format: */
+	BE_64_TO_8(&context->buffer[SHA256_SHORT_BLOCK_LENGTH],
+	    context->bitcount[0]);
+
+	/* Final transform: */
+	SHA256Transform(context->state.st32, context->buffer);
+
+	/* Clean up: */
+	usedspace = 0;
+}
+
+void
+SHA256Final(uint8_t digest[SHA256_DIGEST_LENGTH], SHA2_CTX *context)
+{
+	SHA2_CTX *volatile const contextv = context;
+	SHA256Pad(context);
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+	int	i;
+
+	/* Convert TO host byte order */
+	for (i = 0; i < 8; i++)
+		BE_32_TO_8(digest + i * 4, context->state.st32[i]);
+#else
+	memcpy(digest, context->state.st32, SHA256_DIGEST_LENGTH);
+#endif
+	memset(contextv, 0, sizeof(*contextv));
+}

--- a/sha2.h
+++ b/sha2.h
@@ -1,0 +1,64 @@
+/*	$OpenBSD: sha2.h,v 1.10 2016/09/03 17:00:29 tedu Exp $	*/
+
+/*
+ * FILE:	sha2.h
+ * AUTHOR:	Aaron D. Gifford <me@aarongifford.com>
+ *
+ * Copyright (c) 2000-2001, Aaron D. Gifford
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTOR(S) ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTOR(S) BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $From: sha2.h,v 1.1 2001/11/08 00:02:01 adg Exp adg $
+ */
+
+#ifndef __SHA2_H__
+#define __SHA2_H__
+
+#include "stdint.h"
+
+/*** SHA-256/384/512 Various Length Definitions ***********************/
+#define SHA256_BLOCK_LENGTH			64
+#define SHA256_DIGEST_LENGTH		32
+#define SHA256_DIGEST_STRING_LENGTH	(SHA256_DIGEST_LENGTH * 2 + 1)
+
+/*** SHA-224/256/384/512 Context Structure *******************************/
+typedef struct _SHA2_CTX {
+	union {
+		uint32_t	st32[8];
+		uint64_t	st64[8];
+	} state;
+	uint64_t	bitcount[2];
+	uint8_t	buffer[SHA256_BLOCK_LENGTH];
+} SHA2_CTX;
+
+void SHA256Init(SHA2_CTX *);
+void SHA256Transform(uint32_t state[8], const uint8_t [SHA256_BLOCK_LENGTH]);
+void SHA256Update(SHA2_CTX *, const uint8_t *, size_t);
+void SHA256Pad(SHA2_CTX *);
+void SHA256Final(uint8_t [SHA256_DIGEST_LENGTH], SHA2_CTX *);
+char *SHA256End(SHA2_CTX *, char *);
+
+#endif /* __SHA2_H__ */

--- a/sim.h
+++ b/sim.h
@@ -27,90 +27,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdlib.h>
-#include <string.h>
+#ifndef __SIM_H__
+#define __SIM_H__
 
-#include "sim.h"
+#include "qdl.h"
+#include "vip.h"
 
-struct qdl_device_sim
-{
-	struct qdl_device base;
-	struct vip_table_generator *vip_gen;
-	bool create_digests;
-};
-
-static int sim_open(struct qdl_device *qdl, const char *serial)
-{
-	ux_info("This is a dry-run execution of QDL. No actual flashing has been performed\n");
-
-	return 0;
-}
-
-static void sim_close(struct qdl_device *qdl)
-{
-	return;
-}
-
-static int sim_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout)
-{
-	return len;
-}
-
-static int sim_write(struct qdl_device *qdl, const void *buf, size_t len)
-{
-	return len;
-}
-
-static void sim_set_out_chunk_size(struct qdl_device *qdl, long size)
-{
-	return;
-}
-
-struct qdl_device *sim_init(void)
-{
-	struct qdl_device *qdl = malloc(sizeof(struct qdl_device_sim));
-	if (!qdl)
-		return NULL;
-
-	memset(qdl, 0, sizeof(struct qdl_device_sim));
-
-	qdl->dev_type = QDL_DEVICE_SIM;
-	qdl->open = sim_open;
-	qdl->read = sim_read;
-	qdl->write = sim_write;
-	qdl->close = sim_close;
-	qdl->set_out_chunk_size = sim_set_out_chunk_size;
-
-	return qdl;
-}
-
-struct vip_table_generator *sim_get_vip_generator(struct qdl_device *qdl)
-{
-	struct qdl_device_sim *qdl_sim;
-
-	if (qdl->dev_type != QDL_DEVICE_SIM)
-		return NULL;
-
-	qdl_sim = container_of(qdl, struct qdl_device_sim, base);
-
-	if (!qdl_sim->create_digests)
-		return NULL;
-
-	return qdl_sim->vip_gen;
-}
-
+struct vip_table_generator *sim_get_vip_generator(struct qdl_device *qdl);
 bool sim_set_digest_generation(bool create_digests, struct qdl_device *qdl,
-			       struct vip_table_generator *vip_gen)
-{
-	struct qdl_device_sim *qdl_sim;
+                               struct vip_table_generator *vip_gen);
 
-	if (qdl->dev_type != QDL_DEVICE_SIM)
-		return false;
-
-	qdl_sim = container_of(qdl, struct qdl_device_sim, base);
-
-	qdl_sim->create_digests = create_digests;
-	qdl_sim->vip_gen = vip_gen;
-
-	return true;
-}
+#endif /* __SIM_H__ */

--- a/usb.c
+++ b/usb.c
@@ -9,10 +9,6 @@
 
 #include "qdl.h"
 
-#define container_of(ptr, typecast, member) ({                  \
-	void *_ptr = (void *)(ptr);		                \
-	((typecast *)(_ptr - offsetof(typecast, member))); })
-
 #define DEFAULT_OUT_CHUNK_SIZE (1024 * 1024)
 
 struct qdl_device_usb

--- a/vip.c
+++ b/vip.c
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "sim.h"
+
+#define DIGEST_FULL_TABLE_FILE			"DIGEST_TABLE.bin"
+#define CHAINED_TABLE_FILE_PREF			"ChainedTableOfDigests"
+#define CHAINED_TABLE_FILE_MAX_NAME		64
+#define DIGEST_TABLE_TO_SIGN_FILE		"DigestsToSign.bin"
+#define MAX_DIGESTS_PER_SIGNED_FILE		54
+#define MAX_DIGESTS_PER_SIGNED_TABLE		(MAX_DIGESTS_PER_SIGNED_FILE - 1)
+#define MAX_DIGESTS_PER_CHAINED_FILE		256
+#define MAX_DIGESTS_PER_CHAINED_TABLE		(MAX_DIGESTS_PER_CHAINED_FILE - 1)
+#define MAX_DIGESTS_PER_BUF			16
+
+struct vip_table_generator
+{
+	unsigned char hash[SHA256_DIGEST_LENGTH];
+
+	SHA2_CTX ctx;
+
+	FILE *digest_table_fd;
+	size_t digest_num_written;
+
+	const char *path;
+};
+
+static void print_digest(unsigned char *buf)
+{
+	char hex_str[SHA256_DIGEST_STRING_LENGTH];
+
+	for (size_t i = 0; i < SHA256_DIGEST_LENGTH; ++i)
+		sprintf(hex_str + i * 2, "%02x", buf[i]);
+
+	hex_str[SHA256_DIGEST_STRING_LENGTH - 1] = '\0';
+
+	ux_debug("FIREHOSE PACKET SHA256: %s\n", hex_str);
+}
+
+int vip_gen_init(struct qdl_device *qdl, const char *path)
+{
+	struct vip_table_generator *vip_gen;
+	struct stat st;
+	char filepath[PATH_MAX];
+
+	if (qdl->dev_type != QDL_DEVICE_SIM) {
+		ux_err("Should be executed in simulation dry-run mode\n");
+		return -1;
+	}
+
+	if (stat(path, &st) || !S_ISDIR(st.st_mode)) {
+		ux_err("Directory '%s' to store VIP tables doesn't exist\n", path);
+	}
+
+	vip_gen = malloc(sizeof(struct vip_table_generator));
+	if (!vip_gen) {
+		ux_err("Can't allocate memory for vip_table_generator\n");
+		return -1;
+	}
+	if (!sim_set_digest_generation(true, qdl, vip_gen)) {
+		ux_err("Can't enable digest table generation\n");
+		goto out_cleanup;
+	}
+	vip_gen->digest_num_written = 0;
+	vip_gen->path = path;
+
+	snprintf(filepath, sizeof(filepath), "%s/%s", path, DIGEST_FULL_TABLE_FILE);
+
+	vip_gen->digest_table_fd = fopen(filepath, "wb");
+	if (!vip_gen->digest_table_fd) {
+		ux_err("Can't create %s file\n", filepath);
+		goto out_cleanup;
+	}
+
+	return 0;
+out_cleanup:
+	free(vip_gen);
+	sim_set_digest_generation(false, qdl, NULL);
+
+	return -1;
+}
+
+void vip_gen_chunk_init(struct qdl_device *qdl)
+{
+	struct vip_table_generator *vip_gen;
+
+	vip_gen = sim_get_vip_generator(qdl);
+	if (!vip_gen)
+		return;
+
+	SHA256Init(&vip_gen->ctx);
+}
+
+void vip_gen_chunk_update(struct qdl_device *qdl, const void *buf, size_t len)
+{
+	struct vip_table_generator *vip_gen;
+
+	vip_gen = sim_get_vip_generator(qdl);
+	if (!vip_gen)
+		return;
+
+	SHA256Update(&vip_gen->ctx, (uint8_t *)buf, len);
+}
+
+void vip_gen_chunk_store(struct qdl_device *qdl)
+{
+	struct vip_table_generator *vip_gen;
+
+	vip_gen = sim_get_vip_generator(qdl);
+	if (!vip_gen)
+		return;
+
+	SHA256Final(vip_gen->hash, &vip_gen->ctx);
+
+	print_digest(vip_gen->hash);
+
+	if (fwrite(vip_gen->hash, SHA256_DIGEST_LENGTH, 1, vip_gen->digest_table_fd) != 1) {
+		ux_err("Failed to write digest to the " DIGEST_FULL_TABLE_FILE);
+		goto out_cleanup;
+	}
+
+	vip_gen->digest_num_written++;
+
+	return;
+
+out_cleanup:
+	fclose(vip_gen->digest_table_fd);
+}
+
+static int write_output_file(const char *filename, bool append, const void *data, size_t len)
+{
+	FILE *fp;
+	char *mode = "wb";
+
+	if (append)
+		mode = "ab";
+
+	fp = fopen(filename, mode);
+	if (!fp) {
+		ux_err("Failed to open file for appending\n");
+		return -1;
+	}
+
+	if (fwrite(data, 1, len, fp) != len) {
+		ux_err("Failed to append to file\n");
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+
+	return 0;
+}
+
+static int calculate_hash_of_file(const char *filename, unsigned char *hash)
+{
+	unsigned char buf[1024];
+	SHA2_CTX ctx;
+
+	FILE *fp = fopen(filename, "rb");
+	if (!fp) {
+		ux_err("Failed to open file for hashing\n");
+		return -1;
+	}
+
+	SHA256Init(&ctx);
+
+	size_t bytes;
+	while ((bytes = fread(buf, 1, sizeof(buf), fp)) > 0) {
+		SHA256Update(&ctx, (uint8_t *)buf, bytes);
+	}
+
+	fclose(fp);
+
+	SHA256Final(hash, &ctx);
+
+	return 0;
+}
+
+static int write_digests_to_table(char *src_table, char *dest_table, size_t start_digest, size_t count)
+{
+	const size_t elem_size = SHA256_DIGEST_LENGTH;
+	unsigned char buf[MAX_DIGESTS_PER_BUF * SHA256_DIGEST_LENGTH];
+	size_t written = 0;
+	int ret;
+
+	int fd = open(src_table, O_RDONLY);
+	if (fd < 0) {
+		ux_err("Failed to open %s for reading\n", src_table);
+		return -1;
+	}
+
+	/* Seek to offset of start_digest */
+	size_t offset = elem_size * start_digest;
+	if (lseek(fd, offset, SEEK_SET) != offset) {
+		ux_err("Failed to seek in %s\n", src_table);
+		goto out_cleanup;
+	}
+
+	while (written < (count * elem_size)) {
+		size_t to_read = count * elem_size - written;
+		if (to_read > sizeof(buf))
+			to_read = sizeof(buf);
+
+		size_t bytes = read(fd, buf, to_read);
+		if (bytes < 0 || (size_t) bytes != to_read) {
+			ux_err("Failed to read from %s\n", src_table);
+			goto out_cleanup;
+		}
+
+		ret = write_output_file(dest_table, (written != 0), buf, bytes);
+		if (ret < 0) {
+			ux_err("Can't write digests to %s\n", dest_table);
+			goto out_cleanup;
+		}
+
+		written += to_read;
+	}
+	close(fd);
+
+	return 0;
+out_cleanup:
+	close(fd);
+
+	return -1;
+}
+
+static int create_chained_tables(struct vip_table_generator *vip_gen)
+{
+	size_t chained_num = 0;
+	size_t tosign_count = 0;
+	size_t total_digests = vip_gen->digest_num_written;
+	char src_table[PATH_MAX];
+	char dest_table[PATH_MAX];
+	unsigned char hash[SHA256_DIGEST_LENGTH];
+	int ret;
+
+	snprintf(src_table, sizeof(src_table), "%s/%s", vip_gen->path, DIGEST_FULL_TABLE_FILE);
+
+	/* Step 1: Write digest table to DigestsToSign.bin */
+	snprintf(dest_table, sizeof(dest_table), "%s/%s",
+		 vip_gen->path, DIGEST_TABLE_TO_SIGN_FILE);
+	tosign_count = total_digests < MAX_DIGESTS_PER_SIGNED_TABLE ? total_digests :
+		       MAX_DIGESTS_PER_SIGNED_TABLE;
+
+	ret = write_digests_to_table(src_table, dest_table, 0, tosign_count);
+	if (ret) {
+		ux_err("Writing digests to %s failed\n", dest_table);
+		return ret;
+	}
+
+	/* Step 2: Write remaining digests to ChainedTableOfDigests<n>.bin */
+	if (total_digests > MAX_DIGESTS_PER_SIGNED_TABLE) {
+		size_t remaining_digests = total_digests - MAX_DIGESTS_PER_SIGNED_TABLE;
+
+		while (remaining_digests > 0) {
+			size_t table_digests = remaining_digests > MAX_DIGESTS_PER_CHAINED_TABLE ?
+						MAX_DIGESTS_PER_CHAINED_TABLE : remaining_digests;
+
+			snprintf(dest_table, sizeof(dest_table),
+				 "%s/%s%zu.bin", vip_gen->path,
+				 CHAINED_TABLE_FILE_PREF, chained_num);
+
+			ret = write_digests_to_table(src_table, dest_table,
+						     total_digests - remaining_digests,
+						     table_digests);
+			if (ret) {
+				ux_err("Writing digests to %s failed\n", dest_table);
+				return ret;
+			}
+
+			remaining_digests -= table_digests;
+			if (!remaining_digests) {
+				/* Add zero (the packet can't be multiple of 512 bytes) */
+				ret = write_output_file(dest_table, true, "\0", 1);
+				if (ret < 0) {
+					ux_err("Can't write 0 to %s\n", dest_table);
+					return ret;
+				}
+			}
+			chained_num++;
+		}
+	}
+
+	/* Step 3: Recursively hash and append backwards */
+	for (ssize_t i = chained_num - 1; i >= 0; --i) {
+		snprintf(src_table, sizeof(src_table),
+			 "%s/%s%zd.bin", vip_gen->path,
+			 CHAINED_TABLE_FILE_PREF, i);
+		ret = calculate_hash_of_file(src_table, hash);
+		if (ret < 0) {
+			ux_err("Failed to hash %s\n", src_table);
+			return ret;
+		}
+
+		if (i == 0) {
+			snprintf(dest_table, sizeof(dest_table), "%s/%s",
+				 vip_gen->path, DIGEST_TABLE_TO_SIGN_FILE);
+			ret = write_output_file(dest_table, true, hash, SHA256_DIGEST_LENGTH);
+			if (ret < 0) {
+				ux_err("Failed to append hash to %s\n", dest_table);
+				return ret;
+			}
+		} else {
+			snprintf(dest_table, sizeof(dest_table),
+				 "%s/%s%zd.bin", vip_gen->path,
+				 CHAINED_TABLE_FILE_PREF, (i - 1));
+			ret = write_output_file(dest_table, true, hash, SHA256_DIGEST_LENGTH);
+			if (ret < 0) {
+				ux_err("Failed to append hash to %s\n", dest_table);
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void vip_gen_finalize(struct qdl_device *qdl)
+{
+	struct vip_table_generator *vip_gen;
+
+	vip_gen = sim_get_vip_generator(qdl);
+	if (!vip_gen)
+		return;
+
+	fclose(vip_gen->digest_table_fd);
+
+	ux_debug("VIP TABLE DIGESTS: %lu\n", vip_gen->digest_num_written);
+
+	if (create_chained_tables(vip_gen) < 0)
+		ux_err("Error occured when creating table of digests\n");
+
+	free(vip_gen);
+	sim_set_digest_generation(false, qdl, NULL);
+}

--- a/vip.h
+++ b/vip.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __VIP_H__
+#define __VIP_H__
+
+#include "sha2.h"
+
+struct vip_table_generator;
+
+int vip_gen_init(struct qdl_device *qdl, const char *path);
+void vip_gen_chunk_init(struct qdl_device *qdl);
+void vip_gen_chunk_update(struct qdl_device *qdl, const void *buf, size_t len);
+void vip_gen_chunk_store(struct qdl_device *qdl);
+void vip_gen_finalize(struct qdl_device *qdl);
+
+#endif /* __VIP_H__ */


### PR DESCRIPTION
```
Add support for Digests Table generation for Validated Image
Programming (VIP), which is activated when Secure Boot is enabled
on the target. VIP controls which packets are allowed to be issued to
the target. Controlling the packets that can be sent to the target is
done through hashing. The target applies a hashing function to all
received data, comparing the resulting hash digest against an existing
digest table in memory. If the calculated hash digest matches the next
entry in the table, the packet (data or command) is accepted; otherwise,
the packet is rejected, and the target halts.

This change introduces logic for VIP table generation.
In the current VIP design the first signed hash table can be a
maximum of 8 KB. Considering that it must be in MBN format, and in
addition to the raw hash table, it also includes an MBN header,
a signature, and certificates, the number of hash digests it can
contain is limited to 54 hashes (a 40-byte MBN header +
a 1696-byte hash table + a 256-byte signature + 6144 bytes of certificates).
All hashes left are stored in the additional ChainedTableOfDigests<n>.bin
files.

To generate table of digests run QDL with --create-digests param,
providing a path to store VIP tables.

As a result 3 types of files are generated:
- DIGEST_TABLE.bin - contains the SHA256 table of digests for all firehose
  packets to be sent to the target. It is an intermediary table and is
  used only for the subsequent generation of "DigestsToSign.bin" and
  "ChainedTableOfDigests.bin" files. It is not used by QDL for VIP
  programming.

- DigestsToSign.bin - first 53 digests + digest of ChainedTableOfDigests.bin.
  This file has to be converted to MBN format and then signed with sectools:

  $ sectools mbn-tool generate --data DigestsToSign.bin --mbn-version 6
    --outfile DigestsToSign.bin.mbn
  $ sectools secure-image --sign DigestsToSign.bin.mbn --image-id=VIP

  Please check the security profile for your SoC to determine which version of
  the MBN format should be used.

- ChainedTableOfDigests<n>.bin - contains left digests, split on
  multiple files with 255 digests + appended hash of next table.

For example, for 400 packets supposed to be sent to the target, these files
will be generated (all digests are 32 bytes in size):

 DIGEST_TABLE.bin
 _____________
| Digest 0    |
| Digest 1    |
| etc.        |
|             |
| Digest 399  |
|_____________|

 DigestsTableToSign.bin ChainedTableOfDigests0.bin ChainedTableOfDigests1.bin
 ___________________       ___________________       ____________
| Digest 0          |     | Digest 53         |     | Digest 308 |
| Digest 1          |     | Digest 54         |     | Digest 309 |
| etc.              |     | etc.              |     | etc.       |
| Digest 52         |     | Digest 307        |     | Digest 399 |
| Next table digest |     | Next table digest |     |____________|
|___________________|     |___________________|

When QDL is executed with --debug parameter, it will also report
Firehose packet SHA-256 hashes, for example:

FIREHOSE WRITE: <?xml version="1.0"?>
<data><patch SECTOR_SIZE_IN_BYTES="4096" byte_offset="72" filename="DISK"
physical_partition_number="5" size_in_bytes="8"
start_sector="NUM_DISK_SECTORS-1" value="NUM_DISK_SECTORS-5."/></data>

FIREHOSE PACKET SHA256: a27b1459042ea36f654c5eed795730bf73ce37ce5e92e204fe06833e5e5e1749
```