### PR TITLE
firehose/usb: Explicitly handle ZLP on USB read transfers

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -244,6 +244,14 @@ static int usb_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int 
 	if (ret == LIBUSB_ERROR_TIMEOUT && actual == 0)
 		return -ETIMEDOUT;
 
+	/* If what we read equals the endpoint's Max Packet Size, consume the ZLP explicitly */
+	if ((len == actual) && !(actual % qdl_usb->in_maxpktsize)) {
+		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->in_ep,
+					   NULL, 0, NULL, timeout);
+		if (ret)
+			warnx("Unable to read ZLP: %s", libusb_strerror(ret));
+	}
+
 	return actual;
 }
 


### PR DESCRIPTION
The previous assumption that every other transfer in Firehose reads is null was incorrect. A Zero-Length Packet (ZLP) is only sent when the received chunk size exactly matches the USB IN endpoint's Max Packet Size.

In such cases, the device sends a ZLP to indicate end-of-transfer, but libusb does not implicitly consume it because it only reads the number of bytes requested. Therefore, we must explicitly read and discard the ZLP, similar to what we already do for USB writes. example: read 512/512 (data) + read 0/512 (ZLP)

Unconditionally expecting an empty packet was not an issue with USB 2.0, where the typical 512-byte sector size matches the bulk IN endpoint's Max Packet Size. However, with USB SuperSpeed (Max Packet Size = 1024), attempting to read an empty packet after a 512/1024-byte transfer is unnecessary and fails (timeout), resulting in errors during storage device sector size discovery:
```
waiting for programmer...
qdl: failed to read: Resource temporarily unavailable
```

Fix and move ZLP handling to bus-specific code (usb.c).

Reported-by: Danilo Leo <d.leo@arduino.cc>