### PR TITLE
Move __unused macro after variable definitions

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -83,7 +83,7 @@ static xmlNode *firehose_response_parse(const void *buf, size_t len, int *error)
 	return node;
 }
 
-static int firehose_generic_parser(xmlNode *node, void __unused *data, bool *rawmode)
+static int firehose_generic_parser(xmlNode *node, void *data __unused, bool *rawmode)
 {
 	xmlChar *value;
 	int ret = -EINVAL;
@@ -255,7 +255,7 @@ static int firehose_write(struct qdl_device *qdl, xmlDoc *doc)
  * Return: max size supported by the remote, or negative errno on failure
  */
 static int firehose_configure_response_parser(xmlNode *node, void *data,
-					      bool __unused *rawmode)
+					      bool *rawmode __unused)
 {
 	xmlChar *payload;
 	xmlChar *value;
@@ -945,7 +945,7 @@ static int firehose_reset(struct qdl_device *qdl)
 }
 
 static int firehose_detect_and_configure(struct qdl_device *qdl,
-					 bool __unused skip_storage_init,
+					 bool skip_storage_init __unused,
 					 enum qdl_storage_type storage,
 					 unsigned int timeout_s)
 {

--- a/ks.c
+++ b/ks.c
@@ -24,12 +24,12 @@ static struct qdl_device qdl;
 
 bool qdl_debug;
 
-int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int __unused timeout)
+int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout __unused)
 {
 	return read(qdl->fd, buf, len);
 }
 
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int __unused timeout)
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, unsigned int timeout __unused)
 {
 	return write(qdl->fd, buf, len);
 }

--- a/sahara.c
+++ b/sahara.c
@@ -264,7 +264,7 @@ static void sahara_eoi(struct qdl_device *qdl, struct sahara_pkt *pkt)
 	qdl_write(qdl, &done, done.length, SAHARA_CMD_TIMEOUT_MS);
 }
 
-static int sahara_done(struct qdl_device __unused *qdl, struct sahara_pkt *pkt)
+static int sahara_done(struct qdl_device *qdl __unused, struct sahara_pkt *pkt)
 {
 	assert(pkt->length == SAHARA_DONE_RESP_LENGTH);
 

--- a/sim.c
+++ b/sim.c
@@ -13,31 +13,31 @@ struct qdl_device_sim {
 	bool create_digests;
 };
 
-static int sim_open(struct qdl_device __unused *qdl,
-		    const char __unused *serial)
+static int sim_open(struct qdl_device *qdl __unused,
+		    const char *serial __unused)
 {
 	ux_info("This is a dry-run execution of QDL. No actual flashing has been performed\n");
 
 	return 0;
 }
 
-static void sim_close(struct qdl_device __unused *qdl) {}
+static void sim_close(struct qdl_device *qdl __unused) {}
 
-static int sim_read(struct qdl_device __unused *qdl,
-		    void  __unused *buf, size_t len,
-		    unsigned int __unused timeout)
+static int sim_read(struct qdl_device *qdl __unused,
+		    void  *buf __unused, size_t len,
+		    unsigned int timeout __unused)
 {
 	return len;
 }
 
-static int sim_write(struct qdl_device __unused *qdl, const void __unused *buf,
-		     size_t len, unsigned int __unused timeout)
+static int sim_write(struct qdl_device *qdl __unused, const void *buf __unused,
+		     size_t len, unsigned int timeout __unused)
 {
 	return len;
 }
 
-static void sim_set_out_chunk_size(struct qdl_device __unused *qdl,
-				   long __unused size)
+static void sim_set_out_chunk_size(struct qdl_device *qdl __unused,
+				   long size __unused)
 {}
 
 struct qdl_device *sim_init(void)

--- a/ufs.c
+++ b/ufs.c
@@ -36,7 +36,7 @@ bool ufs_need_provisioning(void)
 	return !!ufs_epilogue_p;
 }
 
-struct ufs_common *ufs_parse_common_params(xmlNode *node, bool __unused finalize_provisioning)
+struct ufs_common *ufs_parse_common_params(xmlNode *node, bool finalize_provisioning __unused)
 {
 	struct ufs_common *result;
 	int errors;


### PR DESCRIPTION
Usage of __unused macro before the variable name leads to triggering checkpatch sanity check:
CHECK: spaces preferred around that '*' (ctx:WxV)

Fix this by moving the macro to the end of a function param declaration, like it's done in the Linux kernel code.

Fixes: a79a572f("Address unused parameter warnings")