### PR TITLE
usb: increase bulk transfer timeout for firehose raw write

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -228,7 +228,7 @@ static int firehose_write(struct qdl_device *qdl, xmlDoc *doc)
 	for (;;) {
 		ux_debug("FIREHOSE WRITE: %s\n", s);
 		vip_gen_chunk_update(qdl, s, len);
-		ret = qdl_write(qdl, s, len);
+		ret = qdl_write(qdl, s, len, 1000);
 		saved_errno = errno;
 
 		/*
@@ -560,7 +560,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 
 			vip_transfer_clear_status(qdl);
 		}
-		n = qdl_write(qdl, buf, chunk_size * sector_size);
+		n = qdl_write(qdl, buf, chunk_size * sector_size, 10000);
 		if (n < 0) {
 			ux_err("USB write failed for data chunk\n");
 			ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);

--- a/io.c
+++ b/io.c
@@ -58,11 +58,12 @@ int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout
  * @qdl: device handle
  * @buf: buffer with data to be written
  * @len: length of data to be written
+ * @timeout: timeout for write, in milliseconds
  *
  * Returns: number of bytes read
  *	    negative errno on failure (notably -ETIMEDOUT)
  */
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout)
 {
-	return qdl->write(qdl, buf, len);
+	return qdl->write(qdl, buf, len, timeout);
 }

--- a/ks.c
+++ b/ks.c
@@ -29,7 +29,7 @@ int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout
 	return read(qdl->fd, buf, len);
 }
 
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len)
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout)
 {
 	return write(qdl->fd, buf, len);
 }

--- a/qdl.h
+++ b/qdl.h
@@ -43,7 +43,7 @@ struct qdl_device {
 
 	int (*open)(struct qdl_device *qdl, const char *serial);
 	int (*read)(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
-	int (*write)(struct qdl_device *qdl, const void *buf, size_t nbytes);
+	int (*write)(struct qdl_device *qdl, const void *buf, size_t nbytes, unsigned int timeout);
 	void (*close)(struct qdl_device *qdl);
 	void (*set_out_chunk_size)(struct qdl_device *qdl, long size);
 	void (*set_vip_transfer)(struct qdl_device *qdl, const char *signed_table,
@@ -61,7 +61,7 @@ void qdl_deinit(struct qdl_device *qdl);
 int qdl_open(struct qdl_device *qdl, const char *serial);
 void qdl_close(struct qdl_device *qdl);
 int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len);
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout);
 void qdl_set_out_chunk_size(struct qdl_device *qdl, long size);
 int qdl_vip_transfer_enable(struct qdl_device *qdl, const char *vip_table_path);
 

--- a/sim.c
+++ b/sim.c
@@ -27,7 +27,7 @@ static int sim_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int 
 	return len;
 }
 
-static int sim_write(struct qdl_device *qdl, const void *buf, size_t len)
+static int sim_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout)
 {
 	return len;
 }

--- a/usb.c
+++ b/usb.c
@@ -247,7 +247,7 @@ static int usb_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int 
 	return actual;
 }
 
-static int usb_write(struct qdl_device *qdl, const void *buf, size_t len)
+static int usb_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout)
 {
 	unsigned char *data = (unsigned char *)buf;
 	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
@@ -261,7 +261,7 @@ static int usb_write(struct qdl_device *qdl, const void *buf, size_t len)
 		xfer = (len > qdl_usb->out_chunk_size) ? qdl_usb->out_chunk_size : len;
 
 		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->out_ep, data,
-					   xfer, &actual, 1000);
+					   xfer, &actual, timeout);
 		if (ret != 0 && ret != LIBUSB_ERROR_TIMEOUT) {
 			warnx("bulk write failed: %s", libusb_strerror(ret));
 			return -EIO;
@@ -276,7 +276,7 @@ static int usb_write(struct qdl_device *qdl, const void *buf, size_t len)
 
 	if (len_orig % qdl_usb->out_maxpktsize == 0) {
 		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->out_ep, NULL,
-					   0, &actual, 1000);
+					   0, &actual, timeout);
 		if (ret < 0)
 			return -EIO;
 	}

--- a/vip.c
+++ b/vip.c
@@ -432,7 +432,7 @@ static int vip_transfer_send_raw(struct qdl_device *qdl, int table_fd)
 		goto out;
 	}
 
-	n = qdl_write(qdl, buf, sb.st_size);
+	n = qdl_write(qdl, buf, sb.st_size, 1000);
 	if (n < 0) {
 		ux_err("USB write failed for data chunk\n");
 		ret = -1;


### PR DESCRIPTION
During QRB2210 provisioning, a USB write failure has been observed early in the Firehose phase (first block write). This issue has been traced to a timeout during the USB bulk transfer of the Zero-Length Packet (ZLP).

In some conditions, the ZLP transfer may take longer than the current timeout, up to approximately 1.7 seconds.

Increasing the USB bulk transfer timeout to 3 seconds appears to resolve the issue.

The issue specifically occurs after a prior large eMMC write operation (e.g., during a previous QDL session). It could then be related to internal eMMC operations or timing delays that affect the USB ack.