### PR TITLE
qdl: Drop alloca definition

### DIFF
--- a/qdl.h
+++ b/qdl.h
@@ -4,7 +4,6 @@
 
 #ifdef _WIN32
 #include <malloc.h>
-#define alloca _alloca
 #else
 #include <alloca.h>
 #endif


### PR DESCRIPTION
Commit '069b852cdc00 ("firehose: replace malloc with alloca for sector probe buffer")' introduced a redefine of alloca, but this results in a compile warning every time qdl.h is included:

  ../qdl.h:7:9: warning: 'alloca' redefined
      7 | #define alloca _alloca

The define is guarded by _WIN32 and each applicable target this has been tested on presents the same warning.

Remove the define to avoid the warning.