### PR TITLE
sahara: Unbreak ramdump by making images optional again

### DIFF
--- a/sahara.c
+++ b/sahara.c
@@ -438,7 +438,8 @@ int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	bool done = false;
 	int n;
 
-	sahara_debug_list_images(images, single_image);
+	if (images)
+		sahara_debug_list_images(images, single_image);
 
 	/*
 	 * Don't need to do anything in simulation mode with Sahara,


### PR DESCRIPTION
Commit 'ff260604e774 ("sahara: Load programmer at parse time")' added a convenient debug function to dump the list of loaded images, but failed to recognize that when this is invoked from qdl-ramdump `images` will be NULL, and hence we have a segfault.

Make the debug call conditional on the presence of images.

Fixes: ff260604e774 ("sahara: Load programmer at parse time")