### PR TITLE
Add --skip-reset and auto-skip Sahara when programmer is already running

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -1053,7 +1053,7 @@ static int firehose_detect_and_configure(struct qdl_device *qdl,
 	return 0;
 }
 
-int firehose_provision(struct qdl_device *qdl)
+int firehose_provision(struct qdl_device *qdl, bool skip_reset)
 {
 	int ret;
 
@@ -1069,7 +1069,8 @@ int firehose_provision(struct qdl_device *qdl)
 	else
 		ux_info("UFS provisioning failed\n");
 
-	firehose_reset(qdl);
+	if (!skip_reset)
+		firehose_reset(qdl);
 
 	return ret;
 
@@ -1169,6 +1170,11 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 		case FIREHOSE_OP_SET_BOOTABLE:
 			firehose_set_bootable(qdl, op->partition);
 			break;
+		case FIREHOSE_OP_RESET:
+			ret = firehose_reset(qdl);
+			if (ret < 0)
+				return ret;
+			break;
 		default:
 			ux_err("internal error: unknown firehose operation %d\n", op->type);
 			return -1;
@@ -1180,15 +1186,7 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 
 int firehose_run(struct qdl_device *qdl, struct list_head *ops)
 {
-	int ret;
-
 	ux_info("waiting for Firehose programmer...\n");
 
-	ret = firehose_execute_ops(qdl, ops);
-	if (ret)
-		return ret;
-
-	firehose_reset(qdl);
-
-	return 0;
+	return firehose_execute_ops(qdl, ops);
 }

--- a/firehose.h
+++ b/firehose.h
@@ -17,6 +17,7 @@ enum firehose_op_type {
 	FIREHOSE_OP_READ,
 	FIREHOSE_OP_PATCH,
 	FIREHOSE_OP_SET_BOOTABLE,
+	FIREHOSE_OP_RESET,
 };
 
 struct firehose_op {

--- a/qdl.c
+++ b/qdl.c
@@ -460,6 +460,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " -t, --create-digests=T\t\tGenerate table of digests in the T folder\n");
 	fprintf(out, " -T, --slot=T\t\t\tSet slot number T for multiple storage devices\n");
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
+	fprintf(out, " -R, --skip-reset\t\tDo not send the reset command after flashing completes\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\t\txml file containing <program> or <erase> directives\n");
 	fprintf(out, " <patch-xml>\t\txml file containing <patch> directives\n");
@@ -705,6 +706,7 @@ static int qdl_flash(int argc, char **argv)
 	bool qdl_finalize_provisioning = false;
 	bool allow_fusing = false;
 	bool allow_missing = false;
+	bool skip_reset = false;
 	long out_chunk_size = 0;
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
@@ -724,11 +726,12 @@ static int qdl_flash(int argc, char **argv)
 		{"dry-run", no_argument, 0, 'n'},
 		{"create-digests", required_argument, 0, 't'},
 		{"slot", required_argument, 0, 'T'},
+		{"skip-reset", no_argument, 0, 'R'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:h", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "dvi:lu:S:D:s:fcnt:T:Rh", options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			qdl_debug = true;
@@ -772,6 +775,9 @@ static int qdl_flash(int argc, char **argv)
 			break;
 		case 'T':
 			slot = (unsigned int)strtoul(optarg, NULL, 10);
+			break;
+		case 'R':
+			skip_reset = true;
 			break;
 		case 'h':
 			print_usage(stdout);
@@ -909,6 +915,21 @@ static int qdl_flash(int argc, char **argv)
 	if (ret)
 		goto out_cleanup;
 
+	/*
+	 * Reset is the last operation in any flashing run, modelled as a regular
+	 * firehose op so callers can compose it like any other. Skip the append
+	 * to leave the programmer alive across qdl invocations.
+	 */
+	if (!skip_reset) {
+		struct firehose_op *reset_op = firehose_alloc_op(FIREHOSE_OP_RESET);
+
+		if (!reset_op) {
+			ret = -1;
+			goto out_cleanup;
+		}
+		list_append(&firehose_ops, &reset_op->node);
+	}
+
 	ret = qdl_open(qdl, serial);
 	if (ret)
 		goto out_cleanup;
@@ -918,7 +939,7 @@ static int qdl_flash(int argc, char **argv)
 		goto out_cleanup;
 
 	if (ufs_need_provisioning())
-		ret = firehose_provision(qdl);
+		ret = firehose_provision(qdl, skip_reset);
 	else
 		ret = firehose_run(qdl, &firehose_ops);
 	if (ret < 0)

--- a/qdl.h
+++ b/qdl.h
@@ -109,7 +109,7 @@ struct qdl_device_desc {
 struct qdl_device_desc *usb_list(unsigned int *devices_found);
 
 int firehose_run(struct qdl_device *qdl, struct list_head *ops);
-int firehose_provision(struct qdl_device *qdl);
+int firehose_provision(struct qdl_device *qdl, bool skip_reset);
 int firehose_read_buf(struct qdl_device *qdl, struct firehose_op *read_op, void *out_buf, size_t out_size);
 int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	       const char *ramdump_path,

--- a/sahara.c
+++ b/sahara.c
@@ -509,6 +509,15 @@ int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	       const char *ramdump_path,
 	       const char *ramdump_filter)
 {
+	/*
+	 * Auto-detect that the device is already running the Firehose
+	 * programmer (e.g. left running by a previous --skip-reset
+	 * invocation): if the first read times out or returns a Firehose XML
+	 * banner instead of a Sahara HELLO, skip Sahara entirely. Disabled
+	 * in ramdump mode, where Sahara is the only valid protocol.
+	 */
+	const bool detect_firehose = !ramdump_path;
+	bool first_read = true;
 	struct sahara_pkt *pkt;
 	char buf[4096];
 	char tmp[32];
@@ -528,9 +537,20 @@ int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	while (!done) {
 		n = qdl_read(qdl, buf, sizeof(buf), SAHARA_CMD_TIMEOUT_MS);
 		if (n < 0) {
+			if (first_read && detect_firehose && n == -ETIMEDOUT) {
+				ux_info("no Sahara HELLO received; assuming Firehose programmer is already running\n");
+				return 0;
+			}
 			ux_err("failed to read sahara request from device\n");
 			break;
 		}
+
+		if (first_read && detect_firehose &&
+		    n >= 5 && !memcmp(buf, "<?xml", 5)) {
+			ux_info("device is already in Firehose mode, skipping Sahara\n");
+			return 0;
+		}
+		first_read = false;
 
 		pkt = (struct sahara_pkt *)buf;
 		if ((uint32_t)n != pkt->length) {


### PR DESCRIPTION
Support workflows where the Firehose programmer is left running between qdl invocations - useful when chaining flash operations, doing post-flash verification, or running a series of reads/writes against the same programmer session.

`--skip-reset (-R)` suppresses the unconditional reset issued at the end of `firehose_run()`, leaving the programmer responsive after the command completes.

A second invocation against the still-running programmer no longer needs an explicit flag: sahara_run() now peeks at the device's first response and, if it sees a Firehose XML banner (`<?xml`) or a read timeout instead of a Sahara HELLO, returns success so the caller proceeds straight to the Firehose phase. This mirrors qdlrs's behaviour and avoids the need for a separate `--skip-sahara` flag.

Typical use:

```bash
$ qdl prog_firehose_ddr.elf rawprogram*.xml patch*.xml --skip-reset
$ qdl prog_firehose_ddr.elf write 0 fastboot.img    # Sahara auto-skipped
```