### PR TITLE
usb: Allow devices with no serial number to show in the usb list

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -367,21 +367,19 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 
 		serial = strstr((char *)buf, "_SN:");
 		if (!serial) {
-			ux_err("ignoring device with no serial number\n");
-			libusb_close(handle);
-			continue;
-		}
+			memcpy(result[count].serial, "(none)", sizeof("(none)"));
+		} else {
+			serial += strlen("_SN:");
+			serial_len = strcspn(serial, " _");
+			if (serial_len + 1 > sizeof(result[count].serial)) {
+				ux_err("ignoring device with unexpectedly long serial number\n");
+				libusb_close(handle);
+				continue;
+			}
 
-		serial += strlen("_SN:");
-		serial_len = strcspn(serial, " _");
-		if (serial_len + 1 > sizeof(result[count].serial)) {
-			ux_err("ignoring device with unexpectedly long serial number\n");
-			libusb_close(handle);
-			continue;
+			memcpy(result[count].serial, serial, serial_len);
+			result[count].serial[serial_len] = '\0';
 		}
-
-		memcpy(result[count].serial, serial, serial_len);
-		result[count].serial[serial_len] = '\0';
 
 		result[count].vid = desc.idVendor;
 		result[count].pid = desc.idProduct;


### PR DESCRIPTION
I have a module type that isn't reporting a serial number (msm8937 based). 
Currently they can't load at all, this change means while they still cannot be selected by serial number, they can still load. 