### PR TITLE
patch: suppress libxml2 stderr output on parse errors

### DIFF
--- a/patch.c
+++ b/patch.c
@@ -70,7 +70,7 @@ int patch_load(struct list_head *ops, const char *patch_file)
 	xmlDoc *doc;
 	int ret;
 
-	doc = xmlReadFile(patch_file, NULL, 0);
+	doc = xmlReadFile(patch_file, NULL, XML_PARSE_NOWARNING | XML_PARSE_NOERROR);
 	if (!doc) {
 		ux_err("failed to parse patch-type file \"%s\"\n", patch_file);
 		return -EINVAL;


### PR DESCRIPTION
libxml2 prints warnings and errors directly to stderr before the caller gets a chance to handle them. This leaks raw parser diagnostics into both test output and user-facing output when a patch file is missing or malformed. patch_load() already checks the return value and reports the failure through ux_err(), so the extra stderr output is redundant noise.

Pass XML_PARSE_NOWARNING | XML_PARSE_NOERROR to xmlReadFile() so all error reporting goes through our own output layer.