### PR TITLE
firehose: Increase image write timeout to 60 seconds

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -465,7 +465,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	 * let's double it to be on the safe side...
 	 */
 	if (qdl->storage_type == QDL_STORAGE_SPINOR)
-		zlp_timeout = 30000;
+		zlp_timeout = 60000;
 
 	num_sectors = program->num_sectors;
 	sector_size = program->sector_size ? : qdl->sector_size;


### PR DESCRIPTION
The somewhat arbitrary timeout of 30 seconds was chosen by observing a worst case time of ~15 seconds when flashing Hamoa and Nord. But, as reported, flashing SAIL on Nord sometimes needs this timeout to be ~35 seconds.

While the relationship between the different factors and the needed timeout isn't fully understood, bump the value to 60 seconds to make it work for this case as well.