### PR TITLE
Address more -Wsign-compare issues

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -451,7 +451,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	void *buf;
 	time_t t0;
 	time_t t;
-	int left;
+	size_t left;
 	int ret;
 	int n;
 	size_t i;
@@ -633,7 +633,7 @@ static int firehose_issue_read(struct qdl_device *qdl, struct read_op *read_op,
 	void *buf;
 	time_t t0;
 	time_t t;
-	int left;
+	size_t left;
 	int ret;
 	int n;
 	bool expect_empty;

--- a/gpt.c
+++ b/gpt.c
@@ -252,7 +252,7 @@ int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *phys_partiti
 		return -1;
 
 	for (gpt_part = gpt_partitions; gpt_part; gpt_part = gpt_part->next) {
-		if (*phys_partition >= 0 && gpt_part->partition != *phys_partition)
+		if (*phys_partition >= 0 && gpt_part->partition != (unsigned int)(*phys_partition))
 			continue;
 
 		if (strcmp(gpt_part->name, name))

--- a/sahara.c
+++ b/sahara.c
@@ -58,7 +58,7 @@
 #define SAHARA_DONE_RESP_LENGTH		0xc
 #define SAHARA_RESET_LENGTH		0x8
 
-#define DEBUG_BLOCK_SIZE (512 * 1024)
+#define DEBUG_BLOCK_SIZE (512u * 1024u)
 
 #define SAHARA_CMD_TIMEOUT_MS	1000
 
@@ -283,7 +283,7 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 
 	chunk = 0;
 	while (chunk < region.length) {
-		remain = MIN(region.length - chunk, DEBUG_BLOCK_SIZE);
+		remain = MIN((uint64_t)(region.length - chunk), DEBUG_BLOCK_SIZE);
 
 		read_req.cmd = SAHARA_MEM_READ64_CMD;
 		read_req.length = SAHARA_MEM_READ64_LENGTH;

--- a/util.c
+++ b/util.c
@@ -43,7 +43,7 @@ void print_hex_dump(const char *prefix, const void *buf, size_t len)
 	unsigned int j;
 
 	for (i = 0; i < len; i += 16) {
-		linelen = MIN(16, len - i);
+		linelen = MIN(16u, (size_t)(len - i));
 		li = 0;
 
 		for (j = 0; j < linelen; j++) {

--- a/vip.c
+++ b/vip.c
@@ -210,7 +210,7 @@ static int write_digests_to_table(char *src_table, char *dest_table, size_t star
 	}
 
 	/* Seek to offset of start_digest */
-	size_t offset = elem_size * start_digest;
+	off_t offset = elem_size * start_digest;
 
 	if (lseek(fd, offset, SEEK_SET) != offset) {
 		ux_err("Failed to seek in %s\n", src_table);


### PR DESCRIPTION
Address more -Wsign-compare issues, like:

```
../sahara.c: In function ‘sahara_debug64_one’:
../qdl.h:20:12: warning: comparison of integer expressions of different
   signedness: ‘long unsigned int’ and ‘int’ [-Wsign-compare]
   20 |         _x < _y ? _x : _y;      \
      |            ^
../sahara.c:286:26: note: in expansion of macro ‘MIN’
  286 |                 remain = MIN((uint64_t)(region.length - chunk), DEBUG_BLOCK_SIZE);
      |                          ^~~
../qdl.h:20:24: warning: operand of ‘?:’ changes signedness from ‘int’ to
  ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
   20 |         _x < _y ? _x : _y;      \

../gpt.c: In function ‘gpt_find_by_name’:
../gpt.c:255:65: warning: comparison of integer expressions of different
  signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
  255 |                 if (*phys_partition >= 0 && gpt_part->partition != *phys_partition)
  ```

Now tools are built without any warnings when -Wsign-compare is enabled.