### PR TITLE
usb: Fix checkpatch warning about unnecessary parenthesis

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -245,7 +245,7 @@ static int usb_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int 
 		return -ETIMEDOUT;
 
 	/* If what we read equals the endpoint's Max Packet Size, consume the ZLP explicitly */
-	if ((len == actual) && !(actual % qdl_usb->in_maxpktsize)) {
+	if (len == actual && !(actual % qdl_usb->in_maxpktsize)) {
 		ret = libusb_bulk_transfer(qdl_usb->usb_handle, qdl_usb->in_ep,
 					   NULL, 0, NULL, timeout);
 		if (ret)


### PR DESCRIPTION
Checkpatch was warning about unnecessary parenthesis in the change to the ZLP handling, but Github apparently doesn't highlight warnings.

Fix this to avoid leaving the building with broken windows.

Fixes: b9ad4ceaf890 ("firehose/usb: Explicitly handle ZLP on USB read transfers")