### PR TITLE
Fix linux command to install libusb

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ loader and use this to flash images.
 ### Linux
 
 ```bash
-sudo apt install libxml2 libusb
+sudo apt install libxml2 libusb-1.0-0-dev
 make
 ```
 


### PR DESCRIPTION
On linux, there is no package named libusb available through apt. On running make, I found that the default version of libusb (libusb-1.0-0) does not work. Upon further testing, I found libusb-1.0-0-dev does work. Therefore, update the name of the libusb package to be installed for linux.