### PR TITLE
For linux msm/sparse int overflow

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -427,10 +427,10 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	} else {
 		switch (program->sparse_chunk_type) {
 		case CHUNK_TYPE_RAW:
-			lseek(fd, (off_t)program->sparse_chunk_data, SEEK_SET);
+			lseek(fd, program->sparse_offset, SEEK_SET);
 			break;
 		case CHUNK_TYPE_FILL:
-			fill_value = (uint32_t)program->sparse_chunk_data;
+			fill_value = program->sparse_fill_value;
 			for (n = 0; n < qdl->max_payload_size; n += sizeof(fill_value))
 				memcpy(buf + n, &fill_value, sizeof(fill_value));
 			break;

--- a/program.c
+++ b/program.c
@@ -65,10 +65,11 @@ static struct program *program_load_sparse(struct program *program, int fd)
 	char tmp[PATH_MAX];
 
 	sparse_header_t sparse_header;
-	unsigned int start_sector, chunk_type;
+	unsigned int start_sector;
 	uint32_t sparse_fill_value;
 	uint64_t chunk_size;
 	off_t sparse_offset;
+	int chunk_type;
 
 	if (sparse_header_parse(fd, &sparse_header)) {
 		/*
@@ -97,13 +98,7 @@ static struct program *program_load_sparse(struct program *program, int fd)
 						       &chunk_size,
 						       &sparse_fill_value,
 						       &sparse_offset);
-
-		switch (chunk_type) {
-		case CHUNK_TYPE_RAW:
-		case CHUNK_TYPE_FILL:
-		case CHUNK_TYPE_DONT_CARE:
-			break;
-		default:
+		if (chunk_type < 0) {
 			ux_err("[PROGRAM] Unable to parse sparse chunk %i at %s...failed\n",
 			       i, program->filename);
 			return NULL;

--- a/program.h
+++ b/program.h
@@ -2,7 +2,9 @@
 #ifndef __PROGRAM_H__
 #define __PROGRAM_H__
 
+#include <sys/types.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "qdl.h"
 
 struct program {
@@ -21,7 +23,8 @@ struct program {
 	bool is_erase;
 
 	unsigned int sparse_chunk_type;
-	unsigned int sparse_chunk_data;
+	uint32_t sparse_fill_value;
+	off_t sparse_offset;
 
 	struct program *next;
 };

--- a/sparse.c
+++ b/sparse.c
@@ -52,7 +52,9 @@ int sparse_header_parse(int fd, sparse_header_t *sparse_header)
 }
 
 int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
-			      unsigned int *chunk_size, unsigned int *value)
+			      unsigned int *chunk_size,
+			      uint32_t *value,
+			      off_t *offset)
 {
 	chunk_header_t chunk_header;
 	uint32_t fill_value = 0;
@@ -77,7 +79,7 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 		}
 
 		/* Save the current file offset in the 'value' variable */
-		*value = lseek(fd, 0, SEEK_CUR);
+		*offset = lseek(fd, 0, SEEK_CUR);
 
 		/* Move the file cursor forward by the size of the chunk */
 		lseek(fd, *chunk_size, SEEK_CUR);

--- a/sparse.c
+++ b/sparse.c
@@ -52,7 +52,7 @@ int sparse_header_parse(int fd, sparse_header_t *sparse_header)
 }
 
 int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
-			      unsigned int *chunk_size,
+			      uint64_t *chunk_size,
 			      uint32_t *value,
 			      off_t *offset)
 {
@@ -70,9 +70,9 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 	if (sparse_header->chunk_hdr_sz > sizeof(chunk_header_t))
 		lseek(fd, sparse_header->chunk_hdr_sz - sizeof(chunk_header_t), SEEK_CUR);
 
-	if (ntohs(chunk_header.chunk_type) == ntohs(CHUNK_TYPE_RAW)) {
-		*chunk_size = chunk_header.chunk_sz * sparse_header->blk_sz;
+	*chunk_size = (uint64_t)chunk_header.chunk_sz * sparse_header->blk_sz;
 
+	if (ntohs(chunk_header.chunk_type) == ntohs(CHUNK_TYPE_RAW)) {
 		if (chunk_header.total_sz != (sparse_header->chunk_hdr_sz + *chunk_size)) {
 			ux_err("[SPARSE] Bogus chunk size, type Raw\n");
 			return -EINVAL;
@@ -87,8 +87,6 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 		return CHUNK_TYPE_RAW;
 
 	} else if (ntohs(chunk_header.chunk_type) == ntohs(CHUNK_TYPE_DONT_CARE)) {
-		*chunk_size = chunk_header.chunk_sz * sparse_header->blk_sz;
-
 		if (chunk_header.total_sz != sparse_header->chunk_hdr_sz) {
 			ux_err("[SPARSE] Bogus chunk size, type Don't Care\n");
 			return -EINVAL;
@@ -97,8 +95,6 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 		return CHUNK_TYPE_DONT_CARE;
 
 	} else if (ntohs(chunk_header.chunk_type) == ntohs(CHUNK_TYPE_FILL)) {
-		*chunk_size = chunk_header.chunk_sz * sparse_header->blk_sz;
-
 		if (chunk_header.total_sz != (sparse_header->chunk_hdr_sz + sizeof(fill_value))) {
 			ux_err("[SPARSE] Bogus chunk size, type Fill\n");
 			return -EINVAL;

--- a/sparse.h
+++ b/sparse.h
@@ -6,6 +6,7 @@
 #define __SPARSE_H__
 
 #include <stdint.h>
+#include <stdio.h>
 
 typedef struct __attribute__((__packed__)) sparse_header {
 	/* 0xed26ff3a */
@@ -55,10 +56,11 @@ int sparse_header_parse(int fd, sparse_header_t *sparse_header);
 
 /*
  * Parses the sparse image chunk header from the file descriptor.
- * Sets the chunk size and value based on the parsed data.
+ * Sets the chunk size, and value or offset based on the parsed data.
  * Returns the chunk type on success, or an error code otherwise.
  */
 int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
-			      unsigned int *chunk_size, unsigned int *value);
+			      unsigned int *chunk_size,
+			      uint32_t *value, off_t *offset);
 
 #endif

--- a/sparse.h
+++ b/sparse.h
@@ -60,7 +60,7 @@ int sparse_header_parse(int fd, sparse_header_t *sparse_header);
  * Returns the chunk type on success, or an error code otherwise.
  */
 int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
-			      unsigned int *chunk_size,
+			      uint64_t *chunk_size,
 			      uint32_t *value, off_t *offset);
 
 #endif


### PR DESCRIPTION
There are a few different integer overflows in the sparse code, resulting in data corruption when flashing large images etc.
While at it, clean up the endianness in the code.

This is likely the problem reported in #124 