### PR TITLE
qdl: add raw xml mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS += -lws2_32
 endif
 prefix := /usr/local
 
-QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sha2.c sim.c ufs.c usb.c ux.c oscompat.c vip.c sparse.c
+QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c raw.c sha2.c sim.c ufs.c usb.c ux.c oscompat.c vip.c sparse.c
 QDL_OBJS := $(QDL_SRCS:.c=.o)
 
 RAMDUMP_SRCS := ramdump.c sahara.c io.c sim.c usb.c util.c ux.c oscompat.c

--- a/firehose.c
+++ b/firehose.c
@@ -660,6 +660,22 @@ out:
 	return ret == FIREHOSE_ACK ? 0 : -1;
 }
 
+static int firehose_raw_op(struct qdl_device *qdl, struct raw_op *raw_op)
+{
+	int ret;
+
+	ret = firehose_write(qdl, raw_op->doc);
+	if (ret < 0)
+		goto out;
+
+	ret = firehose_read(qdl, 5000, firehose_generic_parser, NULL);
+	if (ret)
+		ux_err("raw xml application failed\n");
+
+out:
+	return ret == FIREHOSE_ACK ? 0 : -1;
+}
+
 static int firehose_send_single_tag(struct qdl_device *qdl, xmlNode *node)
 {
 	xmlNode *root;
@@ -865,6 +881,10 @@ int firehose_run(struct qdl_device *qdl, const char *incdir,
 		return ret;
 
 	ret = read_op_execute(qdl, firehose_read_op, incdir);
+	if (ret)
+		return ret;
+
+	ret = raw_op_execute(qdl, firehose_raw_op);
 	if (ret)
 		return ret;
 

--- a/qdl.h
+++ b/qdl.h
@@ -7,6 +7,7 @@
 #include "patch.h"
 #include "program.h"
 #include "read.h"
+#include "raw.h"
 #include <libxml/tree.h>
 #include "vip.h"
 

--- a/raw.c
+++ b/raw.c
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+ * All rights reserved.
+ */
+#include <fcntl.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include "raw.h"
+#include "qdl.h"
+#include "oscompat.h"
+
+static struct raw_op *raw_ops;
+static struct raw_op *raw_ops_last;
+
+int raw_op_load(const char *raw_op_file)
+{
+	xmlDoc *doc;
+	struct raw_op *raw_op;
+
+	doc = xmlReadFile(raw_op_file, NULL, 0);
+
+	if (!doc) {
+		ux_err("failed to parse raw-type file \"%s\"\n", raw_op_file);
+		return -EINVAL;
+	}
+
+	raw_op = calloc(1, sizeof(struct raw_op));
+	raw_op->doc = doc;
+
+	if (raw_ops) {
+		raw_ops_last->next = raw_op;
+		raw_ops_last = raw_op;
+	} else {
+		raw_ops = raw_op;
+		raw_ops_last = raw_op;
+	}
+
+	return 0;
+}
+
+int raw_op_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct raw_op *raw_op))
+{
+	struct raw_op *raw_op;
+	int ret;
+
+	for (raw_op = raw_ops; raw_op; raw_op = raw_op->next) {
+		ret = apply(qdl, raw_op);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}

--- a/raw.h
+++ b/raw.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef __RAW_H__
+#define __RAW_H__
+
+#include <libxml/parser.h>
+
+struct qdl_device;
+
+struct raw_op {
+	xmlDoc *doc;
+	struct raw_op *next;
+};
+
+int raw_op_load(const char *raw_op_file);
+int raw_op_execute(struct qdl_device *qdl,
+		    int (*apply)(struct qdl_device *qdl, struct raw_op *raw_op));
+
+#endif


### PR DESCRIPTION
Some firehose commands such as peek, poke, getstorageinfo are simple XML command that can be processed with a generic raw XML file mode and the generic parser.

Introduce a raw XML file mode, to allow sending a user defined XML file to the target.

e.g. create info.xml with

<?xml version="1.0"?>
<data>
<getstorageinfo physicl_partition_number="0"/>
</data>

and run

qdl -r <program> info.xml

it will return the response of the target.