### PR TITLE
commitlint: Recognize kernel-style trailers as footer items

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -30,4 +30,19 @@ export default {
     'scope-empty': [0],
     'subject-case': [0],
   },
+
+  // Teach the parser which trailers terminate the body and start the
+  // footer. Without this, kernel-style trailers like `Fixes:` are
+  // classified as body lines and trip body-max-line-length, while the
+  // relaxed footer-max-line-length (200) never gets a chance to apply.
+  parserPreset: {
+    parserOpts: {
+      noteKeywords: [
+        'BREAKING CHANGE', 'BREAKING-CHANGE',
+        'Fixes', 'Signed-off-by', 'Co-authored-by',
+        'Reviewed-by', 'Tested-by', 'Acked-by',
+        'Reported-by', 'Suggested-by',
+      ],
+    },
+  },
 };


### PR DESCRIPTION
The config relaxes footer-max-line-length to 200 specifically to accommodate long Signed-off-by addresses, but commitlint's default parser only treats `BREAKING CHANGE` as a note keyword. Other kernel-style trailers (Fixes, Reviewed-by, Tested-by, ...) get classified as body lines, so a trailer that exceeds 72 characters -- typically a `Fixes:` quoting a long commit subject -- trips body-max-line-length even though the relaxed footer limit was meant to cover exactly this case.

Configure parserPreset.parserOpts.noteKeywords with the trailer tokens this project uses, so those lines move into the footer section and inherit the existing footer-max-line-length=200 rule.