### PR TITLE
qdl: fix list/ramdump subcommands ignored when flags precede them

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -804,10 +804,16 @@ out_cleanup:
 
 int main(int argc, char **argv)
 {
-	if (argc == 2 && !strcmp(argv[1], "list"))
-		return qdl_list(stdout);
-	if (argc >= 2 && !strcmp(argv[1], "ramdump"))
-		return qdl_ramdump(argc - 1, argv + 1);
+	int i;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "list"))
+			return qdl_list(stdout);
+		if (!strcmp(argv[i], "ramdump"))
+			return qdl_ramdump(argc - i, argv + i);
+		if (argv[i][0] != '-')
+			break;
+	}
 
 	return qdl_flash(argc, argv);
 }


### PR DESCRIPTION
The list and ramdump subcommand checks in main() were done before any option parsing, so flags like --debug placed before the subcommand (e.g. qdl --debug list) would cause main() to miss the subcommand and fall through to qdl_flash(), resulting in an error.

Fix by scanning argv for the subcommand while skipping over any leading option flags.