### PR TITLE
tests: give each integration test its own fixture directory

### DIFF
--- a/tests/test_flashmap.sh
+++ b/tests/test_flashmap.sh
@@ -40,7 +40,7 @@ case "${uname_out}" in
 esac
 
 DATA_SRC=${SCRIPT_PATH}/data
-FLAT_BUILD=${builddir}/tests/data
+FLAT_BUILD=${builddir}/tests/data-flashmap
 
 ${DATA_SRC}/generate_flat_build.sh "${FLAT_BUILD}" >&2
 

--- a/tests/test_vip_generation.sh
+++ b/tests/test_vip_generation.sh
@@ -24,7 +24,7 @@ if [[ -z "${builddir}" ]]; then
 fi
 
 DATA_SRC=${SCRIPT_PATH}/data
-FLAT_BUILD=${builddir}/tests/data
+FLAT_BUILD=${builddir}/tests/data-vip
 
 # Generate test fixtures in the build directory
 ${DATA_SRC}/generate_flat_build.sh "${FLAT_BUILD}"


### PR DESCRIPTION
test_flashmap.sh and test_vip_generation.sh both wrote fixtures to ${builddir}/tests/data, and meson runs the two tests in parallel. Their generate_flat_build.sh invocations therefore raced on dd, cp and the final `zip flashmap.zip ...`, while test_vip_generation.sh's EXIT trap could rm -rf the directory out from under its peer.

The race was masked while zip took several seconds on the unshrunk 1 GB fixtures; once fixture generation dropped to ~30 ms it started firing on the macos-14 arm64 runner as zip exit status 18 ("could not open a specified file to read").

Point each test at its own directory (data-flashmap / data-vip) so they no longer share mutable state.