### PR TITLE
qdl: Propagate the success of decode_sahara_config()

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -400,7 +400,7 @@ static int decode_programmer(char *s, struct sahara_image *images)
 
 		ret = decode_sahara_config(&archive, images);
 		if (ret < 0 || ret == 1)
-			return -1;
+			return ret;
 
 		images[SAHARA_ID_EHOSTDL_IMG] = archive;
 	}


### PR DESCRIPTION
Commit '44e7be00aca0 ("sahara: Drop "single image" concept")' cleaned up the handling of programmer selection, but in the new flow failed to propagate the successful decoding of the sahara_config.

Fixes: 44e7be00aca0 ("sahara: Drop "single image" concept")