### PR TITLE
usb: add PID 0x90db and refactor PID check

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -36,6 +36,8 @@ struct qdl_device_usb {
 #define LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK LIBUSB_TRANSFER_TYPE_BULK
 #endif
 
+static bool usb_is_edl_pid(uint16_t pid);
+
 static bool usb_read_serial(struct libusb_device_handle *handle,
 			    const struct libusb_device_descriptor *desc,
 			    char *out, size_t out_len)
@@ -101,7 +103,7 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 	/* Consider only devices with vid 0x0506 and known product id */
 	if (desc.idVendor != 0x05c6)
 		return 0;
-	if (desc.idProduct != 0x9008 && desc.idProduct != 0x900e && desc.idProduct != 0x901d)
+	if (!usb_is_edl_pid(desc.idProduct))
 		return 0;
 
 	ret = libusb_get_active_config_descriptor(dev, &config);
@@ -192,7 +194,7 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 
 static bool usb_is_edl_pid(uint16_t pid)
 {
-	return pid == 0x9008 || pid == 0x900e || pid == 0x901d;
+	return pid == 0x9008 || pid == 0x900e || pid == 0x901d || pid == 0x90db;
 }
 
 static int usb_open(struct qdl_device *qdl, const char *serial)


### PR DESCRIPTION
Add PID 0x90db used by some Qualcomm targets in EDL mode.  Also refactor usb_try_open() to use usb_is_edl_pid() instead of a duplicate hardcoded PID list, so future PID additions only need a single change.