### PR TITLE
gpt: gpt_load_table_from_partition: fix off-by-one error for num_sectors

### DIFF
--- a/gpt.c
+++ b/gpt.c
@@ -201,10 +201,11 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 		partition->name = strdup(name);
 		partition->partition = phys_partition;
 		partition->start_sector = entry->first_lba;
-		partition->num_sectors = entry->last_lba - entry->first_lba;
+		/* if first_lba == last_lba there is 1 sector worth of data (IE: add 1 below) */
+		partition->num_sectors = entry->last_lba - entry->first_lba + 1;
 
-		ux_debug("  %3d: %s sector %u to %u\n", i, partition->name,
-			 partition->start_sector, partition->start_sector + partition->num_sectors);
+		ux_debug("  %3d: %s start sector %u, num sectors %u\n", i, partition->name,
+			 partition->start_sector, partition->num_sectors);
 
 		if (gpt_partitions) {
 			gpt_partitions_last->next = partition;


### PR DESCRIPTION
When using first_lba and last_lba information from the GPT entry to calculate the number of sectors, we need to add 1 to the result.

Imagine if both values were 1.  This means there is 1 sector of data and the first and last LBA values are same.  However, the current calculation is: num_sectors = last_lba - first_lba.

In this case, it would return a value of 0.  (Always 1 less sector than it should).

Tested on the CDT partition of RB3 Gen2:
In the rawprogram3.xml file it has num_partition_sectors="32" (4096 byte sector size).  This should result in a binary size of 131072.

Pre-patch:
$ qdl --storage ufs prog_firehose_ddr.elf read 3/cdt cdt-bad.bin waiting for programmer...
partition 6 has not GPT header
partition 7 has not GPT header
0 patches applied
read "cdt-bad.bin" successfully
$ ls -l cdt-bad.bin
-rw-r--r-- 1 user user 126976 Sep 16 21:02 cdt-bad.bin

Post-patch:
$ qdl --storage ufs prog_firehose_ddr.elf read 3/cdt cdt-good.bin Waiting for EDL device
waiting for programmer...
partition 6 has not GPT header
partition 7 has not GPT header
0 patches applied
read "cdt-good.bin" successfully
$ ls -l cdt-good.bin
-rw-r--r-- 1 user user 131072 Sep 16 21:04 cdt-good.bin