### PR TITLE
usb: include stdlib.h for malloc declaration

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <libusb.h>


### PR DESCRIPTION
Yocto Walnascar building qdl leads to following error:
```
  | usb.c: In function 'usb_init':
  | usb.c:295:34: error: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
  |   295 |         struct qdl_device *qdl = malloc(sizeof(struct qdl_device_usb));
```
Fix this by including the required header directly.