### PR TITLE
Update libxml DLL bundled with Windows binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
           New-Item -ItemType Directory -Path $DistDir | Out-Null
 
           Copy-Item (Join-Path $BIN_DIR "zlib1.dll") $DistDir
-          Copy-Item (Join-Path $BIN_DIR "libxml2-2.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libxml2-16.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libusb-1.0.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "liblzma-5.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libiconv-2.dll") $DistDir


### PR DESCRIPTION
libxml DLL has a new version so include it in the Windows bundle. Fixes #131

I tested the x64 version. @ndechesne can you test the arm64 version?