### PR TITLE
sahara: Print an error when device isn't reachable

### DIFF
--- a/sahara.c
+++ b/sahara.c
@@ -452,8 +452,10 @@ int sahara_run(struct qdl_device *qdl, char *img_arr[], bool single_image,
 
 	while (!done) {
 		n = qdl_read(qdl, buf, sizeof(buf), 1000);
-		if (n < 0)
+		if (n < 0) {
+			ux_err("failed to read sahara request from device\n");
 			break;
+		}
 
 		pkt = (struct sahara_pkt *)buf;
 		if (n != pkt->length) {


### PR DESCRIPTION
Sometimes the device ends up in a funky state, resulting in the initial USB read to fail. Rather then just silently exiting with an error code, actually print a message to inform the user.