### PR TITLE
meson: avoid duplicate library entries on executable link lines

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,15 @@ endif
 
 common_dep = [libusb_dep, libxml_dep, libzip_dep, ws2_dep]
 
+# Compile-only view of common_dep (includes + cflags, no link args).
+# Used on executables so their own sources see the headers, while link
+# args propagate exactly once through the static library below, avoiding
+# duplicate "-l..." entries on the link line.
+common_compile_dep = []
+foreach d : [libusb_dep, libxml_dep, libzip_dep]
+  common_compile_dep += d.partial_dependency(compile_args: true, includes: true)
+endforeach
+
 # --- version header generation ---
 conf = configuration_data()
 conf.set('version', ver)
@@ -54,7 +63,7 @@ qdl_sources = files(
 qdl_exe = executable('qdl',
   sources : qdl_sources + [version_h],
   link_with: shared_lib,
-  dependencies : common_dep,
+  dependencies : common_compile_dep,
   include_directories : inc,
   install : true
 )
@@ -67,7 +76,7 @@ ramdump_sources = files(
 qdl_ramdump_exe = executable('qdl-ramdump',
   sources : ramdump_sources + [version_h],
   link_with: shared_lib,
-  dependencies : common_dep,
+  dependencies : common_compile_dep,
   include_directories : inc,
   install : true
 )
@@ -78,7 +87,7 @@ ks_sources = files('ks.c')
 qdl_ks_exe = executable('qdl-ks',
   sources : ks_sources + [version_h],
   link_with: shared_lib,
-  dependencies : common_dep,
+  dependencies : common_compile_dep,
   include_directories : inc,
   install : true
 )


### PR DESCRIPTION
Both the qdl_common static library and each of the qdl/qdl-ramdump/qdl-ks executables were declared with the same `dependencies: common_dep` (libusb-1.0, libxml-2.0, libzip, plus ws2_32 on Windows). Meson propagates a static library's dependencies to its consumers via `link_with`, so listing those dependencies again on each executable caused every common library to appear twice on the final link line. Apple's ld surfaced this as:

  ld: warning: ignoring duplicate libraries: '-lxml2'

The other dependencies are passed by absolute dylib path on macOS (libusb-1.0, libzip), so the linker silently deduplicated those while still warning about libxml2, which is referenced as `-lxml2` from the system path.

Fix it by introducing a compile-only view of the common dependencies using `partial_dependency(compile_args: true, includes: true)` and attaching that to the executables instead of the full deps. The executables still see the headers needed to compile their own sources (e.g. usb.c -> libusb.h, file.c -> zip.h), while link arguments now flow to them exactly once via the static library's automatic propagation.

Fixes: ff189b1a12fe ("build: migrate from GNU Make to Meson build system")