### PR TITLE
firehose: Increase timeout for read of program-ack

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -608,7 +608,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 
 	t = time(NULL) - t0;
 
-	ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
+	ret = firehose_read(qdl, 120000, firehose_generic_parser, NULL);
 	if (ret) {
 		ux_err("flashing of %s failed\n", program->label);
 	} else if (t) {


### PR DESCRIPTION
Commit 'a10cf7f5da7a ("firehose: Increase image write timeout to 60 seconds")' bumped the timeout for writes in the program operation, per observed behavior. This was confirmed to solve the problems seen when programming SPINOR in Nord devices

New reports (and measurements) shows the write taking a negligible amount of time and the read of the following "program ack" taking the whole reported ~35 second, resulting in a timeout.

The proprietary tools has a write timeout of 60 seconds in some operating systems and no timeout for others, and a read timeout of 120 seconds.

Update this timeout for the "program ack" to 120 seconds, to match the proprietary tools.

Fixes: a10cf7f5da7a ("firehose: Increase image write timeout to 60 seconds")