### PR TITLE
[RFC] ux: Route libxml2 parser diagnostics through ux_err()

### DIFF
--- a/ux.c
+++ b/ux.c
@@ -8,7 +8,17 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <libxml/xmlerror.h>
+#include <libxml/xmlversion.h>
+
 #include "qdl.h"
+
+/* libxml2 2.12 const-qualified the xmlError pointer in this callback. */
+#if LIBXML_VERSION >= 21200
+typedef const xmlError * ux_xml_error_ptr;
+#else
+typedef xmlErrorPtr ux_xml_error_ptr;
+#endif
 
 #define UX_PROGRESS_REFRESH_RATE	10
 #define UX_PROGRESS_SIZE_MAX		80
@@ -42,6 +52,38 @@ static void ux_clear_line(void)
 	ux_cur_line_length = 0;
 }
 
+/*
+ * libxml2 emits parser diagnostics directly to stderr by default. Route them
+ * through ux_err() so the file:line context is preserved while keeping output
+ * consistent with the rest of the tool.
+ */
+static void ux_xml_error_handler(void *ctx __unused, ux_xml_error_ptr error)
+{
+	const char *level;
+
+	if (!error || error->level == XML_ERR_NONE)
+		return;
+
+	switch (error->level) {
+	case XML_ERR_WARNING:
+		level = "warning";
+		break;
+	case XML_ERR_ERROR:
+		level = "error";
+		break;
+	case XML_ERR_FATAL:
+	default:
+		level = "fatal";
+		break;
+	}
+
+	if (error->file)
+		ux_err("libxml2 %s: %s:%d: %s",
+		       level, error->file, error->line, error->message);
+	else
+		ux_err("libxml2 %s: %s", level, error->message);
+}
+
 #ifdef _WIN32
 
 void ux_init(void)
@@ -55,6 +97,8 @@ void ux_init(void)
 		columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
 		ux_width = MIN(columns, UX_PROGRESS_SIZE_MAX);
 	}
+
+	xmlSetStructuredErrorFunc(NULL, ux_xml_error_handler);
 }
 
 #else
@@ -67,6 +111,8 @@ void ux_init(void)
 	ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
 	if (!ret)
 		ux_width = MIN(w.ws_col, UX_PROGRESS_SIZE_MAX);
+
+	xmlSetStructuredErrorFunc(NULL, ux_xml_error_handler);
 }
 
 #endif


### PR DESCRIPTION
libxml2 prints warnings and errors directly to stderr by default. This leaks raw parser diagnostics into both test output and user-facing output when an XML file is missing or malformed, bypassing the tool's ux_err() output layer.

Install a structured error handler via xmlSetStructuredErrorFunc() in ux_init() that formats each diagnostic as

    libxml2 <level>: <file>:<line>: <message>

and routes it through ux_err(). This preserves the file, line and reason detail libxml2 produces for malformed XML while keeping output flow consistent with the rest of the tool, and applies uniformly to every xmlReadFile()/xmlReadMemory() call without per-site flag changes.