### PR TITLE
meson: fix manpage_targets undefined when help2man is missing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,7 @@ foreach checkpatchparam : ['download-checkpatch', 'check', 'check-cached']
 endforeach
 
 # --- man generation ---
+manpage_targets = []
 if help2man.found()
   # Test if we can run the built executable (might fail in cross-compilation)
   can_run_exe = not meson.is_cross_build()
@@ -123,4 +124,6 @@ if help2man.found()
 endif
 
 # Optional: replicate the "manpages" phony target
-alias_target('manpages', manpage_targets)
+if manpage_targets.length() > 0
+  alias_target('manpages', manpage_targets)
+endif


### PR DESCRIPTION
alias_target('manpages', manpage_targets) was called unconditionally but manpage_targets was only defined inside the help2man.found() block. When help2man is not installed (e.g. during cross-compilation) meson would abort with an "Unknown variable" error.

Fix by initialising manpage_targets to an empty list before the block and guarding alias_target with a length check.