### PR TITLE
github: Resolve liblzma-related failure in Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,7 @@ jobs:
             mingw-w64-x86_64-pkg-config
             mingw-w64-x86_64-libxml2
             mingw-w64-x86_64-libusb
+            mingw-w64-x86_64-xz
 
       - name: Build
         run: |


### PR DESCRIPTION
The Windows builds suddenly fails with:
  Cannot find path 'C:\a\_temp\msys64\mingw64\bin\liblzma-5.dll' because it does not exist.

The internet indicates that this is caused by the lack of mingw-w64-x86_64-xz, so let's introduce this.