### PR TITLE
Add build instructions for MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ make
 
 ### MacOS
 
+For Homebrew users,
 ```bash
 brew install libxml2 pkg-config libusb
+make
+```
+
+For MacPorts users
+```bash
+sudo port install libxml2 pkgconfig libusb
 make
 ```
 


### PR DESCRIPTION
Mac users use Homebrew or MacPorts to get their "unix" tools. 

Add instructions to build on MacPorts users.