### PR TITLE
For linux msm/flashmap support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev libzip-dev help2man pipx
+          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev libzip-dev help2man pipx zip
           pipx ensurepath
           pipx install meson==1.4.0
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Dependencies
         run: |
-          brew install libxml2 libzip meson ninja help2man
+          brew install libxml2 libzip meson ninja help2man zip
 
       - name: Configure
         run: meson setup build
@@ -147,6 +147,7 @@ jobs:
             mingw-w64-x86_64-libusb
             mingw-w64-x86_64-libzip
             mingw-w64-x86_64-xz
+            zip
 
       - name: Configure
         run: meson setup build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev help2man pipx
+          sudo apt-get install -y libxml2-dev libusb-1.0-0-dev libzip-dev help2man pipx
           pipx ensurepath
           pipx install meson==1.4.0
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Dependencies
         run: |
-          brew install libxml2 meson ninja help2man
+          brew install libxml2 libzip meson ninja help2man
 
       - name: Configure
         run: meson setup build
@@ -145,6 +145,7 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-libxml2
             mingw-w64-x86_64-libusb
+            mingw-w64-x86_64-libzip
             mingw-w64-x86_64-xz
 
       - name: Configure
@@ -176,6 +177,7 @@ jobs:
           Copy-Item (Join-Path $BIN_DIR "zlib1.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libxml2-16.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libusb-1.0.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libzip.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "liblzma-5.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libiconv-2.dll") $DistDir
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ IDs `9008`, `900e`, `901d`) to upload a flash loader and use it to flash images.
 ### Linux
 
 ```bash
-sudo apt install libxml2-dev libusb-1.0-0-dev meson ninja-build help2man
+sudo apt install libxml2-dev libusb-1.0-0-dev libzip-dev meson ninja-build help2man
 meson setup build
 meson compile -C build
 ```
@@ -21,7 +21,7 @@ meson compile -C build
 For Homebrew users:
 
 ```bash
-brew install libxml2 libusb meson ninja help2man
+brew install libxml2 libusb libzip meson ninja help2man
 meson setup build
 meson compile -C build
 ```
@@ -29,7 +29,7 @@ meson compile -C build
 For MacPorts users:
 
 ```bash
-sudo port install libxml2 libusb meson ninja help2man
+sudo port install libxml2 libusb libzip meson ninja help2man
 meson setup build
 meson compile -C build
 ```
@@ -49,6 +49,7 @@ pacman -S mingw-w64-x86_64-meson
 pacman -S mingw-w64-x86_64-ninja
 pacman -S mingw-w64-x86_64-libusb
 pacman -S mingw-w64-x86_64-libxml2
+pacman -S mingw-w64-x86_64-libzip
 ```
 
 Then use the `meson` tool to build QDL:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ the board to flash through the `--serial` option:
 qdl --serial=0AA94EFD prog_firehose_ddr.elf rawprogram*.xml patch*.xml
 ```
 
+### Flashing installer packages
+
+If you have an installer package instead of individual binaries and XML
+definitions, you can flash this using the *flash* subcommand:
+
+```bash
+qdl flash <installer.zip>
+```
+
+If the *installer package* is unpacked it can be installed as:
+
+```bash
+qdl flash flashmap.json
+```
+
+These can of course be combined with e.g. *--serial*.
+
+A subset of the installer package can be selected for installation by appending
+a **::storage1[,storage2...]** suffix to the file name.
+
 ### Flash simulation (dry run)
 
 Use the `--dry-run` option to run QDL without connecting to or flashing any

--- a/file.c
+++ b/file.c
@@ -5,34 +5,71 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <zip.h>
 
 #include "oscompat.h"
 #include "qdl.h"
 #include "file.h"
 
-int qdl_file_open(const char *filename, struct qdl_file *file)
+struct qdl_zip {
+	zip_t *zip;
+	unsigned int refcount;
+};
+
+int qdl_file_open(struct qdl_zip *qdl_zip, const char *filename, struct qdl_file *file)
 {
+	struct zip_stat st;
+	zip_int64_t idx;
+	zip_file_t *zf;
 	off_t len;
+	zip_t *zip;
 	int fd;
 
-	fd = open(filename, O_RDONLY | O_BINARY);
-	if (fd < 0) {
-		ux_err("failed to open \"%s\" for reading\n", filename);
-		return -1;
+	if (qdl_zip) {
+		zip = qdl_zip->zip;
+
+		idx = zip_name_locate(zip, filename, 0);
+		if (idx < 0) {
+			ux_err("unable to locate \"%s\" in zip archive\n", filename);
+			return -1;
+		}
+
+		if (zip_stat_index(zip, idx, 0, &st) < 0) {
+			ux_err("unable to stat \"%s\" in zip archive\n", filename);
+			return -1;
+		}
+
+		zf = zip_fopen_index(zip, idx, 0);
+		if (!zf) {
+			ux_err("unable to open \"%s\" in zip archive\n", filename);
+			return -1;
+		}
+
+		file->type = QDL_FILE_TYPE_ZIP;
+		file->fd = -1;
+		file->size = st.size;
+		file->zip_file = zf;
+	} else {
+		fd = open(filename, O_RDONLY | O_BINARY);
+		if (fd < 0) {
+			ux_err("failed to open \"%s\" for reading\n", filename);
+			return -1;
+		}
+
+		len = lseek(fd, 0, SEEK_END);
+		if (len < 0) {
+			ux_err("failed to find end of \"%s\"\n", filename);
+			close(fd);
+			return -1;
+		}
+
+		lseek(fd, 0, SEEK_SET);
+
+		file->type = QDL_FILE_TYPE_POSIX;
+		file->fd = fd;
+		file->size = len;
+		file->zip_file = NULL;
 	}
-
-	len = lseek(fd, 0, SEEK_END);
-	if (len < 0) {
-		ux_err("failed to find end of \"%s\"\n", filename);
-		close(fd);
-		return -1;
-	}
-
-	lseek(fd, 0, SEEK_SET);
-
-	file->type = QDL_FILE_TYPE_POSIX;
-	file->fd = fd;
-	file->size = len;
 
 	return 0;
 }
@@ -59,6 +96,14 @@ void *qdl_file_load(struct qdl_file *file, size_t *len)
 			goto err_free_buf;
 		}
 		break;
+	case QDL_FILE_TYPE_ZIP:
+		n = zip_fread(file->zip_file, buf, file->size);
+		if ((size_t)n != file->size) {
+			ux_err("failed to load zip file member\n");
+			goto err_free_buf;
+		}
+
+		break;
 	};
 
 	*len = file->size;
@@ -78,6 +123,10 @@ void qdl_file_close(struct qdl_file *file)
 		close(file->fd);
 		file->fd = -1;
 		break;
+	case QDL_FILE_TYPE_ZIP:
+		zip_fclose(file->zip_file);
+		file->zip_file = NULL;
+		break;
 	};
 
 	file->type = QDL_FILE_TYPE_UNKNOWN;
@@ -95,6 +144,8 @@ ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len)
 		break;
 	case QDL_FILE_TYPE_POSIX:
 		return read(file->fd, buf, len);
+	case QDL_FILE_TYPE_ZIP:
+		return zip_fread(file->zip_file, buf, len);
 	};
 
 	return -1;
@@ -107,7 +158,56 @@ off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence)
 		return -1;
 	case QDL_FILE_TYPE_POSIX:
 		return lseek(file->fd, offset, whence);
+	case QDL_FILE_TYPE_ZIP:
+		if (offset == 0 && whence == SEEK_SET)
+			return 0;
+
+		ux_err("seek not implemented for zip files\n");
+		return -1;
 	};
 
 	return -1;
+}
+
+int qdl_zip_open(const char *filename, struct qdl_zip **__qdl_zip)
+{
+	struct qdl_zip *qdl_zip;
+	zip_t *zip;
+
+	zip = zip_open(filename, ZIP_RDONLY, NULL);
+	if (!zip) {
+		*__qdl_zip = NULL;
+		return 0;
+	}
+
+	qdl_zip = calloc(1, sizeof(*qdl_zip));
+	if (!qdl_zip) {
+		zip_close(zip);
+		return -1;
+	}
+
+	qdl_zip->zip = zip;
+	qdl_zip->refcount = 1;
+
+	*__qdl_zip = qdl_zip;
+
+	return 0;
+}
+
+struct qdl_zip *qdl_zip_get(struct qdl_zip *qdl_zip)
+{
+	if (qdl_zip)
+		qdl_zip->refcount++;
+
+	return qdl_zip;
+}
+
+void qdl_zip_put(struct qdl_zip *qdl_zip)
+{
+	if (qdl_zip) {
+		if (--qdl_zip->refcount == 0) {
+			zip_close(qdl_zip->zip);
+			free(qdl_zip);
+		}
+	}
 }

--- a/file.c
+++ b/file.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "oscompat.h"
+#include "qdl.h"
+#include "file.h"
+
+int qdl_file_open(const char *filename, struct qdl_file *file)
+{
+	off_t len;
+	int fd;
+
+	fd = open(filename, O_RDONLY | O_BINARY);
+	if (fd < 0) {
+		ux_err("failed to open \"%s\" for reading\n", filename);
+		return -1;
+	}
+
+	len = lseek(fd, 0, SEEK_END);
+	if (len < 0) {
+		ux_err("failed to find end of \"%s\"\n", filename);
+		close(fd);
+		return -1;
+	}
+
+	lseek(fd, 0, SEEK_SET);
+
+	file->type = QDL_FILE_TYPE_POSIX;
+	file->fd = fd;
+	file->size = len;
+
+	return 0;
+}
+
+void *qdl_file_load(struct qdl_file *file, size_t *len)
+{
+	ssize_t n;
+	void *buf;
+
+	buf = malloc(file->size);
+	if (!buf) {
+		ux_err("unable to allocate memory to load file\n");
+		return NULL;
+	}
+
+	switch (file->type) {
+	case QDL_FILE_TYPE_UNKNOWN:
+		ux_err("internal error: attempting to load unknown file type\n");
+		return NULL;
+	case QDL_FILE_TYPE_POSIX:
+		n = read(file->fd, buf, file->size);
+		if ((size_t)n != file->size) {
+			ux_err("failed to load content of file\n");
+			goto err_free_buf;
+		}
+		break;
+	};
+
+	*len = file->size;
+	return buf;
+
+err_free_buf:
+	free(buf);
+	return NULL;
+}
+
+void qdl_file_close(struct qdl_file *file)
+{
+	switch (file->type) {
+	case QDL_FILE_TYPE_UNKNOWN:
+		break;
+	case QDL_FILE_TYPE_POSIX:
+		close(file->fd);
+		file->fd = -1;
+		break;
+	};
+
+	file->type = QDL_FILE_TYPE_UNKNOWN;
+}
+
+size_t qdl_file_getsize(struct qdl_file *file)
+{
+	return file->size;
+}
+
+ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len)
+{
+	switch (file->type) {
+	case QDL_FILE_TYPE_UNKNOWN:
+		break;
+	case QDL_FILE_TYPE_POSIX:
+		return read(file->fd, buf, len);
+	};
+
+	return -1;
+}
+
+off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence)
+{
+	switch (file->type) {
+	case QDL_FILE_TYPE_UNKNOWN:
+		return -1;
+	case QDL_FILE_TYPE_POSIX:
+		return lseek(file->fd, offset, whence);
+	};
+
+	return -1;
+}

--- a/file.h
+++ b/file.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+#ifndef __QDL_FILE_H__
+#define __QDL_FILE_H__
+
+#include <sys/types.h>
+
+enum qdl_file_type {
+	QDL_FILE_TYPE_UNKNOWN,
+	QDL_FILE_TYPE_POSIX,
+};
+
+struct qdl_file {
+	enum qdl_file_type type;
+
+	size_t size;
+
+	int fd;
+};
+
+int qdl_file_open(const char *filename, struct qdl_file *file);
+void *qdl_file_load(struct qdl_file *file, size_t *len);
+void qdl_file_close(struct qdl_file *file);
+size_t qdl_file_getsize(struct qdl_file *file);
+ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len);
+off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence);
+
+#endif

--- a/file.h
+++ b/file.h
@@ -7,9 +7,12 @@
 
 #include <sys/types.h>
 
+struct zip_file;
+
 enum qdl_file_type {
 	QDL_FILE_TYPE_UNKNOWN,
 	QDL_FILE_TYPE_POSIX,
+	QDL_FILE_TYPE_ZIP,
 };
 
 struct qdl_file {
@@ -18,13 +21,19 @@ struct qdl_file {
 	size_t size;
 
 	int fd;
+	struct zip_file *zip_file;
 };
 
-int qdl_file_open(const char *filename, struct qdl_file *file);
+struct qdl_zip;
+
+int qdl_file_open(struct qdl_zip *qzip, const char *filename, struct qdl_file *file);
 void *qdl_file_load(struct qdl_file *file, size_t *len);
 void qdl_file_close(struct qdl_file *file);
 size_t qdl_file_getsize(struct qdl_file *file);
 ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len);
 off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence);
 
+int qdl_zip_open(const char *filename, struct qdl_zip **__qdl_zip);
+struct qdl_zip *qdl_zip_get(struct qdl_zip *qzip);
+void qdl_zip_put(struct qdl_zip *qzip);
 #endif

--- a/firehose.c
+++ b/firehose.c
@@ -1145,6 +1145,9 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			if (op->filename && !strcmp(op->filename, "DISK"))
 				ux_progress("Applying patches", patch_idx++, patch_count);
 			break;
+		case FIREHOSE_OP_SET_BOOTABLE:
+			firehose_set_bootable(qdl, op->partition);
+			break;
 		default:
 			ux_err("internal error: unknown firehose operation %d\n", op->type);
 			return -1;
@@ -1159,8 +1162,6 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 
 int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 {
-	bool multiple;
-	int bootable;
 	int ret;
 
 	ux_info("waiting for Firehose programmer...\n");
@@ -1176,17 +1177,6 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 	ret = firehose_execute_ops(qdl, ops);
 	if (ret)
 		return ret;
-
-	bootable = program_find_bootable_partition(ops, &multiple);
-	if (bootable < 0) {
-		ux_debug("no boot partition found\n");
-	} else {
-		if (multiple) {
-			ux_info("Multiple candidates for primary bootloader found, using partition %d\n",
-				bootable);
-		}
-		firehose_set_bootable(qdl, bootable);
-	}
 
 	firehose_reset(qdl);
 

--- a/firehose.c
+++ b/firehose.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2018, The Linux Foundation. All rights reserved.
  * All rights reserved.
  */
+#include "list.h"
 #define _FILE_OFFSET_BITS 64
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -1112,16 +1113,11 @@ void firehose_free_ops(struct list_head *ops)
 static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 {
 	unsigned int patch_count = 0;
+	struct firehose_op *status_patch = NULL;
+	struct firehose_op *tmp;
 	struct firehose_op *op;
 	unsigned int patch_idx = 0;
 	int ret;
-
-	list_for_each_entry(op, ops, node) {
-		if (op->type != FIREHOSE_OP_PATCH)
-			continue;
-		if (op->filename && !strcmp(op->filename, "DISK"))
-			patch_count++;
-	}
 
 	list_for_each_entry(op, ops, node) {
 		switch (op->type) {
@@ -1133,6 +1129,21 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			ret = gpt_resolve_deferrals(qdl, ops);
 			if (ret)
 				return ret;
+
+			/* Update the number of patches for this storage device */
+			patch_count = 0;
+			patch_idx = 0;
+			tmp = op;
+			list_for_each_entry_continue(tmp, ops, node) {
+				if (tmp->type == FIREHOSE_OP_CONFIGURE)
+					break;
+				if (tmp->type != FIREHOSE_OP_PATCH)
+					continue;
+				if (tmp->filename && !strcmp(tmp->filename, "DISK")) {
+					patch_count++;
+					status_patch = tmp;
+				}
+			}
 			break;
 		case FIREHOSE_OP_PROGRAM:
 			ret = firehose_program(qdl, op);
@@ -1155,7 +1166,10 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 				return ret;
 
 			if (op->filename && !strcmp(op->filename, "DISK"))
-				ux_progress("Applying patches", patch_idx++, patch_count);
+				ux_progress("Applying patches", ++patch_idx, patch_count);
+
+			if (op == status_patch)
+				ux_info("%d patches applied\n", patch_idx);
 			break;
 		case FIREHOSE_OP_SET_BOOTABLE:
 			firehose_set_bootable(qdl, op->partition);
@@ -1165,9 +1179,6 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			return -1;
 		}
 	}
-
-	if (patch_count)
-		ux_info("%d patches applied\n", patch_idx);
 
 	return 0;
 }

--- a/firehose.c
+++ b/firehose.c
@@ -27,6 +27,7 @@
 #include "oscompat.h"
 #include "vip.h"
 #include "sparse.h"
+#include "gpt.h"
 
 enum {
 	FIREHOSE_ACK = 0,
@@ -1168,11 +1169,7 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 	if (ret)
 		return ret;
 
-	ret = read_resolve_gpt_deferrals(qdl, ops);
-	if (ret)
-		return ret;
-
-	ret = program_resolve_gpt_deferrals(qdl, ops);
+	ret = gpt_resolve_deferrals(qdl, ops);
 	if (ret)
 		return ret;
 

--- a/firehose.c
+++ b/firehose.c
@@ -476,7 +476,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	 * ZLP has been measured to take up to 15 seconds on SPINOR devices,
 	 * let's double it to be on the safe side...
 	 */
-	if (qdl->storage_type == QDL_STORAGE_SPINOR)
+	if (qdl->current_storage_type == QDL_STORAGE_SPINOR)
 		zlp_timeout = 60000;
 
 	if (!program->filename)
@@ -1012,6 +1012,9 @@ static int firehose_detect_and_configure(struct qdl_device *qdl,
 	struct timeval now;
 	int ret;
 
+	/* Track the currently configured storage type */
+	qdl->current_storage_type = storage;
+
 	/*
 	 * The speculative retry loop below sends configure (and therefore the
 	 * VIP table) before the programmer has had a chance to start up and
@@ -1122,6 +1125,15 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 
 	list_for_each_entry(op, ops, node) {
 		switch (op->type) {
+		case FIREHOSE_OP_CONFIGURE:
+			ret = firehose_detect_and_configure(qdl, false, op->storage_type, 5);
+			if (ret)
+				return ret;
+
+			ret = gpt_resolve_deferrals(qdl, ops);
+			if (ret)
+				return ret;
+			break;
 		case FIREHOSE_OP_PROGRAM:
 			ret = firehose_program(qdl, op);
 			if (ret < 0)
@@ -1165,14 +1177,6 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 	int ret;
 
 	ux_info("waiting for Firehose programmer...\n");
-
-	ret = firehose_detect_and_configure(qdl, false, qdl->storage_type, 5);
-	if (ret)
-		return ret;
-
-	ret = gpt_resolve_deferrals(qdl, ops);
-	if (ret)
-		return ret;
 
 	ret = firehose_execute_ops(qdl, ops);
 	if (ret)

--- a/firehose.c
+++ b/firehose.c
@@ -22,6 +22,7 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include "qdl.h"
+#include "firehose.h"
 #include "ufs.h"
 #include "oscompat.h"
 #include "vip.h"
@@ -407,7 +408,7 @@ static int firehose_try_configure(struct qdl_device *qdl, bool skip_storage_init
 	return 0;
 }
 
-static int firehose_erase(struct qdl_device *qdl, struct program *program)
+static int firehose_erase(struct qdl_device *qdl, struct firehose_op *program)
 {
 	unsigned int sector_size;
 	xmlNode *root;
@@ -450,7 +451,7 @@ out:
 	return ret == FIREHOSE_ACK ? 0 : -1;
 }
 
-static int firehose_program(struct qdl_device *qdl, struct program *program, int fd)
+static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 {
 	unsigned int num_sectors;
 	unsigned int sector_size;
@@ -465,6 +466,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	time_t t;
 	size_t left;
 	int ret;
+	int fd;
 	int n;
 	size_t i;
 	uint32_t fill_value;
@@ -476,13 +478,22 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	if (qdl->storage_type == QDL_STORAGE_SPINOR)
 		zlp_timeout = 60000;
 
+	if (!program->filename)
+		return 0;
+
+	fd = open(program->filename, O_RDONLY | O_BINARY);
+	if (fd < 0) {
+		ux_err("unable to open %s\n", program->filename);
+		return -1;
+	}
+
 	num_sectors = program->num_sectors;
 	sector_size = program->sector_size ? : qdl->sector_size;
 
 	ret = fstat(fd, &sb);
 	if (ret < 0) {
 		ux_err("failed to stat \"%s\": %m\n", program->filename);
-		return -1;
+		goto err_close_fd;
 	}
 
 	if (!program->sparse) {
@@ -500,7 +511,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	buf = malloc(qdl->max_payload_size);
 	if (!buf) {
 		ux_err("failed to allocate sector buffer\n");
-		return -1;
+		goto err_close_fd;
 	}
 
 	doc = xmlNewDoc((xmlChar *)"1.0");
@@ -526,13 +537,13 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	ret = firehose_write(qdl, doc);
 	if (ret < 0) {
 		ux_err("failed to send program request\n");
-		goto out;
+		goto err_free_doc;
 	}
 
 	ret = firehose_read(qdl, 10000, firehose_generic_parser, NULL);
 	if (ret) {
 		ux_err("failed to setup programming\n");
-		goto out;
+		goto err_free_doc;
 	}
 
 	t0 = time(NULL);
@@ -551,7 +562,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 			break;
 		default:
 			ux_err("[SPARSE] invalid chunk type\n");
-			goto out;
+			goto err_free_doc;
 		}
 	}
 
@@ -572,7 +583,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 			n = read(fd, buf, chunk_size * sector_size);
 			if (n < 0) {
 				ux_err("failed to read %s\n", program->filename);
-				goto out;
+				goto err_free_doc;
 			}
 
 			if ((size_t)n < qdl->max_payload_size)
@@ -592,13 +603,13 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 			if (ret)
 				ux_err("flashing of chunk failed\n");
 
-			goto out;
+			goto err_free_doc;
 		}
 
 		if ((size_t)n != chunk_size * sector_size) {
 			ux_err("USB write truncated\n");
 			ret = -1;
-			goto out;
+			goto err_free_doc;
 		}
 
 		left -= chunk_size;
@@ -610,7 +621,7 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 	t = time(NULL) - t0;
 
 	ret = firehose_read(qdl, 120000, firehose_generic_parser, NULL);
-	if (ret) {
+	if (ret != FIREHOSE_ACK) {
 		ux_err("flashing of %s failed\n", program->label);
 	} else if (t) {
 		ux_info("flashed \"%s\" successfully at %lukB/s\n",
@@ -621,11 +632,19 @@ static int firehose_program(struct qdl_device *qdl, struct program *program, int
 			program->label);
 	}
 
-out:
 	xmlFreeDoc(doc);
 	free(buf);
+	close(fd);
 
-	return ret == FIREHOSE_ACK ? 0 : -1;
+	return 0;
+
+err_free_doc:
+	xmlFreeDoc(doc);
+	free(buf);
+err_close_fd:
+	close(fd);
+
+	return -1;
 }
 
 static int firehose_issue_read(struct qdl_device *qdl, struct read_op *read_op,
@@ -1038,7 +1057,60 @@ int firehose_provision(struct qdl_device *qdl)
 
 }
 
-int firehose_run(struct qdl_device *qdl)
+struct firehose_op *firehose_alloc_op(int type)
+{
+	struct firehose_op *op;
+
+	op = calloc(1, sizeof(*op));
+	if (!op)
+		return NULL;
+
+	op->type = type;
+	return op;
+}
+
+void firehose_free_ops(struct list_head *ops)
+{
+	struct firehose_op *next;
+	struct firehose_op *op;
+
+	list_for_each_entry_safe(op, next, ops, node) {
+		list_del(&op->node);
+		free((void *)op->filename);
+		free((void *)op->label);
+		free((void *)op->start_sector);
+		free((void *)op->gpt_partition);
+		free(op);
+	}
+}
+
+static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
+{
+	struct firehose_op *op;
+	int ret;
+
+	list_for_each_entry(op, ops, node) {
+		switch (op->type) {
+		case FIREHOSE_OP_PROGRAM:
+			ret = firehose_program(qdl, op);
+			if (ret < 0)
+				return ret;
+			break;
+		case FIREHOSE_OP_ERASE:
+			ret = firehose_erase(qdl, op);
+			if (ret < 0)
+				return ret;
+			break;
+		default:
+			ux_err("internal error: unknown firehose operation %d\n", op->type);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 {
 	bool multiple;
 	int bootable;
@@ -1054,15 +1126,11 @@ int firehose_run(struct qdl_device *qdl)
 	if (ret)
 		return ret;
 
-	ret = program_resolve_gpt_deferrals(qdl);
+	ret = program_resolve_gpt_deferrals(qdl, ops);
 	if (ret)
 		return ret;
 
-	ret = erase_execute(qdl, firehose_erase);
-	if (ret)
-		return ret;
-
-	ret = program_execute(qdl, firehose_program);
+	ret = firehose_execute_ops(qdl, ops);
 	if (ret)
 		return ret;
 
@@ -1074,7 +1142,7 @@ int firehose_run(struct qdl_device *qdl)
 	if (ret)
 		return ret;
 
-	bootable = program_find_bootable_partition(&multiple);
+	bootable = program_find_bootable_partition(ops, &multiple);
 	if (bootable < 0) {
 		ux_debug("no boot partition found\n");
 	} else {

--- a/firehose.c
+++ b/firehose.c
@@ -23,6 +23,7 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include "qdl.h"
+#include "file.h"
 #include "firehose.h"
 #include "ufs.h"
 #include "oscompat.h"
@@ -458,7 +459,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	unsigned int num_sectors;
 	unsigned int sector_size;
 	unsigned int zlp_timeout = 10000;
-	struct stat sb;
+	struct qdl_file file;
 	size_t chunk_size;
 	xmlNode *root;
 	xmlNode *node;
@@ -468,7 +469,6 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	time_t t;
 	size_t left;
 	int ret;
-	int fd;
 	int n;
 	size_t i;
 	uint32_t fill_value;
@@ -483,8 +483,8 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	if (!program->filename)
 		return 0;
 
-	fd = open(program->filename, O_RDONLY | O_BINARY);
-	if (fd < 0) {
+	ret = qdl_file_open(program->filename, &file);
+	if (ret < 0) {
 		ux_err("unable to open %s\n", program->filename);
 		return -1;
 	}
@@ -492,14 +492,8 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	num_sectors = program->num_sectors;
 	sector_size = program->sector_size ? : qdl->sector_size;
 
-	ret = fstat(fd, &sb);
-	if (ret < 0) {
-		ux_err("failed to stat \"%s\": %m\n", program->filename);
-		goto err_close_fd;
-	}
-
 	if (!program->sparse) {
-		num_sectors = (sb.st_size + sector_size - 1) / sector_size;
+		num_sectors = (qdl_file_getsize(&file) + sector_size - 1) / sector_size;
 
 		if (program->num_sectors && num_sectors > program->num_sectors) {
 			ux_err("%s to big for %s truncated to %d\n",
@@ -551,11 +545,11 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	t0 = time(NULL);
 
 	if (!program->sparse) {
-		lseek(fd, (off_t)program->file_offset * sector_size, SEEK_SET);
+		qdl_file_seek(&file, (off_t)program->file_offset * sector_size, SEEK_SET);
 	} else {
 		switch (program->sparse_chunk_type) {
 		case CHUNK_TYPE_RAW:
-			lseek(fd, program->sparse_offset, SEEK_SET);
+			qdl_file_seek(&file, program->sparse_offset, SEEK_SET);
 			break;
 		case CHUNK_TYPE_FILL:
 			fill_value = program->sparse_fill_value;
@@ -582,7 +576,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 		chunk_size = MIN(qdl->max_payload_size / sector_size, left);
 
 		if (!program->sparse || program->sparse_chunk_type != CHUNK_TYPE_FILL) {
-			n = read(fd, buf, chunk_size * sector_size);
+			n = qdl_file_read(&file, buf, chunk_size * sector_size);
 			if (n < 0) {
 				ux_err("failed to read %s\n", program->filename);
 				goto err_free_doc;
@@ -636,7 +630,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 
 	xmlFreeDoc(doc);
 	free(buf);
-	close(fd);
+	qdl_file_close(&file);
 
 	return 0;
 
@@ -644,7 +638,7 @@ err_free_doc:
 	xmlFreeDoc(doc);
 	free(buf);
 err_close_fd:
-	close(fd);
+	qdl_file_close(&file);
 
 	return -1;
 }

--- a/firehose.c
+++ b/firehose.c
@@ -483,7 +483,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	if (!program->filename)
 		return 0;
 
-	ret = qdl_file_open(program->filename, &file);
+	ret = qdl_file_open(program->zip, program->filename, &file);
 	if (ret < 0) {
 		ux_err("unable to open %s\n", program->filename);
 		return -1;
@@ -1094,6 +1094,7 @@ void firehose_free_ops(struct list_head *ops)
 
 	list_for_each_entry_safe(op, next, ops, node) {
 		list_del(&op->node);
+		qdl_zip_put(op->zip);
 		free((void *)op->filename);
 		free((void *)op->label);
 		free((void *)op->start_sector);

--- a/firehose.c
+++ b/firehose.c
@@ -346,7 +346,7 @@ static int firehose_try_configure(struct qdl_device *qdl, bool skip_storage_init
 {
 	size_t max_sector_size;
 	size_t sector_sizes[] = { 512, 4096 };
-	struct read_op op;
+	struct firehose_op op;
 	size_t size = 0;
 	void *buf;
 	int ret;
@@ -647,7 +647,7 @@ err_close_fd:
 	return -1;
 }
 
-static int firehose_issue_read(struct qdl_device *qdl, struct read_op *read_op,
+static int firehose_issue_read(struct qdl_device *qdl, struct firehose_op *read_op,
 			       int fd, void *out_buf, size_t out_len, bool quiet)
 {
 	unsigned int sector_size;
@@ -765,14 +765,27 @@ out:
 	return ret;
 }
 
-int firehose_read_buf(struct qdl_device *qdl, struct read_op *read_op, void *out_buf, size_t out_size)
+int firehose_read_buf(struct qdl_device *qdl, struct firehose_op *read_op, void *out_buf, size_t out_size)
 {
 	return firehose_issue_read(qdl, read_op, -1, out_buf, out_size, true);
 }
 
-static int firehose_read_op(struct qdl_device *qdl, struct read_op *read_op, int fd)
+static int firehose_read_op(struct qdl_device *qdl, struct firehose_op *op)
 {
-	return firehose_issue_read(qdl, read_op, fd, NULL, 0, false);
+	int ret;
+	int fd;
+
+	fd = open(op->filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
+	if (fd < 0) {
+		ux_info("unable to open %s...\n", op->filename);
+		return -1;
+	}
+
+	ret = firehose_issue_read(qdl, op, fd, NULL, 0, false);
+
+	close(fd);
+
+	return ret;
 }
 
 static int firehose_apply_patch(struct qdl_device *qdl, struct patch *patch)
@@ -1101,10 +1114,18 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			if (ret < 0)
 				return ret;
 			break;
+		case FIREHOSE_OP_READ:
+			ret = firehose_read_op(qdl, op);
+			if (ret < 0)
+				return ret;
+			break;
 		default:
 			ux_err("internal error: unknown firehose operation %d\n", op->type);
 			return -1;
 		}
+
+		if (ret)
+			return ret;
 	}
 
 	return 0;
@@ -1122,7 +1143,7 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 	if (ret)
 		return ret;
 
-	ret = read_resolve_gpt_deferrals(qdl);
+	ret = read_resolve_gpt_deferrals(qdl, ops);
 	if (ret)
 		return ret;
 
@@ -1135,10 +1156,6 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 		return ret;
 
 	ret = patch_execute(qdl, firehose_apply_patch);
-	if (ret)
-		return ret;
-
-	ret = read_op_execute(qdl, firehose_read_op);
 	if (ret)
 		return ret;
 

--- a/firehose.c
+++ b/firehose.c
@@ -788,12 +788,18 @@ static int firehose_read_op(struct qdl_device *qdl, struct firehose_op *op)
 	return ret;
 }
 
-static int firehose_apply_patch(struct qdl_device *qdl, struct patch *patch)
+static int firehose_apply_patch(struct qdl_device *qdl, struct firehose_op *patch)
 {
 	xmlNode *root;
 	xmlNode *node;
 	xmlDoc *doc;
 	int ret;
+
+	if (!patch->filename)
+		return 0;
+
+	if (strcmp(patch->filename, "DISK"))
+		return 0;
 
 	ux_debug("applying patch \"%s\"\n", patch->what);
 
@@ -1093,14 +1099,25 @@ void firehose_free_ops(struct list_head *ops)
 		free((void *)op->label);
 		free((void *)op->start_sector);
 		free((void *)op->gpt_partition);
+		free((void *)op->value);
+		free((void *)op->what);
 		free(op);
 	}
 }
 
 static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 {
+	unsigned int patch_count = 0;
 	struct firehose_op *op;
+	unsigned int patch_idx = 0;
 	int ret;
+
+	list_for_each_entry(op, ops, node) {
+		if (op->type != FIREHOSE_OP_PATCH)
+			continue;
+		if (op->filename && !strcmp(op->filename, "DISK"))
+			patch_count++;
+	}
 
 	list_for_each_entry(op, ops, node) {
 		switch (op->type) {
@@ -1119,14 +1136,22 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			if (ret < 0)
 				return ret;
 			break;
+		case FIREHOSE_OP_PATCH:
+			ret = firehose_apply_patch(qdl, op);
+			if (ret)
+				return ret;
+
+			if (op->filename && !strcmp(op->filename, "DISK"))
+				ux_progress("Applying patches", patch_idx++, patch_count);
+			break;
 		default:
 			ux_err("internal error: unknown firehose operation %d\n", op->type);
 			return -1;
 		}
-
-		if (ret)
-			return ret;
 	}
+
+	if (patch_count)
+		ux_info("%d patches applied\n", patch_idx);
 
 	return 0;
 }
@@ -1152,10 +1177,6 @@ int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 		return ret;
 
 	ret = firehose_execute_ops(qdl, ops);
-	if (ret)
-		return ret;
-
-	ret = patch_execute(qdl, firehose_apply_patch);
 	if (ret)
 		return ret;
 

--- a/firehose.h
+++ b/firehose.h
@@ -7,9 +7,11 @@
 #include <sys/stat.h>
 
 #include "list.h"
+#include "qdl.h"
 
 enum firehose_op_type {
 	FIREHOSE_OP_NONE,
+	FIREHOSE_OP_CONFIGURE,
 	FIREHOSE_OP_PROGRAM,
 	FIREHOSE_OP_ERASE,
 	FIREHOSE_OP_READ,
@@ -50,6 +52,9 @@ struct firehose_op {
 	unsigned int size_in_bytes;
 	const char *value;
 	const char *what;
+
+	/* configure */
+	enum qdl_storage_type storage_type;
 };
 
 struct firehose_op *firehose_alloc_op(int type);

--- a/firehose.h
+++ b/firehose.h
@@ -28,6 +28,7 @@ struct firehose_op {
 
 	/* program, read, patch */
 	unsigned int sector_size;
+	struct qdl_zip *zip;
 	const char *filename;
 	const char *start_sector;
 

--- a/firehose.h
+++ b/firehose.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef __FIREHOSE_H__
+#define __FIREHOSE_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/stat.h>
+
+#include "list.h"
+
+enum firehose_op_type {
+	FIREHOSE_OP_NONE,
+	FIREHOSE_OP_PROGRAM,
+	FIREHOSE_OP_ERASE,
+};
+
+struct firehose_op {
+	enum firehose_op_type type;
+	struct list_head node;
+
+	unsigned int pages_per_block;
+	unsigned int sector_size;
+	unsigned int file_offset;
+	const char *filename;
+	const char *label;
+	unsigned int num_sectors;
+	int partition;
+	bool sparse;
+	const char *start_sector;
+	unsigned int last_sector;
+	bool is_nand;
+
+	unsigned int sparse_chunk_type;
+	uint32_t sparse_fill_value;
+	off_t sparse_offset;
+
+	const char *gpt_partition;
+};
+
+struct firehose_op *firehose_alloc_op(int type);
+void firehose_free_ops(struct list_head *ops);
+
+#endif

--- a/firehose.h
+++ b/firehose.h
@@ -14,16 +14,19 @@ enum firehose_op_type {
 	FIREHOSE_OP_ERASE,
 	FIREHOSE_OP_READ,
 	FIREHOSE_OP_PATCH,
+	FIREHOSE_OP_SET_BOOTABLE,
 };
 
 struct firehose_op {
 	enum firehose_op_type type;
 	struct list_head node;
 
+	/* program, read, patch, set_bootable */
+	int partition;
+
 	/* program, read, patch */
 	unsigned int sector_size;
 	const char *filename;
-	int partition;
 	const char *start_sector;
 
 	/* program, read */

--- a/firehose.h
+++ b/firehose.h
@@ -13,18 +13,21 @@ enum firehose_op_type {
 	FIREHOSE_OP_PROGRAM,
 	FIREHOSE_OP_ERASE,
 	FIREHOSE_OP_READ,
+	FIREHOSE_OP_PATCH,
 };
 
 struct firehose_op {
 	enum firehose_op_type type;
 	struct list_head node;
 
-	/* program, read */
+	/* program, read, patch */
 	unsigned int sector_size;
 	const char *filename;
 	int partition;
-	unsigned int num_sectors;
 	const char *start_sector;
+
+	/* program, read */
+	unsigned int num_sectors;
 	const char *gpt_partition;
 
 	/* program, erase */
@@ -38,6 +41,12 @@ struct firehose_op {
 	unsigned int sparse_chunk_type;
 	uint32_t sparse_fill_value;
 	off_t sparse_offset;
+
+	/* patch */
+	unsigned int byte_offset;
+	unsigned int size_in_bytes;
+	const char *value;
+	const char *what;
 };
 
 struct firehose_op *firehose_alloc_op(int type);

--- a/firehose.h
+++ b/firehose.h
@@ -12,29 +12,32 @@ enum firehose_op_type {
 	FIREHOSE_OP_NONE,
 	FIREHOSE_OP_PROGRAM,
 	FIREHOSE_OP_ERASE,
+	FIREHOSE_OP_READ,
 };
 
 struct firehose_op {
 	enum firehose_op_type type;
 	struct list_head node;
 
-	unsigned int pages_per_block;
+	/* program, read */
 	unsigned int sector_size;
-	unsigned int file_offset;
 	const char *filename;
-	const char *label;
-	unsigned int num_sectors;
 	int partition;
-	bool sparse;
+	unsigned int num_sectors;
 	const char *start_sector;
+	const char *gpt_partition;
+
+	/* program, erase */
+	unsigned int pages_per_block;
+	unsigned int file_offset;
+	const char *label;
+	bool sparse;
 	unsigned int last_sector;
 	bool is_nand;
 
 	unsigned int sparse_chunk_type;
 	uint32_t sparse_fill_value;
 	off_t sparse_offset;
-
-	const char *gpt_partition;
 };
 
 struct firehose_op *firehose_alloc_op(int type);

--- a/flashmap.c
+++ b/flashmap.c
@@ -19,7 +19,8 @@ enum {
 	QDL_FILE_PROGRAM,
 };
 
-static int flashmap_get_programmers(struct json_value *layout, struct sahara_image *images, const char *incdir)
+static int flashmap_get_programmers(struct qdl_zip *zip, struct json_value *layout,
+				    struct sahara_image *images, const char *incdir)
 {
 	struct json_value *programmers;
 	const char *filename;
@@ -49,10 +50,11 @@ static int flashmap_get_programmers(struct json_value *layout, struct sahara_ima
 
 	ux_debug("flashmap: selected programmer: %s\n", path);
 
-	return load_sahara_image(path, &images[SAHARA_ID_EHOSTDL_IMG]);
+	return load_sahara_image(zip, path, &images[SAHARA_ID_EHOSTDL_IMG]);
 }
 
-static int flashmap_load_xml(struct list_head *ops, const char *filename, bool is_nand, const char *incdir)
+static int flashmap_load_xml(struct list_head *ops, struct qdl_zip *zip, const char *filename,
+			     bool is_nand, const char *incdir)
 {
 	struct qdl_file file;
 	xmlNode *node;
@@ -63,7 +65,7 @@ static int flashmap_load_xml(struct list_head *ops, const char *filename, bool i
 	int type = QDL_FILE_UNKNOWN;
 	int ret;
 
-	ret = qdl_file_open(filename, &file);
+	ret = qdl_file_open(zip, filename, &file);
 	if (ret < 0) {
 		ux_err("unable to parse XML: %s\n", filename);
 		return -1;
@@ -111,7 +113,7 @@ static int flashmap_load_xml(struct list_head *ops, const char *filename, bool i
 
 	switch (type) {
 	case QDL_FILE_PROGRAM:
-		ret = program_load_xml(ops, doc, filename, is_nand, false, incdir);
+		ret = program_load_xml(ops, doc, zip, filename, is_nand, false, incdir);
 		break;
 	case QDL_FILE_PATCH:
 		ret = patch_load_xml(ops, doc, filename);
@@ -132,7 +134,8 @@ out_close_file:
 	return ret;
 }
 
-static int flashmap_enumerate_programmables(struct json_value *list, struct list_head *ops, const char *incdir)
+static int flashmap_enumerate_programmables(struct json_value *list, struct list_head *ops,
+					    struct qdl_zip *zip, const char *incdir)
 {
 	struct json_value *programmable;
 	struct json_value *files;
@@ -197,7 +200,7 @@ static int flashmap_enumerate_programmables(struct json_value *list, struct list
 				snprintf(path, PATH_MAX, "%s", file);
 			}
 
-			ret = flashmap_load_xml(ops, path, is_nand, incdir);
+			ret = flashmap_load_xml(ops, zip, path, is_nand, incdir);
 			if (ret)
 				return ret;
 		}
@@ -214,6 +217,7 @@ int flashmap_load(struct list_head *ops, const char *filename, struct sahara_ima
 	struct qdl_file flashmap;
 	struct json_value *json;
 	struct json_value *obj;
+	struct qdl_zip *zip;
 	const char *version;
 	const char *name;
 	size_t json_size;
@@ -221,21 +225,27 @@ int flashmap_load(struct list_head *ops, const char *filename, struct sahara_ima
 	int count;
 	int ret = -1;
 
-	ret = qdl_file_open(filename, &flashmap);
+	ret = qdl_zip_open(filename, &zip);
+	if (ret < 0) {
+		ux_err("unable to create zip reference\n");
+		return -1;
+	}
+
+	ret = qdl_file_open(zip, zip ? "flashmap.json" : filename, &flashmap);
 	if (ret < 0) {
 		ux_err("failed to open flashmap\n");
-		return -1;
+		goto out_put_zip;
 	}
 
 	json_blob = qdl_file_load(&flashmap, &json_size);
 	qdl_file_close(&flashmap);
 	if (!json_blob)
-		return -1;
+		goto out_put_zip;
 
 	json = json_parse_buf(json_blob, json_size);
 	if (!json) {
 		ux_err("failed to parse flashmap json\n");
-		goto out;
+		goto out_free_blob;
 	}
 
 	version = json_get_string(json, "version");
@@ -272,7 +282,7 @@ int flashmap_load(struct list_head *ops, const char *filename, struct sahara_ima
 
 	layout = json_get_element_object(obj, 0);
 
-	ret = flashmap_get_programmers(layout, images, incdir);
+	ret = flashmap_get_programmers(zip, layout, images, zip ? NULL : incdir);
 	if (ret)
 		goto out_free_json;
 
@@ -284,7 +294,7 @@ int flashmap_load(struct list_head *ops, const char *filename, struct sahara_ima
 		goto out_free_json;
 	}
 
-	ret = flashmap_enumerate_programmables(programmable, ops, incdir);
+	ret = flashmap_enumerate_programmables(programmable, ops, zip, zip ? NULL : incdir);
 	if (ret < 0) {
 		firehose_free_ops(ops);
 		sahara_images_free(images, MAPPING_SZ);
@@ -292,7 +302,10 @@ int flashmap_load(struct list_head *ops, const char *filename, struct sahara_ima
 
 out_free_json:
 	json_free(json);
-out:
+out_free_blob:
+	free(json_blob);
+out_put_zip:
+	qdl_zip_put(zip);
 
 	return ret;
 }

--- a/flashmap.c
+++ b/flashmap.c
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "file.h"
+#include "json.h"
+#include "list.h"
+#include "firehose.h"
+#include "qdl.h"
+
+enum {
+	QDL_FILE_UNKNOWN,
+	QDL_FILE_PATCH,
+	QDL_FILE_PROGRAM,
+};
+
+static int flashmap_get_programmers(struct json_value *layout, struct sahara_image *images, const char *incdir)
+{
+	struct json_value *programmers;
+	const char *filename;
+	char path[PATH_MAX];
+	int count;
+
+	programmers = json_get_child(layout, "programmer");
+	count = json_count_children(programmers);
+	if (count != 1) {
+		ux_err("flashmap: single programmer expected, found %d\n", count);
+		return -1;
+	}
+
+	filename = json_get_element_string(programmers, 0);
+	if (!filename) {
+		ux_err("flashmap: parse error when decoding programmer\n");
+		return -1;
+	}
+
+	if (incdir) {
+		snprintf(path, PATH_MAX, "%s/%s", incdir, filename);
+		if (access(path, F_OK))
+			snprintf(path, PATH_MAX, "%s", filename);
+	} else {
+		snprintf(path, PATH_MAX, "%s", filename);
+	}
+
+	ux_debug("flashmap: selected programmer: %s\n", path);
+
+	return load_sahara_image(path, &images[SAHARA_ID_EHOSTDL_IMG]);
+}
+
+static int flashmap_load_xml(struct list_head *ops, const char *filename, bool is_nand, const char *incdir)
+{
+	struct qdl_file file;
+	xmlNode *node;
+	xmlNode *root;
+	xmlDoc *doc;
+	size_t len;
+	void *xml;
+	int type = QDL_FILE_UNKNOWN;
+	int ret;
+
+	ret = qdl_file_open(filename, &file);
+	if (ret < 0) {
+		ux_err("unable to parse XML: %s\n", filename);
+		return -1;
+	}
+
+	xml = qdl_file_load(&file, &len);
+	if (!xml) {
+		ux_err("failed to load \"%s\"\n", filename);
+		ret = -1;
+		goto out_close_file;
+	}
+
+	if (len > INT_MAX) {
+		ux_err("\"%s\" too large for XML parser\n", filename);
+		ret = -1;
+		goto out_free_xml;
+	}
+
+	doc = xmlReadMemory(xml, (int)len, filename, NULL, 0);
+	if (!doc) {
+		ux_err("failed to parse %s\n", filename);
+		ret = -1;
+		goto out_free_xml;
+	}
+
+	root = xmlDocGetRootElement(doc);
+	if (!root) {
+		ux_err("unable to find XML root in \"%s\"\n", filename);
+		ret = -1;
+		goto out_free_doc;
+	}
+
+	if (!xmlStrcmp(root->name, (xmlChar *)"patches")) {
+		type = QDL_FILE_PATCH;
+	} else if (!xmlStrcmp(root->name, (xmlChar *)"data")) {
+		for (node = root->children; node ; node = node->next) {
+			if (node->type != XML_ELEMENT_NODE)
+				continue;
+			if (!xmlStrcmp(node->name, (xmlChar *)"program")) {
+				type = QDL_FILE_PROGRAM;
+				break;
+			}
+		}
+	}
+
+	switch (type) {
+	case QDL_FILE_PROGRAM:
+		ret = program_load_xml(ops, doc, filename, is_nand, false, incdir);
+		break;
+	case QDL_FILE_PATCH:
+		ret = patch_load_xml(ops, doc, filename);
+		break;
+	default:
+		ux_err("unknown file type: %s\n", filename);
+		ret = -1;
+		break;
+	}
+
+out_free_doc:
+	xmlFreeDoc(doc);
+out_free_xml:
+	free(xml);
+out_close_file:
+	qdl_file_close(&file);
+
+	return ret;
+}
+
+static int flashmap_enumerate_programmables(struct json_value *list, struct list_head *ops, const char *incdir)
+{
+	struct json_value *programmable;
+	struct json_value *files;
+	struct firehose_op *op;
+	char path[PATH_MAX];
+	const char *memory;
+	const char *file;
+	int file_count;
+	int file_idx;
+	bool is_nand;
+	double slot;
+	int count;
+	int ret;
+	int i;
+
+	count = json_count_children(list);
+	if (count < 0) {
+		ux_err("flashmap: programmable list is not an array\n");
+		return -1;
+	}
+	if (count == 0) {
+		ux_err("flashmap: programmable list is empty\n");
+		return -1;
+	}
+
+	for (i = 0; i < count; i++) {
+		programmable = json_get_element_object(list, i);
+
+		memory = json_get_string(programmable, "memory");
+		ret = json_get_number(programmable, "slot", &slot);
+		files = json_get_child(programmable, "files");
+
+		if (!memory || ret < 0 || !files) {
+			ux_err("failed to parse flashmap\n");
+			return -1;
+		}
+
+		is_nand = !strcmp(memory, "nand");
+
+		op = firehose_alloc_op(FIREHOSE_OP_CONFIGURE);
+		op->storage_type = decode_storage(memory);
+		list_append(ops, &op->node);
+
+		file_count = json_count_children(files);
+		if (file_count < 0) {
+			ux_err("flashmap: files list is not an array\n");
+			return -1;
+		}
+
+		for (file_idx = 0; file_idx < file_count; file_idx++) {
+			file = json_get_element_string(files, file_idx);
+			if (!file) {
+				ux_err("flashmap: parse error when decoding files\n");
+				return -1;
+			}
+
+			if (incdir) {
+				snprintf(path, PATH_MAX, "%s/%s", incdir, file);
+				if (access(path, F_OK))
+					snprintf(path, PATH_MAX, "%s", file);
+			} else {
+				snprintf(path, PATH_MAX, "%s", file);
+			}
+
+			ret = flashmap_load_xml(ops, path, is_nand, incdir);
+			if (ret)
+				return ret;
+		}
+	}
+
+	return 0;
+}
+
+int flashmap_load(struct list_head *ops, const char *filename, struct sahara_image *images, const char *incdir)
+{
+	struct json_value *programmable;
+	struct json_value *product;
+	struct json_value *layout;
+	struct qdl_file flashmap;
+	struct json_value *json;
+	struct json_value *obj;
+	const char *version;
+	const char *name;
+	size_t json_size;
+	void *json_blob;
+	int count;
+	int ret = -1;
+
+	ret = qdl_file_open(filename, &flashmap);
+	if (ret < 0) {
+		ux_err("failed to open flashmap\n");
+		return -1;
+	}
+
+	json_blob = qdl_file_load(&flashmap, &json_size);
+	qdl_file_close(&flashmap);
+	if (!json_blob)
+		return -1;
+
+	json = json_parse_buf(json_blob, json_size);
+	if (!json) {
+		ux_err("failed to parse flashmap json\n");
+		goto out;
+	}
+
+	version = json_get_string(json, "version");
+	if (!version || strcmp(version, "1.1.0")) {
+		ux_err("unsupported flashmap version\n");
+		ret = -1;
+		goto out_free_json;
+	}
+
+	ux_debug("found flashmap of version: %s\n", version);
+
+	obj = json_get_child(json, "products");
+
+	count = json_count_children(obj);
+	if (count != 1) {
+		ux_err("flashmap: only single product map supported, found %d\n", count);
+		ret = -1;
+		goto out_free_json;
+	}
+
+	product = json_get_element_object(obj, 0);
+
+	name = json_get_string(product, "name");
+	ux_debug("product: %s\n", name);
+
+	obj = json_get_child(product, "layouts");
+
+	count = json_count_children(obj);
+	if (count != 1) {
+		ux_err("flashmap: only one layout supported, found %d\n", count);
+		ret = -1;
+		goto out_free_json;
+	}
+
+	layout = json_get_element_object(obj, 0);
+
+	ret = flashmap_get_programmers(layout, images, incdir);
+	if (ret)
+		goto out_free_json;
+
+	programmable = json_get_child(layout, "programmable");
+	if (!programmable) {
+		ux_err("flashmap: parse error when decoding programmables\n");
+		sahara_images_free(images, MAPPING_SZ);
+		ret = -1;
+		goto out_free_json;
+	}
+
+	ret = flashmap_enumerate_programmables(programmable, ops, incdir);
+	if (ret < 0) {
+		firehose_free_ops(ops);
+		sahara_images_free(images, MAPPING_SZ);
+	}
+
+out_free_json:
+	json_free(json);
+out:
+
+	return ret;
+}

--- a/flashmap.h
+++ b/flashmap.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+#ifndef __FLASHMAP_H__
+#define __FLASHMAP_H__
+
+#include <stdbool.h>
+#include "list.h"
+
+struct sahara_image;
+
+int flashmap_load(struct list_head *ops, const char *filename, struct sahara_image *images, const char *incdir);
+
+#endif

--- a/gpt.c
+++ b/gpt.c
@@ -282,3 +282,31 @@ int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *phys_partiti
 
 	return 0;
 }
+
+int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops)
+{
+	unsigned int start_sector;
+	struct firehose_op *op;
+	char buf[20];
+	int ret;
+
+	list_for_each_entry(op, ops, node) {
+		if (op->type != FIREHOSE_OP_PROGRAM &&
+		    op->type != FIREHOSE_OP_ERASE &&
+		    op->type != FIREHOSE_OP_READ)
+			continue;
+
+		if (!op->gpt_partition)
+			continue;
+
+		ret = gpt_find_by_name(qdl, op->gpt_partition, &op->partition,
+				       &start_sector, &op->num_sectors);
+		if (ret < 0)
+			return -1;
+
+		sprintf(buf, "%u", start_sector);
+		op->start_sector = strdup(buf);
+	}
+
+	return 0;
+}

--- a/gpt.c
+++ b/gpt.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
+#include "firehose.h"
 #include <stdlib.h>
 #include <string.h>
 #define _FILE_OFFSET_BITS 64
@@ -138,7 +139,7 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 	struct gpt_entry *entry;
 	struct gpt_header gpt;
 	uint8_t buf[4096];
-	struct read_op op;
+	struct firehose_op op;
 	unsigned int offset;
 	uint64_t lba;
 	char lba_buf[21];
@@ -149,6 +150,7 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 
 	memset(&op, 0, sizeof(op));
 
+	op.type = FIREHOSE_OP_READ;
 	op.sector_size = qdl->sector_size;
 	op.start_sector = "1";
 	op.num_sectors = 1;

--- a/gpt.h
+++ b/gpt.h
@@ -2,9 +2,13 @@
 #ifndef __GPT_H__
 #define __GPT_H__
 
+#include "list.h"
+
 struct qdl_device;
+struct list_head;
 
 int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *partition,
 		     unsigned int *start_sector, unsigned int *num_sectors);
+int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/json.c
+++ b/json.c
@@ -1,0 +1,843 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * Copyright (c) 2018-2019, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdarg.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "json.h"
+
+static const char *input_buf;
+static int input_pos;
+static int input_len;
+static bool input_can_unput;
+static int nesting_depth;
+char json_error[JSON_ERROR_SIZE];
+enum { JSON_INPUT_EOF = -1 };
+
+static int json_parse_array(struct json_value *array);
+static int json_parse_object(struct json_value *object);
+static int json_parse_property(struct json_value *value);
+static int input(void);
+static void unput(void);
+
+static void json_set_error(const char *fmt, ...)
+{
+	va_list ap;
+
+	if (json_error[0])
+		return;
+
+	va_start(ap, fmt);
+	vsnprintf(json_error, sizeof(json_error), fmt, ap);
+	va_end(ap);
+}
+
+static int json_hex_value(int ch)
+{
+	if (ch >= '0' && ch <= '9')
+		return ch - '0';
+	if (ch >= 'a' && ch <= 'f')
+		return ch - 'a' + 10;
+	if (ch >= 'A' && ch <= 'F')
+		return ch - 'A' + 10;
+	return -1;
+}
+
+static int json_buf_append(char **buf, size_t *len, size_t *cap, unsigned char byte)
+{
+	char *new_buf;
+
+	if (*len + 1 >= *cap) {
+		size_t new_cap = *cap ? (*cap * 2) : 32;
+
+		new_buf = realloc(*buf, new_cap);
+		if (!new_buf)
+			return -1;
+
+		*buf = new_buf;
+		*cap = new_cap;
+	}
+
+	(*buf)[*len] = (char)byte;
+	(*len)++;
+
+	return 0;
+}
+
+static int json_buf_append_utf8(char **buf, size_t *len, size_t *cap, unsigned int cp)
+{
+	if (cp <= 0x7f)
+		return json_buf_append(buf, len, cap, (unsigned char)cp);
+	if (cp <= 0x7ff) {
+		if (json_buf_append(buf, len, cap, (unsigned char)(0xc0 | (cp >> 6))))
+			return -1;
+		return json_buf_append(buf, len, cap, (unsigned char)(0x80 | (cp & 0x3f)));
+	}
+	if (cp <= 0xffff) {
+		if (json_buf_append(buf, len, cap, (unsigned char)(0xe0 | (cp >> 12))))
+			return -1;
+		if (json_buf_append(buf, len, cap, (unsigned char)(0x80 | ((cp >> 6) & 0x3f))))
+			return -1;
+		return json_buf_append(buf, len, cap, (unsigned char)(0x80 | (cp & 0x3f)));
+	}
+	if (cp <= 0x10ffff) {
+		if (json_buf_append(buf, len, cap, (unsigned char)(0xf0 | (cp >> 18))))
+			return -1;
+		if (json_buf_append(buf, len, cap, (unsigned char)(0x80 | ((cp >> 12) & 0x3f))))
+			return -1;
+		if (json_buf_append(buf, len, cap, (unsigned char)(0x80 | ((cp >> 6) & 0x3f))))
+			return -1;
+		return json_buf_append(buf, len, cap, (unsigned char)(0x80 | (cp & 0x3f)));
+	}
+
+	return -1;
+}
+
+static int json_parse_hex4(unsigned int *out)
+{
+	unsigned int code = 0;
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		int ch = input();
+		int digit;
+
+		if (ch == JSON_INPUT_EOF)
+			return -1;
+
+		digit = json_hex_value(ch);
+		if (digit < 0)
+			return -1;
+
+		code = (code << 4) | (unsigned int)digit;
+	}
+
+	*out = code;
+	return 0;
+}
+
+static int json_parse_escape(char **buf, size_t *len, size_t *cap, int escape_pos)
+{
+	unsigned int code;
+	unsigned int low;
+	int ch;
+
+	ch = input();
+	if (ch == JSON_INPUT_EOF) {
+		json_set_error("unterminated escape at offset %d", escape_pos);
+		return -1;
+	}
+
+	switch (ch) {
+	case '"':
+	case '\\':
+	case '/':
+		if (json_buf_append(buf, len, cap, (unsigned char)ch)) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 'b':
+		if (json_buf_append(buf, len, cap, '\b')) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 'f':
+		if (json_buf_append(buf, len, cap, '\f')) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 'n':
+		if (json_buf_append(buf, len, cap, '\n')) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 'r':
+		if (json_buf_append(buf, len, cap, '\r')) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 't':
+		if (json_buf_append(buf, len, cap, '\t')) {
+			json_set_error("out of memory while parsing escape at offset %d", escape_pos);
+			return -1;
+		}
+		return 0;
+	case 'u':
+		if (json_parse_hex4(&code)) {
+			json_set_error("invalid unicode escape at offset %d", escape_pos);
+			return -1;
+		}
+
+		if (code >= 0xd800 && code <= 0xdbff) {
+			ch = input();
+			if (ch != '\\') {
+				json_set_error("expected low surrogate escape at offset %d", input_pos - 1);
+				return -1;
+			}
+			ch = input();
+			if (ch != 'u') {
+				json_set_error("expected low surrogate escape at offset %d", input_pos - 1);
+				return -1;
+			}
+			if (json_parse_hex4(&low)) {
+				json_set_error("invalid low surrogate escape at offset %d", input_pos);
+				return -1;
+			}
+			if (low < 0xdc00 || low > 0xdfff) {
+				json_set_error("invalid low surrogate value at offset %d", input_pos);
+				return -1;
+			}
+
+			code = 0x10000 + (((code - 0xd800) << 10) | (low - 0xdc00));
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			json_set_error("unexpected low surrogate at offset %d", escape_pos);
+			return -1;
+		}
+
+		if (json_buf_append_utf8(buf, len, cap, code)) {
+			json_set_error("out of memory while decoding unicode escape");
+			return -1;
+		}
+		return 0;
+	default:
+		json_set_error("invalid escape '\\%c' at offset %d", ch, escape_pos);
+		return -1;
+	}
+}
+
+static int json_enter_nesting(int offset)
+{
+	nesting_depth++;
+	if (nesting_depth > JSON_MAX_DEPTH) {
+		nesting_depth--;
+		json_set_error("maximum nesting depth %d exceeded at offset %d",
+			       JSON_MAX_DEPTH, offset);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void json_leave_nesting(void)
+{
+	if (nesting_depth > 0)
+		nesting_depth--;
+}
+
+static int input(void)
+{
+	if (input_pos >= input_len) {
+		input_can_unput = false;
+		return JSON_INPUT_EOF;
+	}
+
+	input_can_unput = true;
+	return (unsigned char)input_buf[input_pos++];
+}
+
+static void unput(void)
+{
+	if (input_can_unput && input_pos > 0) {
+		input_pos--;
+		input_can_unput = false;
+	}
+}
+
+static void json_skip_whitespace(void)
+{
+	int ch;
+
+	while ((ch = input()) != JSON_INPUT_EOF && isspace((unsigned char)ch))
+		;
+	unput();
+}
+
+static int json_parse_string(struct json_value *value)
+{
+	size_t len = 0;
+	size_t cap = 0;
+	char *str;
+	int string_start;
+	int ch;
+
+	ch = input();
+	if (ch != '"') {
+		unput();
+		return 0;
+	}
+
+	string_start = input_pos - 1;
+	str = NULL;
+
+	while ((ch = input()) != JSON_INPUT_EOF) {
+		if (ch == '"')
+			break;
+		if (ch == '\\') {
+			if (json_parse_escape(&str, &len, &cap, input_pos - 1)) {
+				free(str);
+				return -1;
+			}
+			continue;
+		}
+		if (ch < 0x20) {
+			json_set_error("unescaped control character in string at offset %d", input_pos - 1);
+			free(str);
+			return -1;
+		}
+		if (json_buf_append(&str, &len, &cap, (unsigned char)ch)) {
+			json_set_error("out of memory while parsing string");
+			free(str);
+			return -1;
+		}
+	}
+
+	if (ch == JSON_INPUT_EOF) {
+		json_set_error("unterminated string starting at offset %d", string_start);
+		free(str);
+		return -1;
+	}
+
+	if (json_buf_append(&str, &len, &cap, '\0')) {
+		json_set_error("out of memory while finalizing string");
+		free(str);
+		return -1;
+	}
+
+	value->type = JSON_TYPE_STRING;
+	value->u.string = str;
+
+	return 1;
+}
+
+static int json_parse_number(struct json_value *value)
+{
+	char *token;
+	char *endptr;
+	double parsed;
+	size_t len;
+	int start;
+	int end;
+	int ch;
+
+	ch = input();
+	if (ch != '-' && (ch == JSON_INPUT_EOF || !isdigit(ch))) {
+		unput();
+		return 0;
+	}
+
+	start = input_pos - 1;
+
+	if (ch == '-') {
+		ch = input();
+		if (ch == JSON_INPUT_EOF || !isdigit(ch)) {
+			json_set_error("invalid number: '-' not followed by digit at offset %d", start);
+			return -1;
+		}
+	}
+
+	if (ch == '0') {
+		ch = input();
+		if (ch != JSON_INPUT_EOF && isdigit(ch)) {
+			json_set_error("invalid number: leading zero at offset %d", start);
+			return -1;
+		}
+	} else if (isdigit(ch)) {
+		do {
+			ch = input();
+		} while (ch != JSON_INPUT_EOF && isdigit(ch));
+	} else {
+		json_set_error("invalid number at offset %d", start);
+		return -1;
+	}
+
+	if (ch == '.') {
+		ch = input();
+		if (ch == JSON_INPUT_EOF || !isdigit(ch)) {
+			json_set_error("invalid number: fractional part missing digits at offset %d",
+				       start);
+			return -1;
+		}
+		do {
+			ch = input();
+		} while (ch != JSON_INPUT_EOF && isdigit(ch));
+	}
+
+	if (ch == 'e' || ch == 'E') {
+		ch = input();
+		if (ch == '+' || ch == '-')
+			ch = input();
+		if (ch == JSON_INPUT_EOF || !isdigit(ch)) {
+			json_set_error("invalid number: exponent missing digits at offset %d",
+				       start);
+			return -1;
+		}
+		do {
+			ch = input();
+		} while (ch != JSON_INPUT_EOF && isdigit(ch));
+	}
+
+	if (ch != JSON_INPUT_EOF) {
+		end = input_pos - 1;
+		unput();
+	} else {
+		end = input_pos;
+	}
+
+	len = (size_t)(end - start);
+	token = malloc(len + 1);
+	if (!token) {
+		json_set_error("out of memory while parsing number");
+		return -1;
+	}
+
+	memcpy(token, input_buf + start, len);
+	token[len] = '\0';
+
+	errno = 0;
+	parsed = strtod(token, &endptr);
+	if (endptr != token + len || errno == ERANGE || !isfinite(parsed)) {
+		json_set_error("invalid or out-of-range number at offset %d", start);
+		free(token);
+		return -1;
+	}
+	free(token);
+
+	value->type = JSON_TYPE_NUMBER;
+	value->u.number = parsed;
+
+	return 1;
+}
+
+static int json_parse_keyword(struct json_value *value)
+{
+	const char *match;
+	int i;
+	int ch;
+
+	ch = input();
+	switch (ch) {
+	case 't':
+		match = "true";
+		value->type = JSON_TYPE_TRUE;
+		break;
+	case 'f':
+		match = "false";
+		value->type = JSON_TYPE_FALSE;
+		break;
+	case 'n':
+		match = "null";
+		value->type = JSON_TYPE_NULL;
+		break;
+	default:
+		unput();
+		return 0;
+	}
+
+	for (i = 1; match[i]; i++) {
+		ch = input();
+		if (ch == JSON_INPUT_EOF || ch != match[i]) {
+			json_set_error("invalid keyword at offset %d", input_pos - 1);
+			return -1;
+		}
+	}
+
+	return 1;
+}
+
+static int json_parse_value(struct json_value *value)
+{
+	int ret;
+
+	json_skip_whitespace();
+
+	ret = json_parse_object(value);
+	if (ret)
+		goto out;
+
+	ret = json_parse_array(value);
+	if (ret)
+		goto out;
+
+	ret = json_parse_string(value);
+	if (ret)
+		goto out;
+
+	ret = json_parse_number(value);
+	if (ret)
+		goto out;
+
+	ret = json_parse_keyword(value);
+	if (ret)
+		goto out;
+
+	json_set_error("unable to match value at offset %d", input_pos);
+	return -1;
+
+out:
+	json_skip_whitespace();
+	return ret;
+}
+
+static int json_parse_array(struct json_value *array)
+{
+	struct json_value *value;
+	struct json_value *last = NULL;
+	int ret;
+	int ch;
+
+	ch = input();
+	if (ch != '[') {
+		unput();
+		return 0;
+	}
+	if (json_enter_nesting(input_pos - 1))
+		return -1;
+
+	array->type = JSON_TYPE_ARRAY;
+	json_skip_whitespace();
+	ch = input();
+	if (ch == ']') {
+		json_leave_nesting();
+		return 1;
+	}
+	unput();
+
+	do {
+		value = calloc(1, sizeof(*value));
+		if (!value) {
+			json_set_error("out of memory while parsing array at offset %d", input_pos);
+			json_leave_nesting();
+			return -1;
+		}
+
+		ret = json_parse_value(value);
+		if (ret <= 0) {
+			json_set_error("invalid array element at offset %d", input_pos);
+			free(value);
+			json_leave_nesting();
+			return -1;
+		}
+
+		if (!array->u.value)
+			array->u.value = value;
+		if (last)
+			last->next = value;
+		last = value;
+
+		ch = input();
+		if (ch == ']') {
+			json_leave_nesting();
+			return 1;
+		}
+
+	} while (ch == ',');
+
+	json_set_error("expected ',' or ']' at offset %d", input_pos - 1);
+	json_leave_nesting();
+
+	return -1;
+}
+
+static int json_parse_object(struct json_value *object)
+{
+	struct json_value *value;
+	struct json_value *last = NULL;
+	int ret;
+	int ch;
+
+	ch = input();
+	if (ch != '{') {
+		unput();
+		return 0;
+	}
+	if (json_enter_nesting(input_pos - 1))
+		return -1;
+
+	object->type = JSON_TYPE_OBJECT;
+	json_skip_whitespace();
+	ch = input();
+	if (ch == '}') {
+		json_leave_nesting();
+		return 1;
+	}
+	unput();
+
+	do {
+		value = calloc(1, sizeof(*value));
+		if (!value) {
+			json_set_error("out of memory while parsing object at offset %d", input_pos);
+			json_leave_nesting();
+			return -1;
+		}
+
+		ret = json_parse_property(value);
+		if (ret <= 0) {
+			json_set_error("invalid object property at offset %d", input_pos);
+			free(value);
+			json_leave_nesting();
+			return -1;
+		}
+
+		if (!object->u.value)
+			object->u.value = value;
+		if (last)
+			last->next = value;
+		last = value;
+
+		ch = input();
+		if (ch == '}') {
+			json_leave_nesting();
+			return 1;
+		}
+	} while (ch == ',');
+
+	json_set_error("expected ',' or '}' at offset %d", input_pos - 1);
+	json_leave_nesting();
+
+	return -1;
+}
+
+static int json_parse_property(struct json_value *value)
+{
+	struct json_value key;
+	int ret;
+	int ch;
+
+	json_skip_whitespace();
+
+	ret = json_parse_string(&key);
+	if (ret <= 0) {
+		json_set_error("expected string key at offset %d", input_pos);
+		return -1;
+	}
+
+	value->key = key.u.string;
+
+	json_skip_whitespace();
+
+	ch = input();
+	if (ch != ':') {
+		json_set_error("expected ':' after key at offset %d", input_pos - 1);
+		return -1;
+	}
+
+	ret = json_parse_value(value);
+	if (ret <= 0) {
+		json_set_error("invalid property value at offset %d", input_pos);
+		return -1;
+	}
+
+	return 1;
+}
+
+static struct json_value *json_parse_internal(const char *json, size_t len)
+{
+	struct json_value *root;
+	int ret;
+
+	input_buf = json;
+	input_pos = 0;
+	input_len = len;
+	input_can_unput = false;
+	nesting_depth = 0;
+	json_error[0] = '\0';
+
+	root = calloc(1, sizeof(*root));
+	if (!root) {
+		json_set_error("out of memory while allocating parse root");
+		return NULL;
+	}
+
+	ret = json_parse_value(root);
+	if (ret != 1) {
+		json_set_error("parse error near offset %d", input_pos);
+		json_free(root);
+		return NULL;
+	}
+
+	json_skip_whitespace();
+	if (input() != JSON_INPUT_EOF) {
+		json_set_error("unexpected trailing token at offset %d", input_pos - 1);
+		json_free(root);
+		return NULL;
+	}
+
+	return root;
+}
+
+struct json_value *json_parse_buf(const char *json, size_t len)
+{
+	return json_parse_internal(json, len);
+}
+
+struct json_value *json_get_child(struct json_value *object, const char *key)
+{
+	struct json_value *it;
+
+	if (!object || object->type != JSON_TYPE_OBJECT)
+		return NULL;
+
+	for (it = object->u.value; it; it = it->next) {
+		if (!strcmp(it->key, key))
+			return it;
+	}
+
+	return NULL;
+}
+
+struct json_value *json_get_element_object(struct json_value *object, unsigned int idx)
+{
+	struct json_value *it;
+	unsigned int i;
+
+	if (!object || object->type != JSON_TYPE_ARRAY)
+		return NULL;
+
+	for (it = object->u.value, i = 0; it; it = it->next, i++) {
+		if (i == idx)
+			return it;
+	}
+
+	return NULL;
+}
+
+const char *json_get_element_string(struct json_value *object, unsigned int idx)
+{
+	struct json_value *element;
+
+	if (!object)
+		return NULL;
+
+	element = json_get_element_object(object, idx);
+	if (!element || element->type != JSON_TYPE_STRING)
+		return NULL;
+
+	return element->u.string;
+}
+
+int json_count_children(struct json_value *array)
+{
+	struct json_value *it;
+	int count = 0;
+
+	if (!array || array->type != JSON_TYPE_ARRAY)
+		return -1;
+
+	for (it = array->u.value; it; it = it->next)
+		count++;
+
+	return count;
+}
+
+int json_get_number(struct json_value *object, const char *key, double *number)
+{
+	struct json_value *it;
+
+	if (!object || object->type != JSON_TYPE_OBJECT)
+		return -1;
+
+	for (it = object->u.value; it; it = it->next) {
+		if (!strcmp(it->key, key)) {
+			if (it->type != JSON_TYPE_NUMBER)
+				return -1;
+
+			*number = it->u.number;
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+const char *json_get_string(struct json_value *object, const char *key)
+{
+	struct json_value *it;
+
+	if (!object || object->type != JSON_TYPE_OBJECT)
+		return NULL;
+
+	for (it = object->u.value; it; it = it->next) {
+		if (!strcmp(it->key, key)) {
+			if (it->type != JSON_TYPE_STRING)
+				return NULL;
+
+			return it->u.string;
+		}
+	}
+
+	return NULL;
+}
+
+void json_free(struct json_value *value)
+{
+	struct json_value *stack;
+	struct json_value *next;
+	struct json_value *it;
+
+	if (!value)
+		return;
+
+	/* Free iteratively to avoid recursion depth issues on deeply nested JSON. */
+	stack = value;
+	stack->next = NULL;
+	while (stack) {
+		value = stack;
+		stack = stack->next;
+
+		if (value->type == JSON_TYPE_OBJECT || value->type == JSON_TYPE_ARRAY) {
+			it = value->u.value;
+			while (it) {
+				next = it->next;
+				it->next = stack;
+				stack = it;
+				it = next;
+			}
+		}
+
+		free((char *)value->key);
+		if (value->type == JSON_TYPE_STRING)
+			free((char *)value->u.string);
+
+		free(value);
+	}
+}

--- a/json.h
+++ b/json.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * Copyright (c) 2019, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __JSON_H__
+#define __JSON_H__
+
+#include <stddef.h>
+
+#define JSON_ERROR_SIZE 256
+#define JSON_MAX_DEPTH 256
+
+enum {
+	JSON_TYPE_UNKNOWN,
+	JSON_TYPE_TRUE,
+	JSON_TYPE_FALSE,
+	JSON_TYPE_NULL,
+	JSON_TYPE_NUMBER,
+	JSON_TYPE_STRING,
+	JSON_TYPE_ARRAY,
+	JSON_TYPE_OBJECT,
+};
+
+struct json_value {
+	const char *key;
+
+	int type;
+	union {
+		double number;
+		const char *string;
+		struct json_value *value;
+	} u;
+
+	struct json_value *next;
+};
+
+/*
+ * Parser error message for the most recent json_parse_buf() call.
+ * Empty string means no parse error was recorded.
+ * This buffer is global and not thread-safe.
+ */
+extern char json_error[JSON_ERROR_SIZE];
+
+struct json_value *json_parse_buf(const char *json, size_t len);
+int json_count_children(struct json_value *array);
+/* Duplicate object keys are resolved by first match in input order. */
+struct json_value *json_get_child(struct json_value *object, const char *key);
+struct json_value *json_get_element_object(struct json_value *object, unsigned int idx);
+const char *json_get_element_string(struct json_value *object, unsigned int idx);
+int json_get_number(struct json_value *object, const char *key, double *number);
+const char *json_get_string(struct json_value *object, const char *key);
+void json_free(struct json_value *value);
+
+#endif

--- a/ks.c
+++ b/ks.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 				return 1;
 			}
 			filename = &optarg[colon - optarg + 1];
-			ret = load_sahara_image(filename, &mappings[file_id]);
+			ret = load_sahara_image(NULL, filename, &mappings[file_id]);
 			if (ret < 0)
 				return 1;
 

--- a/list.h
+++ b/list.h
@@ -26,7 +26,18 @@ static inline bool list_empty(struct list_head *list)
 	return list->next == list;
 }
 
-static inline void list_add(struct list_head *list, struct list_head *item)
+static inline void list_prepend(struct list_head *list, struct list_head *item)
+{
+	struct list_head *first = list->next;
+
+	item->next = first;
+	item->prev = list;
+
+	list->next = item;
+	first->prev = item;
+}
+
+static inline void list_append(struct list_head *list, struct list_head *item)
 {
 	struct list_head *prev = list->prev;
 
@@ -60,6 +71,11 @@ static inline void list_del(struct list_head *item)
 
 #define list_for_each_entry(item, list, member) \
 	for (item = list_entry_first(list, typeof(*(item)), member); \
+	     &item->member != list; \
+	     item = list_entry_next(item, member))
+
+#define list_for_each_entry_continue(item, list, member) \
+	for (item = list_entry_next(item, member); \
 	     &item->member != list; \
 	     item = list_entry_next(item, member))
 

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,15 @@ test(
   suite: 'integration',
 )
 
+test(
+  'Flashmap dry-run',
+  find_program('bash'),
+  args: [meson.current_source_dir() / 'tests/test_flashmap.sh', '--builddir', meson.current_build_dir()],
+  depends: [qdl_exe],
+  suite: 'integration',
+  protocol: 'tap',
+)
+
 # --- checkpatch targets  ---
 check_script = join_paths(meson.project_source_root(), 'scripts', 'checkpatch_wrapper.sh')
 foreach checkpatchparam : ['download-checkpatch', 'check', 'check-cached']

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ ver   = env_v != '' ? env_v : git_v
 # Dependencies
 libusb_dep = dependency('libusb-1.0')
 libxml_dep = dependency('libxml-2.0')
+libzip_dep = dependency('libzip')
 help2man = find_program('help2man', required: false)
 
 # Common include dirs
@@ -24,7 +25,7 @@ if host_machine.system() == 'windows'
   ws2_dep = meson.get_compiler('c').find_library('ws2_32', required : false)
 endif
 
-common_dep = [libusb_dep, libxml_dep, ws2_dep]
+common_dep = [libusb_dep, libxml_dep, libzip_dep, ws2_dep]
 
 # --- version header generation ---
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ version_h = configure_file(
 )
 
 common_sources = files(
-  'sahara.c', 'util.c', 'ux.c', 'oscompat.c'
+  'sahara.c', 'util.c', 'ux.c', 'oscompat.c', 'file.c'
 )
 
 shared_lib = static_library('qdl_common', common_sources, dependencies: common_dep)

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ qdl_sources = files(
   'firehose.c',
   'io.c', 'qdl.c', 'patch.c',
   'program.c', 'read.c', 'sha2.c', 'sim.c', 'ufs.c', 'usb.c',
-  'vip.c', 'sparse.c', 'gpt.c'
+  'vip.c', 'sparse.c', 'gpt.c', 'flashmap.c', 'json.c'
 )
 
 qdl_exe = executable('qdl',

--- a/patch.c
+++ b/patch.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016-2017, Linaro Ltd.
  * All rights reserved.
  */
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -11,14 +12,14 @@
 #include <unistd.h>
 
 #include "patch.h"
+#include "firehose.h"
 #include "qdl.h"
 
-static struct list_head patches = LIST_INIT(patches);
 static bool patches_loaded;
 
-int patch_load(const char *patch_file)
+int patch_load(struct list_head *ops, const char *patch_file)
 {
-	struct patch *patch;
+	struct firehose_op *patch;
 	xmlNode *node;
 	xmlNode *root;
 	xmlDoc *doc;
@@ -42,7 +43,7 @@ int patch_load(const char *patch_file)
 
 		errors = 0;
 
-		patch = calloc(1, sizeof(struct patch));
+		patch = firehose_alloc_op(FIREHOSE_OP_PATCH);
 
 		patch->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 		patch->byte_offset = attr_as_unsigned(node, "byte_offset", &errors);
@@ -63,7 +64,7 @@ int patch_load(const char *patch_file)
 			continue;
 		}
 
-		list_append(&patches, &patch->node);
+		list_append(ops, &patch->node);
 	}
 
 	xmlFreeDoc(doc);
@@ -71,57 +72,4 @@ int patch_load(const char *patch_file)
 	patches_loaded = true;
 
 	return 0;
-}
-
-int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch))
-{
-	struct patch *patch;
-	unsigned int count = 0;
-	unsigned int idx = 0;
-	int ret;
-
-	if (!patches_loaded)
-		return 0;
-
-	list_for_each_entry(patch, &patches, node) {
-		if (!patch->filename)
-			continue;
-
-		if (!strcmp(patch->filename, "DISK"))
-			count++;
-	}
-
-	list_for_each_entry(patch, &patches, node) {
-		if (!patch->filename)
-			continue;
-
-		if (strcmp(patch->filename, "DISK"))
-			continue;
-
-		ret = apply(qdl, patch);
-		if (ret)
-			return ret;
-
-		ux_progress("Applying patches", idx++, count);
-	}
-
-	ux_info("%d patches applied\n", idx);
-
-	return 0;
-}
-
-void free_patches(void)
-{
-	struct patch *patch;
-	struct patch *next;
-
-	list_for_each_entry_safe(patch, next, &patches, node) {
-		free((void *)patch->filename);
-		free((void *)patch->start_sector);
-		free((void *)patch->value);
-		free((void *)patch->what);
-		free(patch);
-	}
-
-	list_init(&patches);
 }

--- a/patch.c
+++ b/patch.c
@@ -63,7 +63,7 @@ int patch_load(const char *patch_file)
 			continue;
 		}
 
-		list_add(&patches, &patch->node);
+		list_append(&patches, &patch->node);
 	}
 
 	xmlFreeDoc(doc);

--- a/patch.c
+++ b/patch.c
@@ -17,19 +17,12 @@
 
 static bool patches_loaded;
 
-int patch_load(struct list_head *ops, const char *patch_file)
+int patch_load_xml(struct list_head *ops, xmlDoc *doc, const char *patch_file)
 {
 	struct firehose_op *patch;
 	xmlNode *node;
 	xmlNode *root;
-	xmlDoc *doc;
 	int errors;
-
-	doc = xmlReadFile(patch_file, NULL, 0);
-	if (!doc) {
-		ux_err("failed to parse patch-type file \"%s\"\n", patch_file);
-		return -EINVAL;
-	}
 
 	root = xmlDocGetRootElement(doc);
 	for (node = root->children; node ; node = node->next) {
@@ -67,9 +60,25 @@ int patch_load(struct list_head *ops, const char *patch_file)
 		list_append(ops, &patch->node);
 	}
 
-	xmlFreeDoc(doc);
-
 	patches_loaded = true;
 
 	return 0;
+}
+
+int patch_load(struct list_head *ops, const char *patch_file)
+{
+	xmlDoc *doc;
+	int ret;
+
+	doc = xmlReadFile(patch_file, NULL, 0);
+	if (!doc) {
+		ux_err("failed to parse patch-type file \"%s\"\n", patch_file);
+		return -EINVAL;
+	}
+
+	ret = patch_load_xml(ops, doc, patch_file);
+
+	xmlFreeDoc(doc);
+
+	return ret;
 }

--- a/patch.h
+++ b/patch.h
@@ -2,11 +2,13 @@
 #ifndef __PATCH_H__
 #define __PATCH_H__
 
+#include <libxml/parser.h>
 #include "list.h"
 
 struct qdl_device;
 struct firehose_op;
 
 int patch_load(struct list_head *ops, const char *patch_file);
+int patch_load_xml(struct list_head *ops, xmlDoc *doc, const char *patch_file);
 
 #endif

--- a/patch.h
+++ b/patch.h
@@ -5,22 +5,8 @@
 #include "list.h"
 
 struct qdl_device;
+struct firehose_op;
 
-struct patch {
-	unsigned int sector_size;
-	unsigned int byte_offset;
-	const char *filename;
-	unsigned int partition;
-	unsigned int size_in_bytes;
-	const char *start_sector;
-	const char *value;
-	const char *what;
-
-	struct list_head node;
-};
-
-int patch_load(const char *patch_file);
-int patch_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct patch *patch));
-void free_patches(void);
+int patch_load(struct list_head *ops, const char *patch_file);
 
 #endif

--- a/program.c
+++ b/program.c
@@ -150,7 +150,8 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 	return 0;
 }
 
-static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, bool allow_missing, const char *incdir)
+static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand,
+			    bool allow_missing, struct qdl_zip *zip, const char *incdir)
 {
 	struct firehose_op *program;
 	struct qdl_file file = {};
@@ -165,6 +166,7 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 	program->is_nand = is_nand;
 
 	program->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
+	program->zip = qdl_zip_get(zip);
 	program->filename = attr_as_string(node, "filename", &errors);
 	program->label = attr_as_string(node, "label", &errors);
 	program->num_sectors = attr_as_unsigned(node, "num_partition_sectors", &errors);
@@ -196,7 +198,7 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 			}
 		}
 
-		ret = qdl_file_open(program->filename, &file);
+		ret = qdl_file_open(zip, program->filename, &file);
 		if (ret < 0) {
 			ux_info("unable to open %s", program->filename);
 			if (!allow_missing) {
@@ -230,7 +232,7 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 	return 0;
 }
 
-int program_load_xml(struct list_head *ops, xmlDoc *doc, const char *program_file,
+int program_load_xml(struct list_head *ops, xmlDoc *doc, struct qdl_zip *zip, const char *program_file,
 		     bool is_nand, bool allow_missing, const char *incdir)
 {
 	xmlNode *node;
@@ -245,7 +247,7 @@ int program_load_xml(struct list_head *ops, xmlDoc *doc, const char *program_fil
 		if (!xmlStrcmp(node->name, (xmlChar *)"erase"))
 			errors = load_erase_tag(ops, node, is_nand);
 		else if (!xmlStrcmp(node->name, (xmlChar *)"program"))
-			errors = load_program_tag(ops, node, is_nand, allow_missing, incdir);
+			errors = load_program_tag(ops, node, is_nand, allow_missing, zip, incdir);
 		else {
 			ux_err("unrecognized tag \"%s\" in program-type file \"%s\"\n", node->name, program_file);
 			errors = -EINVAL;
@@ -269,7 +271,7 @@ int program_load(struct list_head *ops, const char *program_file, bool is_nand, 
 		return -EINVAL;
 	}
 
-	errors = program_load_xml(ops, doc, program_file, is_nand, allow_missing, incdir);
+	errors = program_load_xml(ops, doc, NULL, program_file, is_nand, allow_missing, incdir);
 
 	xmlFreeDoc(doc);
 

--- a/program.c
+++ b/program.c
@@ -230,18 +230,12 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 	return 0;
 }
 
-int program_load(struct list_head *ops, const char *program_file, bool is_nand, bool allow_missing, const char *incdir)
+int program_load_xml(struct list_head *ops, xmlDoc *doc, const char *program_file,
+		     bool is_nand, bool allow_missing, const char *incdir)
 {
 	xmlNode *node;
 	xmlNode *root;
-	xmlDoc *doc;
 	int errors = 0;
-
-	doc = xmlReadFile(program_file, NULL, 0);
-	if (!doc) {
-		ux_err("failed to parse program-type file \"%s\"\n", program_file);
-		return -EINVAL;
-	}
 
 	root = xmlDocGetRootElement(doc);
 	for (node = root->children; node ; node = node->next) {
@@ -258,10 +252,25 @@ int program_load(struct list_head *ops, const char *program_file, bool is_nand, 
 		}
 
 		if (errors)
-			goto out;
+			break;
 	}
 
-out:
+	return errors;
+}
+
+int program_load(struct list_head *ops, const char *program_file, bool is_nand, bool allow_missing, const char *incdir)
+{
+	xmlDoc *doc;
+	int errors;
+
+	doc = xmlReadFile(program_file, NULL, 0);
+	if (!doc) {
+		ux_err("failed to parse program-type file \"%s\"\n", program_file);
+		return -EINVAL;
+	}
+
+	errors = program_load_xml(ops, doc, program_file, is_nand, allow_missing, incdir);
+
 	xmlFreeDoc(doc);
 
 	return errors;

--- a/program.c
+++ b/program.c
@@ -16,6 +16,7 @@
 #include <libxml/tree.h>
 
 #include "program.h"
+#include "file.h"
 #include "qdl.h"
 #include "oscompat.h"
 #include "firehose.h"
@@ -52,7 +53,7 @@ static int load_erase_tag(struct list_head *ops, xmlNode *node, bool is_nand)
 	return 0;
 }
 
-static int program_load_sparse(struct list_head *ops, struct firehose_op *program, int fd)
+static int program_load_sparse(struct list_head *ops, struct firehose_op *program, struct qdl_file *file)
 {
 	struct firehose_op *program_sparse = NULL;
 	char tmp[PATH_MAX];
@@ -64,7 +65,7 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 	off_t sparse_offset;
 	int chunk_type;
 
-	if (sparse_header_parse(fd, &sparse_header)) {
+	if (sparse_header_parse(file, &sparse_header)) {
 		/*
 		 * If the XML tag "program" contains the attribute 'sparse="true"'
 		 * for a partition node but lacks a sparse header,
@@ -73,8 +74,7 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 		 * was set by mistake, fix the sparse flag and add the
 		 * program entry to the list.
 		 */
-		if ((off_t)program->sector_size * program->num_sectors ==
-		    lseek(fd, 0, SEEK_END)) {
+		if ((off_t)program->sector_size * program->num_sectors == qdl_file_seek(file, 0, SEEK_END)) {
 			program->sparse = false;
 			list_append(ops, &program->node);
 			return 0;
@@ -86,7 +86,7 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 	}
 
 	for (uint32_t i = 0; i < sparse_header.total_chunks; ++i) {
-		chunk_type = sparse_chunk_header_parse(fd, &sparse_header,
+		chunk_type = sparse_chunk_header_parse(file, &sparse_header,
 						       &chunk_size,
 						       &sparse_fill_value,
 						       &sparse_offset);
@@ -153,10 +153,10 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, bool allow_missing, const char *incdir)
 {
 	struct firehose_op *program;
+	struct qdl_file file = {};
 	char tmp[PATH_MAX];
 	int errors = 0;
 	int ret;
-	int fd = -1;
 
 	program = firehose_alloc_op(FIREHOSE_OP_PROGRAM);
 	if (!program)
@@ -196,8 +196,8 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 			}
 		}
 
-		fd = open(program->filename, O_RDONLY | O_BINARY);
-		if (fd < 0) {
+		ret = qdl_file_open(program->filename, &file);
+		if (ret < 0) {
 			ux_info("unable to open %s", program->filename);
 			if (!allow_missing) {
 				ux_info("...failing\n");
@@ -210,8 +210,8 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 		}
 	}
 
-	if (fd >= 0 && program->sparse) {
-		ret = program_load_sparse(ops, program, fd);
+	if (program->filename && program->sparse) {
+		ret = program_load_sparse(ops, program, &file);
 		if (ret < 0)
 			return -1;
 
@@ -225,8 +225,7 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, 
 
 	list_append(ops, &program->node);
 
-	if (fd >= 0)
-		close(fd);
+	qdl_file_close(&file);
 
 	return 0;
 }

--- a/program.c
+++ b/program.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016-2017, Linaro Ltd.
  * All rights reserved.
  */
+#include <assert.h>
 #define _FILE_OFFSET_BITS 64
 #include <errno.h>
 #include <fcntl.h>
@@ -17,20 +18,20 @@
 #include "program.h"
 #include "qdl.h"
 #include "oscompat.h"
+#include "firehose.h"
 #include "sparse.h"
 #include "gpt.h"
 
-static struct list_head programs = LIST_INIT(programs);
-
-static int load_erase_tag(xmlNode *node, bool is_nand)
+static int load_erase_tag(struct list_head *ops, xmlNode *node, bool is_nand)
 {
-	struct program *program;
+	struct firehose_op *program;
 	int errors = 0;
 
-	program = calloc(1, sizeof(struct program));
+	program = firehose_alloc_op(FIREHOSE_OP_ERASE);
+	if (!program)
+		return -1;
 
 	program->is_nand = is_nand;
-	program->is_erase = true;
 
 	program->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 	program->num_sectors = attr_as_unsigned(node, "num_partition_sectors", &errors);
@@ -46,14 +47,14 @@ static int load_erase_tag(xmlNode *node, bool is_nand)
 		return -EINVAL;
 	}
 
-	list_append(&programs, &program->node);
+	list_append(ops, &program->node);
 
 	return 0;
 }
 
-static int program_load_sparse(struct program *program, int fd)
+static int program_load_sparse(struct list_head *ops, struct firehose_op *program, int fd)
 {
-	struct program *program_sparse = NULL;
+	struct firehose_op *program_sparse = NULL;
 	char tmp[PATH_MAX];
 
 	sparse_header_t sparse_header;
@@ -75,7 +76,7 @@ static int program_load_sparse(struct program *program, int fd)
 		if ((off_t)program->sector_size * program->num_sectors ==
 		    lseek(fd, 0, SEEK_END)) {
 			program->sparse = false;
-			list_append(&programs, &program->node);
+			list_append(ops, &program->node);
 			return 0;
 		}
 
@@ -115,7 +116,8 @@ static int program_load_sparse(struct program *program, int fd)
 		}
 
 		if (chunk_type == CHUNK_TYPE_RAW || chunk_type == CHUNK_TYPE_FILL) {
-			program_sparse = calloc(1, sizeof(struct program));
+			program_sparse = firehose_alloc_op(FIREHOSE_OP_PROGRAM);
+
 			program_sparse->pages_per_block = program->pages_per_block;
 			program_sparse->sector_size = program->sector_size;
 			program_sparse->file_offset = program->file_offset;
@@ -126,7 +128,6 @@ static int program_load_sparse(struct program *program, int fd)
 			program_sparse->start_sector = strdup(program->start_sector);
 			program_sparse->last_sector = program->last_sector;
 			program_sparse->is_nand = program->is_nand;
-			program_sparse->is_erase = false;
 
 			program_sparse->sparse_chunk_type = chunk_type;
 			program_sparse->num_sectors = chunk_size / program->sector_size;
@@ -136,7 +137,7 @@ static int program_load_sparse(struct program *program, int fd)
 			else
 				program_sparse->sparse_fill_value = sparse_fill_value;
 
-			list_append(&programs, &program_sparse->node);
+			list_append(ops, &program_sparse->node);
 		}
 
 		start_sector = (unsigned int)strtoul(program->start_sector, NULL, 0);
@@ -149,15 +150,17 @@ static int program_load_sparse(struct program *program, int fd)
 	return 0;
 }
 
-static int load_program_tag(xmlNode *node, bool is_nand, bool allow_missing, const char *incdir)
+static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand, bool allow_missing, const char *incdir)
 {
-	struct program *program;
+	struct firehose_op *program;
 	char tmp[PATH_MAX];
 	int errors = 0;
 	int ret;
 	int fd = -1;
 
-	program = calloc(1, sizeof(struct program));
+	program = firehose_alloc_op(FIREHOSE_OP_PROGRAM);
+	if (!program)
+		return -1;
 
 	program->is_nand = is_nand;
 
@@ -208,7 +211,7 @@ static int load_program_tag(xmlNode *node, bool is_nand, bool allow_missing, con
 	}
 
 	if (fd >= 0 && program->sparse) {
-		ret = program_load_sparse(program, fd);
+		ret = program_load_sparse(ops, program, fd);
 		if (ret < 0)
 			return -1;
 
@@ -220,7 +223,7 @@ static int load_program_tag(xmlNode *node, bool is_nand, bool allow_missing, con
 		program->filename = NULL;
 	}
 
-	list_append(&programs, &program->node);
+	list_append(ops, &program->node);
 
 	if (fd >= 0)
 		close(fd);
@@ -228,7 +231,7 @@ static int load_program_tag(xmlNode *node, bool is_nand, bool allow_missing, con
 	return 0;
 }
 
-int program_load(const char *program_file, bool is_nand, bool allow_missing, const char *incdir)
+int program_load(struct list_head *ops, const char *program_file, bool is_nand, bool allow_missing, const char *incdir)
 {
 	xmlNode *node;
 	xmlNode *root;
@@ -247,9 +250,9 @@ int program_load(const char *program_file, bool is_nand, bool allow_missing, con
 			continue;
 
 		if (!xmlStrcmp(node->name, (xmlChar *)"erase"))
-			errors = load_erase_tag(node, is_nand);
+			errors = load_erase_tag(ops, node, is_nand);
 		else if (!xmlStrcmp(node->name, (xmlChar *)"program"))
-			errors = load_program_tag(node, is_nand, allow_missing, incdir);
+			errors = load_program_tag(ops, node, is_nand, allow_missing, incdir);
 		else {
 			ux_err("unrecognized tag \"%s\" in program-type file \"%s\"\n", node->name, program_file);
 			errors = -EINVAL;
@@ -265,55 +268,29 @@ out:
 	return errors;
 }
 
-int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd))
+int erase_execute(struct qdl_device *qdl, struct firehose_op *op,
+		  int (*apply)(struct qdl_device *qdl, struct firehose_op *op))
 {
-	struct program *program;
 	int ret;
-	int fd;
 
-	list_for_each_entry(program, &programs, node) {
-		if (program->is_erase || !program->filename)
-			continue;
+	assert(op->type == FIREHOSE_OP_ERASE);
 
-		fd = open(program->filename, O_RDONLY | O_BINARY);
-
-		if (fd < 0) {
-			ux_err("unable to open %s\n", program->filename);
-			return -1;
-		}
-
-		ret = apply(qdl, program, fd);
-		close(fd);
-		if (ret)
-			return ret;
-	}
+	ret = apply(qdl, op);
+	if (ret)
+		return ret;
 
 	return 0;
 }
 
-int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program))
+static struct firehose_op *program_find_partition(struct list_head *ops, const char *partition)
 {
-	struct program *program;
-	int ret;
-
-	list_for_each_entry(program, &programs, node) {
-		if (!program->is_erase)
-			continue;
-
-		ret = apply(qdl, program);
-		if (ret)
-			return ret;
-	}
-
-	return 0;
-}
-
-static struct program *program_find_partition(const char *partition)
-{
-	struct program *program;
+	struct firehose_op *program;
 	const char *label;
 
-	list_for_each_entry(program, &programs, node) {
+	list_for_each_entry(program, ops, node) {
+		if (program->type != FIREHOSE_OP_PROGRAM)
+			continue;
+
 		label = program->label;
 		if (!label)
 			continue;
@@ -335,18 +312,18 @@ static struct program *program_find_partition(const char *partition)
  * we're informing the caller so that they can warn the user about the
  * uncertainty of this logic.
  */
-int program_find_bootable_partition(bool *multiple_found)
+int program_find_bootable_partition(struct list_head *ops, bool *multiple_found)
 {
-	struct program *program;
+	struct firehose_op *program;
 	int part = -ENOENT;
 
 	*multiple_found = false;
 
-	program = program_find_partition("xbl");
+	program = program_find_partition(ops, "xbl");
 	if (program)
 		part = program->partition;
 
-	program = program_find_partition("xbl_a");
+	program = program_find_partition(ops, "xbl_a");
 	if (program) {
 		if (part != -ENOENT)
 			*multiple_found = true;
@@ -354,7 +331,7 @@ int program_find_bootable_partition(bool *multiple_found)
 			part = program->partition;
 	}
 
-	program = program_find_partition("sbl1");
+	program = program_find_partition(ops, "sbl1");
 	if (program) {
 		if (part != -ENOENT)
 			*multiple_found = true;
@@ -371,11 +348,11 @@ int program_find_bootable_partition(bool *multiple_found)
  * Returns true if filename for secdata is set in program*.xml,
  * or false otherwise.
  */
-int program_is_sec_partition_flashed(void)
+int program_is_sec_partition_flashed(struct list_head *ops)
 {
-	struct program *program;
+	struct firehose_op *program;
 
-	program = program_find_partition("secdata");
+	program = program_find_partition(ops, "secdata");
 	if (!program)
 		return false;
 
@@ -385,27 +362,11 @@ int program_is_sec_partition_flashed(void)
 	return false;
 }
 
-void free_programs(void)
-{
-	struct program *program;
-	struct program *next;
-
-	list_for_each_entry_safe(program, next, &programs, node) {
-		free((void *)program->filename);
-		free((void *)program->label);
-		free((void *)program->start_sector);
-		free((void *)program->gpt_partition);
-		free(program);
-	}
-
-	list_init(&programs);
-}
-
-int program_cmd_add(const char *address, const char *filename)
+int program_cmd_add(struct list_head *ops, const char *address, const char *filename)
 {
 	unsigned int start_sector;
 	unsigned int num_sectors;
-	struct program *program;
+	struct firehose_op *program;
 	char *gpt_partition;
 	int partition;
 	char buf[20];
@@ -415,7 +376,7 @@ int program_cmd_add(const char *address, const char *filename)
 	if (ret < 0)
 		return ret;
 
-	program = calloc(1, sizeof(struct program));
+	program = firehose_alloc_op(FIREHOSE_OP_PROGRAM);
 	if (!program) {
 		ux_err("failed to allocate program command\n");
 		return -1;
@@ -432,19 +393,18 @@ int program_cmd_add(const char *address, const char *filename)
 	program->start_sector = strdup(buf);
 	program->last_sector = 0;
 	program->is_nand = false;
-	program->is_erase = false;
 	program->gpt_partition = gpt_partition;
 
-	list_append(&programs, &program->node);
+	list_append(ops, &program->node);
 
 	return 0;
 }
 
-int erase_cmd_add(const char *address)
+int erase_cmd_add(struct list_head *ops, const char *address)
 {
 	unsigned int start_sector;
 	unsigned int num_sectors;
-	struct program *program;
+	struct firehose_op *program;
 	char *gpt_partition;
 	int partition;
 	char buf[20];
@@ -454,7 +414,7 @@ int erase_cmd_add(const char *address)
 	if (ret < 0)
 		return ret;
 
-	program = calloc(1, sizeof(struct program));
+	program = firehose_alloc_op(FIREHOSE_OP_ERASE);
 	if (!program) {
 		ux_err("failed to allocate erase command\n");
 		return -1;
@@ -464,32 +424,33 @@ int erase_cmd_add(const char *address)
 	program->partition = partition;
 	sprintf(buf, "%u", start_sector);
 	program->start_sector = strdup(buf);
-	program->is_erase = true;
 	program->gpt_partition = gpt_partition;
 
-	list_append(&programs, &program->node);
+	list_append(ops, &program->node);
 
 	return 0;
 }
 
-int program_resolve_gpt_deferrals(struct qdl_device *qdl)
+int program_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops)
 {
-	struct program *program;
 	unsigned int start_sector;
+	struct firehose_op *op;
 	char buf[20];
 	int ret;
 
-	list_for_each_entry(program, &programs, node) {
-		if (!program->gpt_partition)
+	list_for_each_entry(op, ops, node) {
+		if (op->type != FIREHOSE_OP_PROGRAM)
+			continue;
+		if (!op->gpt_partition)
 			continue;
 
-		ret = gpt_find_by_name(qdl, program->gpt_partition, &program->partition,
-				       &start_sector, &program->num_sectors);
+		ret = gpt_find_by_name(qdl, op->gpt_partition, &op->partition,
+				       &start_sector, &op->num_sectors);
 		if (ret < 0)
 			return -1;
 
 		sprintf(buf, "%u", start_sector);
-		program->start_sector = strdup(buf);
+		op->start_sector = strdup(buf);
 	}
 
 	return 0;

--- a/program.c
+++ b/program.c
@@ -430,28 +430,3 @@ int erase_cmd_add(struct list_head *ops, const char *address)
 
 	return 0;
 }
-
-int program_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops)
-{
-	unsigned int start_sector;
-	struct firehose_op *op;
-	char buf[20];
-	int ret;
-
-	list_for_each_entry(op, ops, node) {
-		if (op->type != FIREHOSE_OP_PROGRAM)
-			continue;
-		if (!op->gpt_partition)
-			continue;
-
-		ret = gpt_find_by_name(qdl, op->gpt_partition, &op->partition,
-				       &start_sector, &op->num_sectors);
-		if (ret < 0)
-			return -1;
-
-		sprintf(buf, "%u", start_sector);
-		op->start_sector = strdup(buf);
-	}
-
-	return 0;
-}

--- a/program.c
+++ b/program.c
@@ -416,6 +416,10 @@ int program_cmd_add(const char *address, const char *filename)
 		return ret;
 
 	program = calloc(1, sizeof(struct program));
+	if (!program) {
+		ux_err("failed to allocate program command\n");
+		return -1;
+	}
 
 	program->sector_size = 0;
 	program->file_offset = 0;
@@ -451,9 +455,10 @@ int erase_cmd_add(const char *address)
 		return ret;
 
 	program = calloc(1, sizeof(struct program));
-
-	if (!program)
-		err(1, "failed to allocate program\n");
+	if (!program) {
+		ux_err("failed to allocate erase command\n");
+		return -1;
+	}
 
 	program->num_sectors = num_sectors;
 	program->partition = partition;

--- a/program.c
+++ b/program.c
@@ -46,7 +46,7 @@ static int load_erase_tag(xmlNode *node, bool is_nand)
 		return -EINVAL;
 	}
 
-	list_add(&programs, &program->node);
+	list_append(&programs, &program->node);
 
 	return 0;
 }
@@ -75,7 +75,7 @@ static int program_load_sparse(struct program *program, int fd)
 		if ((off_t)program->sector_size * program->num_sectors ==
 		    lseek(fd, 0, SEEK_END)) {
 			program->sparse = false;
-			list_add(&programs, &program->node);
+			list_append(&programs, &program->node);
 			return 0;
 		}
 
@@ -136,7 +136,7 @@ static int program_load_sparse(struct program *program, int fd)
 			else
 				program_sparse->sparse_fill_value = sparse_fill_value;
 
-			list_add(&programs, &program_sparse->node);
+			list_append(&programs, &program_sparse->node);
 		}
 
 		start_sector = (unsigned int)strtoul(program->start_sector, NULL, 0);
@@ -220,7 +220,7 @@ static int load_program_tag(xmlNode *node, bool is_nand, bool allow_missing, con
 		program->filename = NULL;
 	}
 
-	list_add(&programs, &program->node);
+	list_append(&programs, &program->node);
 
 	if (fd >= 0)
 		close(fd);
@@ -435,7 +435,7 @@ int program_cmd_add(const char *address, const char *filename)
 	program->is_erase = false;
 	program->gpt_partition = gpt_partition;
 
-	list_add(&programs, &program->node);
+	list_append(&programs, &program->node);
 
 	return 0;
 }
@@ -467,7 +467,7 @@ int erase_cmd_add(const char *address)
 	program->is_erase = true;
 	program->gpt_partition = gpt_partition;
 
-	list_add(&programs, &program->node);
+	list_append(&programs, &program->node);
 
 	return 0;
 }

--- a/program.h
+++ b/program.h
@@ -10,10 +10,11 @@
 
 struct qdl_device;
 struct firehose_op;
+struct qdl_zip;
 
 int program_load(struct list_head *ops, const char *program_file, bool is_nand,
 		 bool allow_missing, const char *incdir);
-int program_load_xml(struct list_head *ops, xmlDoc *doc, const char *program_file,
+int program_load_xml(struct list_head *ops, xmlDoc *doc, struct qdl_zip *zip, const char *program_file,
 		     bool is_nand, bool allow_missing, const char *incdir);
 int erase_execute(struct qdl_device *qdl, struct firehose_op *op,
 		  int (*apply)(struct qdl_device *qdl, struct firehose_op *op));

--- a/program.h
+++ b/program.h
@@ -18,6 +18,5 @@ int program_find_bootable_partition(struct list_head *ops, bool *multiple_found)
 int program_is_sec_partition_flashed(struct list_head *ops);
 int program_cmd_add(struct list_head *ops, const char *address, const char *filename);
 int erase_cmd_add(struct list_head *ops, const char *address);
-int program_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/program.h
+++ b/program.h
@@ -3,6 +3,7 @@
 #define __PROGRAM_H__
 
 #include <sys/types.h>
+#include <libxml/parser.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "list.h"
@@ -12,6 +13,8 @@ struct firehose_op;
 
 int program_load(struct list_head *ops, const char *program_file, bool is_nand,
 		 bool allow_missing, const char *incdir);
+int program_load_xml(struct list_head *ops, xmlDoc *doc, const char *program_file,
+		     bool is_nand, bool allow_missing, const char *incdir);
 int erase_execute(struct qdl_device *qdl, struct firehose_op *op,
 		  int (*apply)(struct qdl_device *qdl, struct firehose_op *op));
 int program_find_bootable_partition(struct list_head *ops, bool *multiple_found);

--- a/program.h
+++ b/program.h
@@ -7,41 +7,17 @@
 #include <stdint.h>
 #include "list.h"
 
-struct program {
-	unsigned int pages_per_block;
-	unsigned int sector_size;
-	unsigned int file_offset;
-	const char *filename;
-	const char *label;
-	unsigned int num_sectors;
-	int partition;
-	bool sparse;
-	const char *start_sector;
-	unsigned int last_sector;
-
-	bool is_nand;
-	bool is_erase;
-
-	unsigned int sparse_chunk_type;
-	uint32_t sparse_fill_value;
-	off_t sparse_offset;
-
-	const char *gpt_partition;
-
-	struct list_head node;
-};
-
 struct qdl_device;
+struct firehose_op;
 
-int program_load(const char *program_file, bool is_nand, bool allow_missing, const char *incdir);
-int program_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program, int fd));
-int erase_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct program *program));
-int program_find_bootable_partition(bool *multiple_found);
-int program_is_sec_partition_flashed(void);
-int program_cmd_add(const char *address, const char *filename);
-int erase_cmd_add(const char *address);
-int program_resolve_gpt_deferrals(struct qdl_device *qdl);
-
-void free_programs(void);
+int program_load(struct list_head *ops, const char *program_file, bool is_nand,
+		 bool allow_missing, const char *incdir);
+int erase_execute(struct qdl_device *qdl, struct firehose_op *op,
+		  int (*apply)(struct qdl_device *qdl, struct firehose_op *op));
+int program_find_bootable_partition(struct list_head *ops, bool *multiple_found);
+int program_is_sec_partition_flashed(struct list_head *ops);
+int program_cmd_add(struct list_head *ops, const char *address, const char *filename);
+int erase_cmd_add(struct list_head *ops, const char *address);
+int program_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/qdl.c
+++ b/qdl.c
@@ -18,6 +18,7 @@
 
 #include "qdl.h"
 #include "firehose.h"
+#include "flashmap.h"
 #include "patch.h"
 #include "program.h"
 #include "ufs.h"
@@ -40,6 +41,7 @@ enum {
 	QDL_CMD_READ,
 	QDL_CMD_WRITE,
 	QDL_CMD_ERASE,
+	QDL_CMD_FLASH,
 };
 
 bool qdl_debug;
@@ -57,6 +59,8 @@ static int detect_type(const char *verb)
 		return QDL_CMD_WRITE;
 	if (!strcmp(verb, "erase"))
 		return QDL_CMD_ERASE;
+	if (!strcmp(verb, "flash"))
+		return QDL_CMD_FLASH;
 
 	if (access(verb, F_OK)) {
 		ux_err("%s is not a verb and not a XML file\n", verb);
@@ -98,7 +102,7 @@ static int detect_type(const char *verb)
 	return type;
 }
 
-static enum qdl_storage_type decode_storage(const char *storage)
+enum qdl_storage_type decode_storage(const char *storage)
 {
 
 	if (!strcmp(storage, "emmc"))
@@ -591,6 +595,72 @@ static int qdl_ensure_configured(struct list_head *ops, enum qdl_storage_type st
 	return 0;
 }
 
+static int qdl_cmd_flash(struct list_head *firehose_ops, char *param,
+			 const char *incdir, struct sahara_image *images)
+{
+	enum qdl_storage_type current_type = QDL_STORAGE_UNKNOWN;
+	struct list_head flashmap_ops = LIST_INIT(flashmap_ops);
+	enum qdl_storage_type type;
+	unsigned int type_filter = 0;
+	struct firehose_op *next;
+	struct firehose_op *op;
+	char *filename;
+	char *filter;
+	char *save;
+	char *tmp;
+	int ret;
+
+	filename = strdup(param);
+	if (!filename) {
+		ux_err("internal error: unable to allocate memory for argument\n");
+		return -1;
+	}
+
+	tmp = strstr(filename, "::");
+	if (tmp) {
+		*tmp = '\0';
+		filter = tmp + 2;
+
+		for (tmp = strtok_r(filter, ",", &save); tmp; tmp = strtok_r(NULL, ",", &save)) {
+			type = decode_storage(tmp);
+			if (type == QDL_STORAGE_UNKNOWN) {
+				ux_err("unknown storage type \"%s\"\n", tmp);
+				ret = -1;
+				goto out_free_filename;
+			}
+
+			type_filter |= 1 << type;
+		}
+	}
+
+	if (!type_filter)
+		type_filter = ~0U;
+
+	ret = flashmap_load(&flashmap_ops, filename, images, incdir);
+	if (ret < 0)
+		goto out_free_filename;
+
+	list_for_each_entry_safe(op, next, &flashmap_ops, node) {
+		if (op->storage_type != QDL_STORAGE_UNKNOWN)
+			current_type = op->storage_type;
+
+		if ((1 << current_type) & type_filter) {
+			list_del(&op->node);
+			list_append(firehose_ops, &op->node);
+		}
+	}
+
+	if (list_empty(firehose_ops)) {
+		ux_err("loaded flashmap does not contain any operations for selected storage type\n");
+		ret = -1;
+	}
+
+out_free_filename:
+	free(filename);
+
+	return ret;
+}
+
 static int qdl_determine_bootable(struct list_head *ops)
 {
 	struct firehose_op *op;
@@ -623,6 +693,7 @@ static int qdl_flash(int argc, char **argv)
 	enum qdl_storage_type storage_type = QDL_STORAGE_UFS;
 	struct sahara_image sahara_images[MAPPING_SZ] = {};
 	struct list_head firehose_ops = LIST_INIT(firehose_ops);
+	struct list_head flashmap_ops = LIST_INIT(flashmap_ops);
 	char *incdir = NULL;
 	char *serial = NULL;
 	const char *vip_generate_dir = NULL;
@@ -746,9 +817,15 @@ static int qdl_flash(int argc, char **argv)
 	if (qdl_debug)
 		print_version();
 
-	ret = decode_programmer(argv[optind++], sahara_images);
-	if (ret < 0)
-		goto out_cleanup;
+	/*
+	 * The programmer needs to either be selected explicitly or through the
+	 * "flash" subcommand. Handling of "flash" happens in the loop below.
+	 */
+	if (strcmp(argv[optind], "flash")) {
+		ret = decode_programmer(argv[optind++], sahara_images);
+		if (ret < 0)
+			goto out_cleanup;
+	}
 
 	do {
 		type = detect_type(argv[optind]);
@@ -809,6 +886,14 @@ static int qdl_flash(int argc, char **argv)
 				errx(1, "failed to add erase command");
 			optind += 1;
 			break;
+		case QDL_CMD_FLASH:
+			if (optind + 1 >= argc)
+				errx(1, "flash command missing operands");
+			ret = qdl_cmd_flash(&firehose_ops, argv[optind + 1], incdir, sahara_images);
+			if (ret < 0)
+				goto out_cleanup;
+			optind += 1;
+			break;
 		default:
 			errx(1, "%s type not yet supported", argv[optind]);
 			break;
@@ -849,6 +934,7 @@ out_cleanup:
 	sahara_images_free(sahara_images, MAPPING_SZ);
 
 	firehose_free_ops(&firehose_ops);
+	firehose_free_ops(&flashmap_ops);
 
 	if (qdl) {
 		if (qdl->vip_data.state != VIP_DISABLED)

--- a/qdl.c
+++ b/qdl.c
@@ -569,6 +569,33 @@ out_cleanup:
 	return ret;
 }
 
+static int qdl_determine_bootable(struct list_head *ops)
+{
+	struct firehose_op *op;
+	bool multiple;
+	int bootable;
+
+	bootable = program_find_bootable_partition(ops, &multiple);
+	if (bootable < 0) {
+		ux_debug("no boot partition found\n");
+		return 0;
+	}
+
+	if (multiple)
+		ux_info("Multiple candidates for primary bootloader found, using partition %d\n",
+			bootable);
+
+	op = firehose_alloc_op(FIREHOSE_OP_SET_BOOTABLE);
+	if (!op)
+		return -1;
+
+	op->partition = bootable;
+
+	list_append(ops, &op->node);
+
+	return 0;
+}
+
 static int qdl_flash(int argc, char **argv)
 {
 	enum qdl_storage_type storage_type = QDL_STORAGE_UFS;
@@ -765,6 +792,10 @@ static int qdl_flash(int argc, char **argv)
 			break;
 		}
 	} while (++optind < argc);
+
+	ret = qdl_determine_bootable(&firehose_ops);
+	if (ret)
+		goto out_cleanup;
 
 	ret = qdl_open(qdl, serial);
 	if (ret)

--- a/qdl.c
+++ b/qdl.c
@@ -724,7 +724,7 @@ static int qdl_flash(int argc, char **argv)
 					" changes. Allow explicitly with --allow-fusing parameter");
 			break;
 		case QDL_FILE_READ:
-			ret = read_op_load(argv[optind], incdir);
+			ret = read_op_load(&firehose_ops, argv[optind], incdir);
 			if (ret < 0)
 				errx(1, "read_op_load %s failed", argv[optind]);
 			break;
@@ -739,7 +739,7 @@ static int qdl_flash(int argc, char **argv)
 		case QDL_CMD_READ:
 			if (optind + 2 >= argc)
 				errx(1, "read command missing arguments");
-			ret = read_cmd_add(argv[optind + 1], argv[optind + 2]);
+			ret = read_cmd_add(&firehose_ops, argv[optind + 1], argv[optind + 2]);
 			if (ret < 0)
 				errx(1, "failed to add read command");
 			optind += 2;

--- a/qdl.c
+++ b/qdl.c
@@ -347,7 +347,7 @@ static int decode_sahara_config(struct sahara_image *blob, struct sahara_image *
 
 		free((void *)image_path);
 
-		ret = load_sahara_image(image_path_full, &images[image_id]);
+		ret = load_sahara_image(NULL, image_path_full, &images[image_id]);
 		if (ret < 0)
 			goto err_free_doc;
 	}
@@ -416,12 +416,12 @@ static int decode_programmer(char *s, struct sahara_image *images)
 			}
 
 			filename = &tail[1];
-			ret = load_sahara_image(filename, &images[id]);
+			ret = load_sahara_image(NULL, filename, &images[id]);
 			if (ret < 0)
 				return -1;
 		}
 	} else {
-		ret = load_sahara_image(s, &archive);
+		ret = load_sahara_image(NULL, s, &archive);
 		if (ret < 0)
 			return -1;
 
@@ -650,6 +650,8 @@ static int qdl_cmd_flash(struct list_head *firehose_ops, char *param,
 		}
 	}
 
+	firehose_free_ops(&flashmap_ops);
+
 	if (list_empty(firehose_ops)) {
 		ux_err("loaded flashmap does not contain any operations for selected storage type\n");
 		ret = -1;
@@ -693,7 +695,6 @@ static int qdl_flash(int argc, char **argv)
 	enum qdl_storage_type storage_type = QDL_STORAGE_UFS;
 	struct sahara_image sahara_images[MAPPING_SZ] = {};
 	struct list_head firehose_ops = LIST_INIT(firehose_ops);
-	struct list_head flashmap_ops = LIST_INIT(flashmap_ops);
 	char *incdir = NULL;
 	char *serial = NULL;
 	const char *vip_generate_dir = NULL;
@@ -934,7 +935,6 @@ out_cleanup:
 	sahara_images_free(sahara_images, MAPPING_SZ);
 
 	firehose_free_ops(&firehose_ops);
-	firehose_free_ops(&flashmap_ops);
 
 	if (qdl) {
 		if (qdl->vip_data.state != VIP_DISABLED)

--- a/qdl.c
+++ b/qdl.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "qdl.h"
+#include "firehose.h"
 #include "patch.h"
 #include "program.h"
 #include "ufs.h"
@@ -572,6 +573,7 @@ static int qdl_flash(int argc, char **argv)
 {
 	enum qdl_storage_type storage_type = QDL_STORAGE_UFS;
 	struct sahara_image sahara_images[MAPPING_SZ] = {};
+	struct list_head firehose_ops = LIST_INIT(firehose_ops);
 	char *incdir = NULL;
 	char *serial = NULL;
 	const char *vip_generate_dir = NULL;
@@ -711,11 +713,13 @@ static int qdl_flash(int argc, char **argv)
 				errx(1, "patch_load %s failed", argv[optind]);
 			break;
 		case QDL_FILE_PROGRAM:
-			ret = program_load(argv[optind], storage_type == QDL_STORAGE_NAND, allow_missing, incdir);
+			ret = program_load(&firehose_ops, argv[optind],
+					   storage_type == QDL_STORAGE_NAND,
+					   allow_missing, incdir);
 			if (ret < 0)
 				errx(1, "program_load %s failed", argv[optind]);
 
-			if (!allow_fusing && program_is_sec_partition_flashed())
+			if (!allow_fusing && program_is_sec_partition_flashed(&firehose_ops))
 				errx(1, "secdata partition to be programmed, which can lead to irreversible"
 					" changes. Allow explicitly with --allow-fusing parameter");
 			break;
@@ -743,7 +747,7 @@ static int qdl_flash(int argc, char **argv)
 		case QDL_CMD_WRITE:
 			if (optind + 2 >= argc)
 				errx(1, "write command missing arguments");
-			ret = program_cmd_add(argv[optind + 1], argv[optind + 2]);
+			ret = program_cmd_add(&firehose_ops, argv[optind + 1], argv[optind + 2]);
 			if (ret < 0)
 				errx(1, "failed to add write command");
 			optind += 2;
@@ -751,7 +755,7 @@ static int qdl_flash(int argc, char **argv)
 		case QDL_CMD_ERASE:
 			if (optind + 1 >= argc)
 				errx(1, "erase command missing address");
-			ret = erase_cmd_add(argv[optind + 1]);
+			ret = erase_cmd_add(&firehose_ops, argv[optind + 1]);
 			if (ret < 0)
 				errx(1, "failed to add erase command");
 			optind += 1;
@@ -775,7 +779,7 @@ static int qdl_flash(int argc, char **argv)
 	if (ufs_need_provisioning())
 		ret = firehose_provision(qdl);
 	else
-		ret = firehose_run(qdl);
+		ret = firehose_run(qdl, &firehose_ops);
 	if (ret < 0)
 		goto out_cleanup;
 
@@ -789,7 +793,7 @@ out_cleanup:
 
 	sahara_images_free(sahara_images, MAPPING_SZ);
 
-	free_programs();
+	firehose_free_ops(&firehose_ops);
 	free_patches();
 
 	if (qdl) {

--- a/qdl.c
+++ b/qdl.c
@@ -708,7 +708,7 @@ static int qdl_flash(int argc, char **argv)
 
 		switch (type) {
 		case QDL_FILE_PATCH:
-			ret = patch_load(argv[optind]);
+			ret = patch_load(&firehose_ops, argv[optind]);
 			if (ret < 0)
 				errx(1, "patch_load %s failed", argv[optind]);
 			break;
@@ -794,7 +794,6 @@ out_cleanup:
 	sahara_images_free(sahara_images, MAPPING_SZ);
 
 	firehose_free_ops(&firehose_ops);
-	free_patches();
 
 	if (qdl) {
 		if (qdl->vip_data.state != VIP_DISABLED)

--- a/qdl.c
+++ b/qdl.c
@@ -569,6 +569,28 @@ out_cleanup:
 	return ret;
 }
 
+static int qdl_ensure_configured(struct list_head *ops, enum qdl_storage_type storage_type)
+{
+	struct firehose_op *op;
+
+	if (list_empty(ops))
+		return 0;
+
+	op = list_entry_first(ops, struct firehose_op, node);
+	if (op->type == FIREHOSE_OP_CONFIGURE)
+		return 0;
+
+	op = firehose_alloc_op(FIREHOSE_OP_CONFIGURE);
+	if (!op)
+		return -1;
+
+	op->storage_type = storage_type;
+
+	list_prepend(ops, &op->node);
+
+	return 0;
+}
+
 static int qdl_determine_bootable(struct list_head *ops)
 {
 	struct firehose_op *op;
@@ -793,6 +815,10 @@ static int qdl_flash(int argc, char **argv)
 		}
 	} while (++optind < argc);
 
+	ret = qdl_ensure_configured(&firehose_ops, storage_type);
+	if (ret < 0)
+		goto out_cleanup;
+
 	ret = qdl_determine_bootable(&firehose_ops);
 	if (ret)
 		goto out_cleanup;
@@ -800,8 +826,6 @@ static int qdl_flash(int argc, char **argv)
 	ret = qdl_open(qdl, serial);
 	if (ret)
 		goto out_cleanup;
-
-	qdl->storage_type = storage_type;
 
 	ret = sahara_run(qdl, sahara_images, NULL, NULL);
 	if (ret < 0)

--- a/qdl.h
+++ b/qdl.h
@@ -106,7 +106,7 @@ struct qdl_device_desc {
 
 struct qdl_device_desc *usb_list(unsigned int *devices_found);
 
-int firehose_run(struct qdl_device *qdl);
+int firehose_run(struct qdl_device *qdl, struct list_head *ops);
 int firehose_provision(struct qdl_device *qdl);
 int firehose_read_buf(struct qdl_device *qdl, struct read_op *read_op, void *out_buf, size_t out_size);
 int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,

--- a/qdl.h
+++ b/qdl.h
@@ -132,6 +132,8 @@ int parse_storage_address(const char *address, int *physical_partition,
 			  unsigned int *start_sector, unsigned int *num_sectors,
 			  char **gpt_partition);
 
+enum qdl_storage_type decode_storage(const char *storage);
+
 extern bool qdl_debug;
 
 #endif

--- a/qdl.h
+++ b/qdl.h
@@ -108,7 +108,7 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found);
 
 int firehose_run(struct qdl_device *qdl, struct list_head *ops);
 int firehose_provision(struct qdl_device *qdl);
-int firehose_read_buf(struct qdl_device *qdl, struct read_op *read_op, void *out_buf, size_t out_size);
+int firehose_read_buf(struct qdl_device *qdl, struct firehose_op *read_op, void *out_buf, size_t out_size);
 int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	       const char *ramdump_path,
 	       const char *ramdump_filter);

--- a/qdl.h
+++ b/qdl.h
@@ -84,6 +84,8 @@ struct sahara_image {
 	size_t len;
 };
 
+struct qdl_zip;
+
 struct libusb_device_handle;
 
 struct qdl_device *qdl_init(enum QDL_DEVICE_TYPE type);
@@ -112,7 +114,7 @@ int firehose_read_buf(struct qdl_device *qdl, struct firehose_op *read_op, void 
 int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	       const char *ramdump_path,
 	       const char *ramdump_filter);
-int load_sahara_image(const char *filename, struct sahara_image *image);
+int load_sahara_image(struct qdl_zip *zip, const char *filename, struct sahara_image *image);
 void sahara_images_free(struct sahara_image *images, size_t count);
 void print_hex_dump(const char *prefix, const void *buf, size_t len);
 unsigned int attr_as_unsigned(xmlNode *node, const char *attr, int *errors);

--- a/qdl.h
+++ b/qdl.h
@@ -64,7 +64,7 @@ struct qdl_device {
 	int fd;
 	size_t max_payload_size;
 	size_t sector_size;
-	enum qdl_storage_type storage_type;
+	enum qdl_storage_type current_storage_type;
 	unsigned int slot;
 
 	int (*open)(struct qdl_device *qdl, const char *serial);

--- a/read.c
+++ b/read.c
@@ -15,13 +15,12 @@
 #include "read.h"
 #include "qdl.h"
 #include "oscompat.h"
+#include "firehose.h"
 #include "gpt.h"
 
-static struct list_head read_ops = LIST_INIT(read_ops);
-
-int read_op_load(const char *read_op_file, const char *incdir)
+int read_op_load(struct list_head *ops, const char *read_op_file, const char *incdir)
 {
-	struct read_op *read_op;
+	struct firehose_op *read_op;
 	xmlNode *node;
 	xmlNode *root;
 	xmlDoc *doc;
@@ -47,7 +46,7 @@ int read_op_load(const char *read_op_file, const char *incdir)
 
 		errors = 0;
 
-		read_op = calloc(1, sizeof(struct read_op));
+		read_op = firehose_alloc_op(FIREHOSE_OP_READ);
 
 		read_op->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 		read_op->filename = attr_as_string(node, "filename", &errors);
@@ -67,7 +66,7 @@ int read_op_load(const char *read_op_file, const char *incdir)
 				read_op->filename = strdup(tmp);
 		}
 
-		list_append(&read_ops, &read_op->node);
+		list_append(ops, &read_op->node);
 	}
 
 	xmlFreeDoc(doc);
@@ -75,34 +74,11 @@ int read_op_load(const char *read_op_file, const char *incdir)
 	return 0;
 }
 
-int read_op_execute(struct qdl_device *qdl, int (*apply)(struct qdl_device *qdl, struct read_op *read_op, int fd))
+int read_cmd_add(struct list_head *ops, const char *address, const char *filename)
 {
-	struct read_op *read_op;
-	int ret;
-	int fd;
-
-	list_for_each_entry(read_op, &read_ops, node) {
-		fd = open(read_op->filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
-		if (fd < 0) {
-			ux_info("unable to open %s...\n", read_op->filename);
-			return ret;
-		}
-
-		ret = apply(qdl, read_op, fd);
-
-		close(fd);
-		if (ret)
-			return ret;
-	}
-
-	return 0;
-}
-
-int read_cmd_add(const char *address, const char *filename)
-{
+	struct firehose_op *read_op;
 	unsigned int start_sector;
 	unsigned int num_sectors;
-	struct read_op *read_op;
 	char *gpt_partition;
 	int partition;
 	char buf[20];
@@ -117,7 +93,9 @@ int read_cmd_add(const char *address, const char *filename)
 		return -1;
 	}
 
-	read_op = calloc(1, sizeof(struct read_op));
+	read_op = firehose_alloc_op(FIREHOSE_OP_READ);
+	if (!read_op)
+		return -1;
 
 	read_op->sector_size = 0;
 	read_op->filename = strdup(filename);
@@ -127,19 +105,22 @@ int read_cmd_add(const char *address, const char *filename)
 	read_op->start_sector = strdup(buf);
 	read_op->gpt_partition = gpt_partition;
 
-	list_append(&read_ops, &read_op->node);
+	list_append(ops, &read_op->node);
 
 	return 0;
 }
 
-int read_resolve_gpt_deferrals(struct qdl_device *qdl)
+int read_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops)
 {
-	struct read_op *read_op;
+	struct firehose_op *read_op;
 	unsigned int start_sector;
 	char buf[20];
 	int ret;
 
-	list_for_each_entry(read_op, &read_ops, node) {
+	list_for_each_entry(read_op, ops, node) {
+		if (read_op->type != FIREHOSE_OP_READ)
+			continue;
+
 		if (!read_op->gpt_partition)
 			continue;
 

--- a/read.c
+++ b/read.c
@@ -109,29 +109,3 @@ int read_cmd_add(struct list_head *ops, const char *address, const char *filenam
 
 	return 0;
 }
-
-int read_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops)
-{
-	struct firehose_op *read_op;
-	unsigned int start_sector;
-	char buf[20];
-	int ret;
-
-	list_for_each_entry(read_op, ops, node) {
-		if (read_op->type != FIREHOSE_OP_READ)
-			continue;
-
-		if (!read_op->gpt_partition)
-			continue;
-
-		ret = gpt_find_by_name(qdl, read_op->gpt_partition, &read_op->partition,
-				       &start_sector, &read_op->num_sectors);
-		if (ret < 0)
-			return -1;
-
-		sprintf(buf, "%u", start_sector);
-		read_op->start_sector = strdup(buf);
-	}
-
-	return 0;
-}

--- a/read.c
+++ b/read.c
@@ -67,7 +67,7 @@ int read_op_load(const char *read_op_file, const char *incdir)
 				read_op->filename = strdup(tmp);
 		}
 
-		list_add(&read_ops, &read_op->node);
+		list_append(&read_ops, &read_op->node);
 	}
 
 	xmlFreeDoc(doc);
@@ -127,7 +127,7 @@ int read_cmd_add(const char *address, const char *filename)
 	read_op->start_sector = strdup(buf);
 	read_op->gpt_partition = gpt_partition;
 
-	list_add(&read_ops, &read_op->node);
+	list_append(&read_ops, &read_op->node);
 
 	return 0;
 }

--- a/read.h
+++ b/read.h
@@ -11,6 +11,5 @@ struct firehose_op;
 
 int read_op_load(struct list_head *ops, const char *read_op_file, const char *incdir);
 int read_cmd_add(struct list_head *ops, const char *address, const char *filename);
-int read_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/read.h
+++ b/read.h
@@ -7,22 +7,10 @@
 #include "list.h"
 
 struct qdl_device;
+struct firehose_op;
 
-struct read_op {
-	unsigned int sector_size;
-	const char *filename;
-	int partition;
-	unsigned int num_sectors;
-	const char *start_sector;
-	const char *gpt_partition;
-
-	struct list_head node;
-};
-
-int read_op_load(const char *read_op_file, const char *incdir);
-int read_op_execute(struct qdl_device *qdl,
-		    int (*apply)(struct qdl_device *qdl, struct read_op *read_op, int fd));
-int read_cmd_add(const char *source, const char *filename);
-int read_resolve_gpt_deferrals(struct qdl_device *qdl);
+int read_op_load(struct list_head *ops, const char *read_op_file, const char *incdir);
+int read_cmd_add(struct list_head *ops, const char *address, const char *filename);
+int read_resolve_gpt_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/sparse.c
+++ b/sparse.c
@@ -18,14 +18,15 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "file.h"
 #include "sparse.h"
 #include "qdl.h"
 
-int sparse_header_parse(int fd, sparse_header_t *sparse_header)
+int sparse_header_parse(struct qdl_file *file, sparse_header_t *sparse_header)
 {
-	lseek(fd, 0, SEEK_SET);
+	qdl_file_seek(file, 0, SEEK_SET);
 
-	if (read(fd, sparse_header, sizeof(sparse_header_t)) != sizeof(sparse_header_t)) {
+	if (qdl_file_read(file, sparse_header, sizeof(sparse_header_t)) != sizeof(sparse_header_t)) {
 		ux_err("[SPARSE] Unable to read sparse header\n");
 		return -EINVAL;
 	}
@@ -46,12 +47,13 @@ int sparse_header_parse(int fd, sparse_header_t *sparse_header)
 	}
 
 	if (sparse_header->file_hdr_sz > sizeof(sparse_header_t))
-		lseek(fd, sparse_header->file_hdr_sz - sizeof(sparse_header_t), SEEK_CUR);
+		qdl_file_seek(file, sparse_header->file_hdr_sz - sizeof(sparse_header_t), SEEK_CUR);
 
 	return 0;
 }
 
-int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
+int sparse_chunk_header_parse(struct qdl_file *file,
+			      sparse_header_t *sparse_header,
 			      uint64_t *chunk_size,
 			      uint32_t *value,
 			      off_t *offset)
@@ -63,13 +65,13 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 	*chunk_size = 0;
 	*value = 0;
 
-	if (read(fd, &chunk_header, sizeof(chunk_header_t)) != sizeof(chunk_header_t)) {
+	if (qdl_file_read(file, &chunk_header, sizeof(chunk_header_t)) != sizeof(chunk_header_t)) {
 		ux_err("[SPARSE] Unable to read sparse chunk header\n");
 		return -EINVAL;
 	}
 
 	if (sparse_header->chunk_hdr_sz > sizeof(chunk_header_t))
-		lseek(fd, sparse_header->chunk_hdr_sz - sizeof(chunk_header_t), SEEK_CUR);
+		qdl_file_seek(file, sparse_header->chunk_hdr_sz - sizeof(chunk_header_t), SEEK_CUR);
 
 	type = chunk_header.chunk_type;
 	*chunk_size = (uint64_t)chunk_header.chunk_sz * sparse_header->blk_sz;
@@ -82,10 +84,10 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 		}
 
 		/* Save the current file offset in the 'value' variable */
-		*offset = lseek(fd, 0, SEEK_CUR);
+		*offset = qdl_file_seek(file, 0, SEEK_CUR);
 
 		/* Move the file cursor forward by the size of the chunk */
-		lseek(fd, *chunk_size, SEEK_CUR);
+		qdl_file_seek(file, *chunk_size, SEEK_CUR);
 		break;
 	case CHUNK_TYPE_DONT_CARE:
 		if (chunk_header.total_sz != sparse_header->chunk_hdr_sz) {
@@ -99,7 +101,7 @@ int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
 			return -EINVAL;
 		}
 
-		if (read(fd, &fill_value, sizeof(fill_value)) != sizeof(fill_value)) {
+		if (qdl_file_read(file, &fill_value, sizeof(fill_value)) != sizeof(fill_value)) {
 			ux_err("[SPARSE] Unable to read fill value\n");
 			return -EINVAL;
 		}

--- a/sparse.h
+++ b/sparse.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+struct qdl_file;
+
 typedef struct __attribute__((__packed__)) sparse_header {
 	/* 0xed26ff3a */
 	uint32_t magic;
@@ -52,14 +54,15 @@ typedef struct __attribute__((__packed__)) chunk_header {
  * Parses the sparse image header from the file descriptor.
  * Returns 0 on success, or an error code otherwise.
  */
-int sparse_header_parse(int fd, sparse_header_t *sparse_header);
+int sparse_header_parse(struct qdl_file *file, sparse_header_t *sparse_header);
 
 /*
  * Parses the sparse image chunk header from the file descriptor.
  * Sets the chunk size, and value or offset based on the parsed data.
  * Returns the chunk type on success, or an error code otherwise.
  */
-int sparse_chunk_header_parse(int fd, sparse_header_t *sparse_header,
+int sparse_chunk_header_parse(struct qdl_file *file,
+			      sparse_header_t *sparse_header,
 			      uint64_t *chunk_size,
 			      uint32_t *value, off_t *offset);
 

--- a/tests/data/flashmap.json
+++ b/tests/data/flashmap.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1.0",
+  "products": [
+    {
+      "name": "unit-test",
+      "layouts": [
+        {
+          "name": "layout0",
+          "programmer": [
+            "prog_firehose_ddr.elf"
+          ],
+          "programmable": [
+            {
+              "memory": "spinor",
+              "slot": 0,
+              "files": [
+                "rawprogram0.xml",
+                "rawprogram1.xml",
+                "patch0.xml",
+                "patch1.xml"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/generate_flat_build.sh
+++ b/tests/data/generate_flat_build.sh
@@ -23,7 +23,13 @@ create_file_with_size rootfs.img 512000
 create_file_with_size xbl_config.elf 320
 create_file_with_size xbl.elf 800
 
-# Copy static test data (XML descriptors) into the output directory
+# Copy static test data (XML descriptors and flashmap.json) into the output directory
 if [ "$OUTDIR" != "$SCRIPT_PATH" ]; then
 	cp "$SCRIPT_PATH"/*.xml "$OUTDIR"/
+	cp "$SCRIPT_PATH"/flashmap.json "$OUTDIR"/
 fi
+
+(cd $OUTDIR ; zip flashmap.zip prog_firehose_ddr.elf efi.bin gpt_backup0.bin \
+		  gpt_backup1.bin gpt_main0.bin gpt_main1.bin rootfs.img \
+		  xbl_config.elf xbl.elf rawprogram0.xml rawprogram1.xml \
+		  patch0.xml patch1.xml flashmap.json)

--- a/tests/test_flashmap.sh
+++ b/tests/test_flashmap.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+
+SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --builddir)
+            builddir="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${builddir}" ]]; then
+    echo "Error: --builddir is required." >&2
+    exit 1
+fi
+
+FLAT_BUILD=${SCRIPT_PATH}/data
+QDL_PATH=$builddir
+
+uname_out="$(uname -s)"
+case "${uname_out}" in
+    Linux*|Darwin*)
+        QDL=qdl
+        ;;
+    CYGWIN*|MINGW*|MSYS*)
+        QDL=qdl.exe
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+DATA_SRC=${SCRIPT_PATH}/data
+FLAT_BUILD=${builddir}/tests/data
+
+${DATA_SRC}/generate_flat_build.sh "${FLAT_BUILD}" >&2
+
+cd $FLAT_BUILD
+
+echo "1..2"
+
+n=1
+fail=0
+
+run_test() {
+	desc="$1"
+	shift
+	out="$(mktemp)"
+	err="$(mktemp)"
+
+	if "$@" >"$out" 2>"$err" ; then
+		echo "ok $n - $desc"
+	else
+		rc=$?
+		echo "not ok $n - $desc"
+		echo "# exit code: $rc"
+
+		sed 's/^/# stdout: /' "$out"
+		sed 's/^/# stderr: /' "$err"
+
+		fail=1
+	fi
+	n=$((n + 1))
+}
+
+#echo "####### Flashing flashmap.json"
+run_test "flashing flashmap.json" ${QDL_PATH}/${QDL} --dry-run flash flashmap.json
+
+#echo "####### Flashing flashmap.zip"
+run_test "flashing flashmap.zip" ${QDL_PATH}/${QDL} --dry-run flash flashmap.zip
+
+exit $fail

--- a/ufs.c
+++ b/ufs.c
@@ -169,7 +169,7 @@ int ufs_load(const char *ufs_file, bool finalize_provisioning)
 		} else if (xmlGetProp(node, (xmlChar *)"LUNum")) {
 			ufs_body_tmp = ufs_parse_body(node);
 			if (ufs_body_tmp) {
-				list_add(&ufs_bodies, &ufs_body_tmp->node);
+				list_append(&ufs_bodies, &ufs_body_tmp->node);
 			} else {
 				ux_err("invalid UFS body tag found in \"%s\"\n",
 				       ufs_file);

--- a/util.c
+++ b/util.c
@@ -15,6 +15,7 @@
 #include <libxml/tree.h>
 #include <unistd.h>
 
+#include "file.h"
 #include "oscompat.h"
 #include "qdl.h"
 #include "version.h"
@@ -223,47 +224,31 @@ done:
  */
 int load_sahara_image(const char *filename, struct sahara_image *image)
 {
-	ssize_t n;
-	off_t len;
+	struct qdl_file file;
+	size_t len;
 	void *ptr;
-	int fd;
+	int ret;
 
-	fd = open(filename, O_RDONLY | O_BINARY);
-	if (fd < 0) {
+	ret = qdl_file_open(filename, &file);
+	if (ret < 0) {
 		ux_err("failed to read \"%s\"\n", filename);
 		return -1;
 	}
 
-	len = lseek(fd, 0, SEEK_END);
-	if (len < 0) {
-		ux_err("failed to find end of \"%s\"\n", filename);
+	ptr = qdl_file_load(&file, &len);
+	if (!ptr || len == 0)
 		goto err_close;
-	}
-	lseek(fd, 0, SEEK_SET);
-
-	ptr = malloc(len);
-	if (!ptr) {
-		ux_err("failed to init buffer for content of \"%s\"\n", filename);
-		goto err_close;
-	}
-
-	n = read(fd, ptr, len);
-	if (n != len) {
-		ux_err("failed to read content of \"%s\"\n", filename);
-		free(ptr);
-		goto err_close;
-	}
-
-	close(fd);
 
 	image->name = strdup(filename);
 	image->ptr = ptr;
 	image->len = len;
 
+	qdl_file_close(&file);
+
 	return 0;
 
 err_close:
-	close(fd);
+	qdl_file_close(&file);
 	return -1;
 }
 

--- a/util.c
+++ b/util.c
@@ -222,14 +222,14 @@ done:
  *
  * Returns: 0 on success, -1 on error
  */
-int load_sahara_image(const char *filename, struct sahara_image *image)
+int load_sahara_image(struct qdl_zip *zip, const char *filename, struct sahara_image *image)
 {
 	struct qdl_file file;
 	size_t len;
 	void *ptr;
 	int ret;
 
-	ret = qdl_file_open(filename, &file);
+	ret = qdl_file_open(zip, filename, &file);
 	if (ret < 0) {
 		ux_err("failed to read \"%s\"\n", filename);
 		return -1;


### PR DESCRIPTION
When distributing builds it's cumbersome and error prone to rely on the user to run QDL on the right programmer, program, and patch files, for each memory type. In Qualcomm's Windows builds this is managed by packaging all the relevant files into a zip archive and include a "flashmap" definition, which tells the flash tools how to process the files across the different memories.

In order to implement this mechanism in QDL the various global lists of firehose operations are merged to a single list, where the client can "mix" configure, program, patch, read, etc operations. Support for parsing the current version of the flashmap json file is introduced, followed by support for getting all these files directly out of a zip file.

The end result is the ability to completely flash something like Hamoa CRD by issuing:

  qdl flash installer.zip

Worth pointing out is that the current version of the flashmap json format does not support specifying multiple programmers, so recent devices such as Nord are not yet supported.