### PR TITLE
[RFC] Support workflows where the Firehose programmer is already running

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -1031,7 +1031,8 @@ int firehose_provision(struct qdl_device *qdl)
 	else
 		ux_info("UFS provisioning failed\n");
 
-	firehose_reset(qdl);
+	if (!qdl->skip_reset)
+		firehose_reset(qdl);
 
 	return ret;
 
@@ -1084,7 +1085,8 @@ int firehose_run(struct qdl_device *qdl)
 		firehose_set_bootable(qdl, bootable);
 	}
 
-	firehose_reset(qdl);
+	if (!qdl->skip_reset)
+		firehose_reset(qdl);
 
 	return 0;
 }

--- a/qdl.c
+++ b/qdl.c
@@ -445,6 +445,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " -T, --slot=T\t\t\tSet slot number T for multiple storage devices\n");
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
 	fprintf(out, " -R  --skip-reset\t\tDo not send reset command after flashing\n");
+	fprintf(out, " -P  --skip-sahara\t\tSkip Sahara phase, connect to already-running programmer\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\t\txml file containing <program> or <erase> directives\n");
 	fprintf(out, " <patch-xml>\t\txml file containing <patch> directives\n");
@@ -573,6 +574,7 @@ static int qdl_flash(int argc, char **argv)
 	bool allow_fusing = false;
 	bool allow_missing = false;
 	bool skip_reset = false;
+	bool skip_sahara = false;
 	long out_chunk_size = 0;
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
@@ -593,11 +595,12 @@ static int qdl_flash(int argc, char **argv)
 		{"create-digests", required_argument, 0, 't'},
 		{"slot", required_argument, 0, 'T'},
 		{"skip-reset", no_argument, 0, 'R'},
+		{"skip-sahara", no_argument, 0, 'P'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:Rh", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:RPh", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -643,6 +646,9 @@ static int qdl_flash(int argc, char **argv)
 		case 'R':
 			skip_reset = true;
 			break;
+		case 'P':
+			skip_sahara = true;
+			break;
 		case 'h':
 			print_usage(stdout);
 			return 0;
@@ -652,8 +658,8 @@ static int qdl_flash(int argc, char **argv)
 		}
 	}
 
-	/* at least 2 non optional args required */
-	if ((optind + 2) > argc) {
+	/* programmer + at least one XML required, unless Sahara is skipped */
+	if ((optind + (skip_sahara ? 1 : 2)) > argc) {
 		print_usage(stderr);
 		return 1;
 	}
@@ -689,9 +695,11 @@ static int qdl_flash(int argc, char **argv)
 	if (qdl_debug)
 		print_version();
 
-	ret = decode_programmer(argv[optind++], sahara_images);
-	if (ret < 0)
-		exit(1);
+	if (!skip_sahara) {
+		ret = decode_programmer(argv[optind++], sahara_images);
+		if (ret < 0)
+			exit(1);
+	}
 
 	do {
 		type = detect_type(argv[optind]);
@@ -754,9 +762,11 @@ static int qdl_flash(int argc, char **argv)
 
 	qdl->storage_type = storage_type;
 
-	ret = sahara_run(qdl, sahara_images, NULL, NULL);
-	if (ret < 0)
-		goto out_cleanup;
+	if (!skip_sahara) {
+		ret = sahara_run(qdl, sahara_images, NULL, NULL);
+		if (ret < 0)
+			goto out_cleanup;
+	}
 
 	if (ufs_need_provisioning())
 		ret = firehose_provision(qdl);

--- a/qdl.c
+++ b/qdl.c
@@ -444,6 +444,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " -t, --create-digests=T\t\tGenerate table of digests in the T folder\n");
 	fprintf(out, " -T, --slot=T\t\t\tSet slot number T for multiple storage devices\n");
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
+	fprintf(out, " -R  --skip-reset\t\tDo not send reset command after flashing\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\t\txml file containing <program> or <erase> directives\n");
 	fprintf(out, " <patch-xml>\t\txml file containing <patch> directives\n");
@@ -571,6 +572,7 @@ static int qdl_flash(int argc, char **argv)
 	bool qdl_finalize_provisioning = false;
 	bool allow_fusing = false;
 	bool allow_missing = false;
+	bool skip_reset = false;
 	long out_chunk_size = 0;
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
@@ -590,11 +592,12 @@ static int qdl_flash(int argc, char **argv)
 		{"dry-run", no_argument, 0, 'n'},
 		{"create-digests", required_argument, 0, 't'},
 		{"slot", required_argument, 0, 'T'},
+		{"skip-reset", no_argument, 0, 'R'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:Rh", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -637,6 +640,9 @@ static int qdl_flash(int argc, char **argv)
 		case 'T':
 			slot = (unsigned int)strtoul(optarg, NULL, 10);
 			break;
+		case 'R':
+			skip_reset = true;
+			break;
 		case 'h':
 			print_usage(stdout);
 			return 0;
@@ -659,6 +665,7 @@ static int qdl_flash(int argc, char **argv)
 	}
 
 	qdl->slot = slot;
+	qdl->skip_reset = skip_reset;
 
 	if (vip_table_path) {
 		if (vip_generate_dir)

--- a/qdl.h
+++ b/qdl.h
@@ -66,6 +66,7 @@ struct qdl_device {
 	size_t sector_size;
 	enum qdl_storage_type storage_type;
 	unsigned int slot;
+	bool skip_reset;
 
 	int (*open)(struct qdl_device *qdl, const char *serial);
 	int (*read)(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);


### PR DESCRIPTION
Support two new CLI options to support workflows where the Firehose programmer
is already running on the device:

- --skip-reset (-R): suppresses the post-flash power/reset command, leaving the programmer alive after flashing completes.

- --skip-sahara (-P): skips the Sahara phase entirely and connects directly to an already-running programmer. When used, the programmer ELF argument is omitted. Intended to be paired with --skip-reset from a previous qdl invocation.

Typical use:

```bash
# First flash - uploads programmer and flashes, but doesn't reset
qdl prog_firehose_ddr.elf rawprogram*.xml patch*.xml --debug --skip-reset

# Subsequent flashes -  programmer already running, skip Sahara entirely
qdl rawprogram*.xml patch*.xml --skip-sahara
```