### PR TITLE
Makefile: isolate build artifacts and use build dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y libxml2-dev libusb-1.0-0-dev
 
       - name: Build
-        run: make
+        run: make all
 
       - name: Run tests
         run: make tests
@@ -35,7 +35,7 @@ jobs:
           mkdir dist
           cp `pkg-config --variable=libdir libusb-1.0`/libusb-1.0.so.0 dist
           chmod 0644 dist/*
-          cp qdl dist
+          cp ./build/release/bin/qdl dist
           patchelf --set-rpath '$ORIGIN' dist/qdl
 
       - name: Upload artifact
@@ -63,7 +63,7 @@ jobs:
           brew install libxml2
 
       - name: Build
-        run: make
+        run: make all
 
       - name: Run tests
         run: make tests
@@ -75,7 +75,7 @@ jobs:
           cp `pkg-config --variable=libdir libusb-1.0`/libusb-1.0.0.dylib dist
           cp `pkg-config --variable=libdir liblzma`/liblzma.5.dylib dist
           chmod 0644 dist/*
-          cp qdl dist
+          cp ./build/release/bin/qdl dist
 
           if uname -a | grep -q arm64; then
             LIBUSB_DIR=/opt/homebrew/opt/libusb/lib
@@ -124,7 +124,7 @@ jobs:
             mingw-w64-x86_64-libusb
 
       - name: Build
-        run: make
+        run: make all
         shell: msys2 {0}
 
       - name: Run tests
@@ -145,7 +145,7 @@ jobs:
           Copy-Item (Join-Path $BIN_DIR "liblzma-5.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libiconv-2.dll") $DistDir
 
-          Copy-Item "qdl.exe" $DistDir
+          Copy-Item "./build/release/bin/qdl.exe" $DistDir
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+/build/
+/tests/data/*.elf
+/tests/data/*.bin
+/tests/data/*.img
 *.o
 qdl
 qdl-ramdump
@@ -7,5 +11,5 @@ compile_commands.json
 .cache
 .version.h
 version.h
-scripts
+.scripts
 .checkpatch-camelcase.git.

--- a/tests/test_vip_generation.sh
+++ b/tests/test_vip_generation.sh
@@ -8,6 +8,7 @@ SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 FLAT_BUILD=${SCRIPT_PATH}/data
 
 REP_ROOT=${SCRIPT_PATH}/..
+QDL_PATH=${REP_ROOT}/build/debug/bin
 VIP_PATH=${FLAT_BUILD}/vip
 EXPECTED_DIGEST="a05e1124edbe34dc504a327544fb66572591353dc3fa25e6e7eafbe4803e63e0"
 VIP_TABLE_FILE=${VIP_PATH}/DigestsToSign.bin
@@ -15,7 +16,7 @@ VIP_TABLE_FILE=${VIP_PATH}/DigestsToSign.bin
 mkdir -p $VIP_PATH
 
 cd $FLAT_BUILD
-${REP_ROOT}/qdl --dry-run --create-digests=${VIP_PATH} \
+${QDL_PATH}/qdl --dry-run --create-digests=${VIP_PATH} \
         prog_firehose_ddr.elf rawprogram*.xml patch*.xml
 
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
Previously, object files, binaries, and generated headers like .version.h were created directly in the project root. This cluttered the source tree and made it difficult to maintain separate debug and release builds. It also risked file collisions when switching build types or performing parallel builds.


* Introduced a unified build directory structure: 
```bash  
  build/
    release/
      bin/   - final executables
      obj/   - object files
      gen/   - generated headers (e.g., version.h)
    debug/
      ...
```
* Added BUILD_TYPE variable (defaults to "debug") with make debug and
  make release targets.