### PR TITLE
qdl: Allow skipping the firehose step by omitting xml files

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -463,6 +463,7 @@ int main(int argc, char **argv)
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
 	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_USB;
+	bool run_firehose = false;
 
 	static struct option options[] = {
 		{"debug", no_argument, 0, 'd'},
@@ -534,8 +535,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	/* at least 2 non optional args required */
-	if ((optind + 2) > argc) {
+	/* the programmer arg is always required. */
+	if ((optind + 1) > argc) {
 		print_usage(stderr);
 		return 1;
 	}
@@ -574,7 +575,8 @@ int main(int argc, char **argv)
 	if (ret < 0)
 		exit(1);
 
-	do {
+	while (optind < argc) {
+		run_firehose = true;
 		type = detect_type(argv[optind]);
 		if (type < 0 || type == QDL_FILE_UNKNOWN)
 			errx(1, "failed to detect file type of %s\n", argv[optind]);
@@ -627,7 +629,8 @@ int main(int argc, char **argv)
 			errx(1, "%s type not yet supported", argv[optind]);
 			break;
 		}
-	} while (++optind < argc);
+		++optind;
+	}
 
 	ret = qdl_open(qdl, serial);
 	if (ret)
@@ -639,9 +642,9 @@ int main(int argc, char **argv)
 	if (ret < 0)
 		goto out_cleanup;
 
-	if (ufs_need_provisioning())
+	if (run_firehose && ufs_need_provisioning())
 		ret = firehose_provision(qdl);
-	else
+	else if (run_firehose)
 		ret = firehose_run(qdl);
 	if (ret < 0)
 		goto out_cleanup;


### PR DESCRIPTION
Sometimes it is useful to run only the sahara step without running
firehose. Allow that by detecting if no xml files are passed.

This is mainly useful to mix and match qdl with stock tools like
QSaharaServer and fh_loader, in case some combination of these
behaves better for a given device.

Signed-off-by: Jerry Zhang <Jerry@skydio.com>