### PR TITLE
[RFC] qdl: make timeout configurable

### DIFF
--- a/ks.c
+++ b/ks.c
@@ -45,6 +45,7 @@ static void print_usage(FILE *out)
 		" -h                   --help                      Print this usage info\n"
 		" -p                   --port                      Sahara device node to use\n"
 		" -s <id:file path>    --sahara <id:file path>     Sahara protocol file mapping\n"
+		" -w <timeout>         --timeout <timeout>         Transfer timeout in ms\n"
 		"\n"
 		"One -p instance is required.  One or more -s instances are required.\n"
 		"\n"
@@ -59,6 +60,7 @@ int main(int argc, char **argv)
 	bool found_mapping = false;
 	char *dev_node = NULL;
 	long file_id;
+	unsigned int timeout = TRANSFER_TIMEOUT;
 	char *colon;
 	int opt;
 	int ret;
@@ -69,10 +71,11 @@ int main(int argc, char **argv)
 		{"version", no_argument, 0, 'v'},
 		{"port", required_argument, 0, 'p'},
 		{"sahara", required_argument, 0, 's'},
+		{"timeout", required_argument, 0, 'w'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvp:s:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvp:s:w:h", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -110,6 +113,9 @@ int main(int argc, char **argv)
 
 			printf("Created mapping ID:%ld File:%s\n", file_id, filename);
 			break;
+		case 'w':
+			timeout = MAX((unsigned int)strtol(optarg, NULL, 10), TRANSFER_TIMEOUT);
+			break;
 		case 'h':
 			print_usage(stdout);
 			return 0;
@@ -133,6 +139,8 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Unable to open %s\n", dev_node);
 		return 1;
 	}
+
+	qdl.timeout_ms = timeout;
 
 	ret = sahara_run(&qdl, mappings, false, NULL, NULL);
 	if (ret < 0)

--- a/qdl.c
+++ b/qdl.c
@@ -433,6 +433,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " -t, --create-digests=T\t\tGenerate table of digests in the T folder\n");
 	fprintf(out, " -T, --slot=T\t\t\tSet slot number T for multiple storage devices\n");
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
+	fprintf(out, " -w, --timeout=T\t\tTransfer timeout in milliseconds\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\txml file containing <program> or <erase> directives\n");
 	fprintf(out, " <patch-xml>\txml file containing <patch> directives\n");
@@ -460,6 +461,7 @@ int main(int argc, char **argv)
 	bool allow_fusing = false;
 	bool allow_missing = false;
 	long out_chunk_size = 0;
+	unsigned int timeout = TRANSFER_TIMEOUT;
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
 	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_USB;
@@ -472,6 +474,7 @@ int main(int argc, char **argv)
 		{"out-chunk-size", required_argument, 0, 'u' },
 		{"serial", required_argument, 0, 'S'},
 		{"vip-table-path", required_argument, 0, 'D'},
+		{"timeout", required_argument, 0, 'w'},
 		{"storage", required_argument, 0, 's'},
 		{"allow-missing", no_argument, 0, 'f'},
 		{"allow-fusing", no_argument, 0, 'c'},
@@ -482,7 +485,7 @@ int main(int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:w:s:fcnt:T:h", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -512,6 +515,9 @@ int main(int argc, char **argv)
 			break;
 		case 'u':
 			out_chunk_size = strtol(optarg, NULL, 10);
+			break;
+		case 'w':
+			timeout = MAX((unsigned int)strtol(optarg, NULL, 10), 30000u);
 			break;
 		case 's':
 			storage_type = decode_storage(optarg);
@@ -547,6 +553,7 @@ int main(int argc, char **argv)
 	}
 
 	qdl->slot = slot;
+	qdl->timeout_ms = timeout;
 
 	if (vip_table_path) {
 		if (vip_generate_dir)

--- a/qdl.h
+++ b/qdl.h
@@ -20,6 +20,12 @@
 	_x < _y ? _x : _y;	\
 })
 
+#define MAX(x, y) ({         \
+	__typeof__(x) _x = (x); \
+	__typeof__(y) _y = (y); \
+	_x > _y ? _x : _y;      \
+})
+
 #define ROUND_UP(x, a) ({		\
 	__typeof__(x) _x = (x);		\
 	__typeof__(a) _a = (a);		\
@@ -35,6 +41,8 @@
 })
 
 #define MAPPING_SZ 64
+
+#define TRANSFER_TIMEOUT 30000u
 
 enum QDL_DEVICE_TYPE {
 	QDL_DEVICE_USB,
@@ -57,6 +65,7 @@ struct qdl_device {
 	size_t sector_size;
 	enum qdl_storage_type storage_type;
 	unsigned int slot;
+	unsigned int timeout_ms;
 
 	int (*open)(struct qdl_device *qdl, const char *serial);
 	int (*read)(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);

--- a/ramdump.c
+++ b/ramdump.c
@@ -32,6 +32,7 @@ int main(int argc, char **argv)
 	char *ramdump_path = ".";
 	char *filter = NULL;
 	char *serial = NULL;
+	unsigned int timeout = TRANSFER_TIMEOUT;
 	int ret = 0;
 	int opt;
 
@@ -40,11 +41,12 @@ int main(int argc, char **argv)
 		{"version", no_argument, 0, 'v'},
 		{"output", required_argument, 0, 'o'},
 		{"serial", required_argument, 0, 'S'},
+		{"timeout", required_argument, 0, 'w'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvo:S:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvo:S:w:h", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -58,6 +60,9 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 			serial = optarg;
+			break;
+		case 'w':
+			timeout = MAX((unsigned int)strtol(optarg, NULL, 10), TRANSFER_TIMEOUT);
 			break;
 		case 'h':
 			print_usage(stdout);
@@ -78,6 +83,8 @@ int main(int argc, char **argv)
 
 	if (qdl_debug)
 		print_version();
+
+	qdl->timeout_ms = timeout;
 
 	ret = qdl_open(qdl, serial);
 	if (ret) {

--- a/sahara.c
+++ b/sahara.c
@@ -296,7 +296,7 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 		offset = 0;
 		while (offset < remain) {
 			buf_offset = 0;
-			n = qdl_read(qdl, buf, DEBUG_BLOCK_SIZE, 30000);
+			n = qdl_read(qdl, buf, DEBUG_BLOCK_SIZE, qdl->timeout_ms);
 			if (n < 0) {
 				warn("failed to read ramdump chunk");
 				goto out;


### PR DESCRIPTION
Unify the timeout value (set default to 30000ms), propagate it through all architectural layers that use the same QDL structure, and make it configurable via a CLI parameter so it can be increased when needed.