### PR TITLE
firehose: Add slot flag

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -417,6 +417,9 @@ static int firehose_erase(struct qdl_device *qdl, struct program *program)
 	xml_setpropf(node, "num_partition_sectors", "%d", program->num_sectors);
 	xml_setpropf(node, "physical_partition_number", "%d", program->partition);
 	xml_setpropf(node, "start_sector", "%s", program->start_sector);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node, "slot", "%u", qdl->slot);
+	}
 	if (program->is_nand) {
 		xml_setpropf(node, "PAGES_PER_BLOCK", "%d", program->pages_per_block);
 	}
@@ -495,6 +498,9 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	xml_setpropf(node, "num_partition_sectors", "%d", num_sectors);
 	xml_setpropf(node, "physical_partition_number", "%d", program->partition);
 	xml_setpropf(node, "start_sector", "%s", program->start_sector);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node, "slot", "%u", qdl->slot);
+	}
 	if (program->filename)
 		xml_setpropf(node, "filename", "%s", program->filename);
 
@@ -652,6 +658,9 @@ static int firehose_issue_read(struct qdl_device *qdl, struct read_op *read_op,
 	xml_setpropf(node, "num_partition_sectors", "%d", read_op->num_sectors);
 	xml_setpropf(node, "physical_partition_number", "%d", read_op->partition);
 	xml_setpropf(node, "start_sector", "%s", read_op->start_sector);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node, "slot", "%u", qdl->slot);
+	}
 	if (read_op->filename)
 		xml_setpropf(node, "filename", "%s", read_op->filename);
 
@@ -770,6 +779,9 @@ static int firehose_apply_patch(struct qdl_device *qdl, struct patch *patch)
 	xml_setpropf(node, "size_in_bytes", "%d", patch->size_in_bytes);
 	xml_setpropf(node, "start_sector", "%s", patch->start_sector);
 	xml_setpropf(node, "value", "%s", patch->value);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node, "slot", "%u", qdl->slot);
+	}
 
 	ret = firehose_write(qdl, doc);
 	if (ret < 0)
@@ -826,6 +838,9 @@ int firehose_apply_ufs_common(struct qdl_device *qdl, struct ufs_common *ufs)
 	xml_setpropf(node_to_send, "bInitActiveICCLevel", "%d", ufs->bInitActiveICCLevel);
 	xml_setpropf(node_to_send, "wPeriodicRTCUpdate", "%d", ufs->wPeriodicRTCUpdate);
 	xml_setpropf(node_to_send, "bConfigDescrLock", "%d", ufs->bConfigDescrLock);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node_to_send, "slot", "%u", qdl->slot);
+	}
 
 	if (ufs->wb) {
 		xml_setpropf(node_to_send, "bWriteBoosterBufferPreserveUserSpaceEn",
@@ -858,6 +873,9 @@ int firehose_apply_ufs_body(struct qdl_device *qdl, struct ufs_body *ufs)
 	xml_setpropf(node_to_send, "bLogicalBlockSize", "%d", ufs->bLogicalBlockSize);
 	xml_setpropf(node_to_send, "bProvisioningType", "%d", ufs->bProvisioningType);
 	xml_setpropf(node_to_send, "wContextCapabilities", "%d", ufs->wContextCapabilities);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node_to_send, "slot", "%u", qdl->slot);
+	}
 	if (ufs->desc)
 		xml_setpropf(node_to_send, "desc", "%s", ufs->desc);
 
@@ -878,6 +896,9 @@ int firehose_apply_ufs_epilogue(struct qdl_device *qdl, struct ufs_epilogue *ufs
 
 	xml_setpropf(node_to_send, "LUNtoGrow", "%d", ufs->LUNtoGrow);
 	xml_setpropf(node_to_send, "commit", "%d", commit);
+	if (qdl->slot != UINT_MAX) {
+		xml_setpropf(node_to_send, "slot", "%u", qdl->slot);
+	}
 
 	ret = firehose_send_single_tag(qdl, node_to_send);
 	if (ret)

--- a/qdl.c
+++ b/qdl.c
@@ -431,6 +431,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " -S, --serial=T\t\t\tSelect target by serial number T (e.g. <0AA94EFD>)\n");
 	fprintf(out, " -u, --out-chunk-size=T\t\tOverride chunk size for transaction with T\n");
 	fprintf(out, " -t, --create-digests=T\t\tGenerate table of digests in the T folder\n");
+	fprintf(out, " -T, --slot=T\t\t\tSet slot number T for multiple storage devices\n");
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\txml file containing <program> or <erase> directives\n");
@@ -459,6 +460,7 @@ int main(int argc, char **argv)
 	bool allow_fusing = false;
 	bool allow_missing = false;
 	long out_chunk_size = 0;
+	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
 	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_USB;
 
@@ -475,11 +477,12 @@ int main(int argc, char **argv)
 		{"allow-fusing", no_argument, 0, 'c'},
 		{"dry-run", no_argument, 0, 'n'},
 		{"create-digests", required_argument, 0, 't'},
+		{"slot", required_argument, 0, 'T'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:h", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -519,6 +522,9 @@ int main(int argc, char **argv)
 		case 'D':
 			vip_table_path = optarg;
 			break;
+		case 'T':
+			slot = (unsigned int)strtoul(optarg, NULL, 10);
+			break;
 		case 'h':
 			print_usage(stdout);
 			return 0;
@@ -539,6 +545,8 @@ int main(int argc, char **argv)
 		ret = -1;
 		goto out_cleanup;
 	}
+
+	qdl->slot = slot;
 
 	if (vip_table_path) {
 		if (vip_generate_dir)

--- a/qdl.h
+++ b/qdl.h
@@ -56,6 +56,7 @@ struct qdl_device {
 	size_t max_payload_size;
 	size_t sector_size;
 	enum qdl_storage_type storage_type;
+	unsigned int slot;
 
 	int (*open)(struct qdl_device *qdl, const char *serial);
 	int (*read)(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);


### PR DESCRIPTION
For SoCs that support multiple UFS devices, firehose allows the slot property. This adds a flag to set the slot parameter.