### PR TITLE
Unify markdown-lint and checkpatch checks

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -5,11 +5,12 @@ jobs:
     name: checkpatch review
     runs-on: ubuntu-latest
     steps:
-    - name: 'Calculate PR commits + 1'
-      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> $GITHUB_ENV
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Run checkpatch review
-      uses: webispy/checkpatch-action@v9
+      env:
+        CHECKPATCH_BASE: ${{ github.event.pull_request.base.sha }}
+        CHECKPATCH_HEAD: ${{ github.event.pull_request.head.sha }}
+      run: ./scripts/checkpatch_wrapper.sh check-range

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,7 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DavidAnson/markdownlint-cli2-action@v20
-      with:
-        globs: |
-          README.md
+    - name: Install mdl
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y markdownlint
+    - name: Run markdown-lint
+      run: ./scripts/markdownlint_wrapper.sh check

--- a/README.md
+++ b/README.md
@@ -386,6 +386,17 @@ NOTE: Whitespace errors detected.
 Your patch has style problems, please review.
 ```
 
+Markdown sources are linted with
+[mdl](https://github.com/markdownlint/markdownlint). Install it via
+`sudo apt install markdownlint` (or `gem install mdl`) and run:
+
+```bash
+meson compile markdown-lint -C build
+```
+
+The wrapper script is invoked from the GitHub Actions workflow as well,
+so a green local run reflects what CI will report.
+
 ## License
 
 This tool is licensed under the BSD 3-Clause license. Check out [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -386,6 +386,30 @@ NOTE: Whitespace errors detected.
 Your patch has style problems, please review.
 ```
 
+To verify a series of commits the same way the CI does (per-commit, in
+patch mode), use the `check-range` target. It runs checkpatch on every
+commit in `$CHECKPATCH_BASE..$CHECKPATCH_HEAD` (defaulting to
+`origin/master..HEAD`):
+
+```bash
+meson compile check-range -C build
+```
+
+To restrict the range explicitly, set the environment variables before
+invoking meson:
+
+```bash
+CHECKPATCH_BASE=origin/master CHECKPATCH_HEAD=HEAD \
+    meson compile check-range -C build
+```
+
+The full file-mode check (run against every tracked C/H/sh source) is
+also available:
+
+```bash
+meson compile check -C build
+```
+
 Markdown sources are linted with
 [mdl](https://github.com/markdownlint/markdownlint). Install it via
 `sudo apt install markdownlint` (or `gem install mdl`) and run:

--- a/meson.build
+++ b/meson.build
@@ -103,7 +103,7 @@ test(
 
 # --- checkpatch targets  ---
 check_script = join_paths(meson.project_source_root(), 'scripts', 'checkpatch_wrapper.sh')
-foreach checkpatchparam : ['download-checkpatch', 'check', 'check-cached']
+foreach checkpatchparam : ['download-checkpatch', 'check', 'check-cached', 'check-range']
   run_target(checkpatchparam,
     command: ['bash', '-lc', check_script + ' ' + checkpatchparam]
   )

--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,12 @@ foreach checkpatchparam : ['download-checkpatch', 'check', 'check-cached']
   )
 endforeach
 
+# --- markdown lint target ---
+markdown_script = join_paths(meson.project_source_root(), 'scripts', 'markdownlint_wrapper.sh')
+run_target('markdown-lint',
+  command: ['bash', '-lc', markdown_script + ' check']
+)
+
 # --- man generation ---
 if help2man.found()
   # Test if we can run the built executable (might fail in cross-compilation)

--- a/scripts/checkpatch_wrapper.sh
+++ b/scripts/checkpatch_wrapper.sh
@@ -46,8 +46,43 @@ do_check_cached() {
 	git diff --cached -- . | perl "$CHECKPATCH" --no-tree -
 }
 
+do_check_range() {
+	ensure_checkpatch
+
+	local base="${CHECKPATCH_BASE:-origin/master}"
+	local head="${CHECKPATCH_HEAD:-HEAD}"
+
+	if ! git rev-parse --verify "${base}" >/dev/null 2>&1; then
+		echo "Base ref '${base}' is not available." >&2
+		echo "Set CHECKPATCH_BASE to a fetched ref (e.g. origin/master)." >&2
+		exit 1
+	fi
+
+	local commits
+	commits=$(git rev-list --reverse "${base}..${head}")
+	if [[ -z "${commits}" ]]; then
+		echo "No commits in range ${base}..${head}; nothing to check."
+		return 0
+	fi
+
+	echo "Running checkpatch on commits in range ${base}..${head}..."
+	local fail=0
+	for commit in ${commits}; do
+		echo
+		echo "--- Checking commit ${commit} ---"
+		if ! git format-patch -1 --stdout "${commit}" | perl "${CHECKPATCH}" --no-tree -; then
+			fail=1
+		fi
+	done
+	return $fail
+}
+
 usage() {
-	echo "Usage: $0 {download-checkpatch|check|check-cached}"
+	echo "Usage: $0 {download-checkpatch|check|check-cached|check-range}"
+	echo
+	echo "  check-range   Run checkpatch per-commit on the range"
+	echo "                \$CHECKPATCH_BASE..\$CHECKPATCH_HEAD"
+	echo "                (defaults: origin/master..HEAD)"
 	exit 2
 }
 
@@ -55,5 +90,6 @@ case "${1:-}" in
 	download)      ensure_checkpatch ;;
 	check)         do_check_all ;;
 	check-cached)  do_check_cached ;;
+	check-range)   do_check_range ;;
 	*)             usage ;;
 esac

--- a/scripts/markdownlint_wrapper.sh
+++ b/scripts/markdownlint_wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -euo pipefail
+
+ROOT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../"
+
+# Run consistently from the repo root regardless of where the script is called
+cd "$ROOT_PATH"
+
+# Files to lint. Keep this in sync with .github/workflows/markdown-lint.yml
+MARKDOWN_FILES=("README.md")
+
+run_lint() {
+	if ! command -v mdl >/dev/null 2>&1; then
+		echo "mdl not found." >&2
+		echo "Install it with: sudo apt install markdownlint  (or 'gem install mdl')" >&2
+		exit 1
+	fi
+	mdl "${MARKDOWN_FILES[@]}"
+}
+
+usage() {
+	echo "Usage: $0 {check}"
+	exit 2
+}
+
+case "${1:-}" in
+	check)  run_lint ;;
+	*)      usage ;;
+esac


### PR DESCRIPTION
Unify the markdown-lint and checkpatch checks between local and CI invocations so a green local run reliably reflects what CI will report. 

Introduce `scripts/markdownlint_wrapper.sh` (driven by `mdl`, installed via `sudo apt install mdl`) and a `markdown-lint` meson target, and switch the markdown-lint workflow to call the wrapper directly. 

Add a `check-range` mode to scripts/checkpatch_wrapper.sh that mirrors webispy/checkpatch-action by running checkpatch in patch mode over every commit in `$CHECKPATCH_BASE..$CHECKPATCH_HEAD` (defaulting to `origin/master..HEAD`), expose it as the `check-range` meson target, and switch the checkpatch workflow to invoke it with the PR base/head SHAs.
