### PR TITLE
github: Bump macos runner versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         include:
           - { sys: macos-14, arch: arm64 }
-          - { sys: macos-13, arch: intel }
+          - { sys: macos-15-intel, arch: intel }
     runs-on: ${{ matrix.sys }}
 
     steps:


### PR DESCRIPTION
As announced by GitHub, the "macos-13" runners are being retired. The x86_64 build has been using this, so bump it to "macos-15-intel", in case we have any x86_64 users.