### PR TITLE
sahara: increase MAPPING_SZ to 128

### DIFF
--- a/qdl.h
+++ b/qdl.h
@@ -41,7 +41,7 @@
 		(__typeof__(p))(((uintptr_t)(p) + _mask) & ~_mask);	\
 })
 
-#define MAPPING_SZ 64
+#define MAPPING_SZ 128
 
 #define SAHARA_ID_EHOSTDL_IMG	13
 


### PR DESCRIPTION
Some targets use Sahara image IDs beyond the previous limit of 64, such as IDs 79 and 80 seen on recent  targets. Increase MAPPING_SZ to 128 to accommodate these higher image IDs.