### PR TITLE
[RFC] qdl: add sha256 subcommand

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -25,6 +25,7 @@
 #include "qdl.h"
 #include "file.h"
 #include "firehose.h"
+#include "sha2.h"
 #include "ufs.h"
 #include "oscompat.h"
 #include "vip.h"
@@ -111,6 +112,93 @@ static int firehose_generic_parser(xmlNode *node, void *data __unused, bool *raw
 		if (xmlStrcmp(value, (xmlChar *)"true") == 0)
 			*rawmode = true;
 		xmlFree(value);
+	}
+
+	return ret;
+}
+
+/*
+ * Scan @str for a contiguous run of exactly SHA256_DIGEST_STRING_LENGTH-1
+ * (64) lowercase or uppercase hex characters bounded by a non-hex character
+ * or string boundary. On match, decode into @digest and return true.
+ */
+static bool extract_sha256_hex(const char *str, uint8_t digest[SHA256_DIGEST_LENGTH])
+{
+	const size_t hex_len = SHA256_DIGEST_LENGTH * 2;
+	const char *p = str;
+	size_t i;
+
+	while (*p) {
+		size_t run = 0;
+		const char *start;
+
+		while (*p && !isxdigit((unsigned char)*p))
+			p++;
+
+		start = p;
+		while (isxdigit((unsigned char)*p)) {
+			run++;
+			p++;
+		}
+
+		if (run == hex_len) {
+			for (i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+				char byte[3] = { start[i * 2], start[i * 2 + 1], '\0' };
+
+				digest[i] = (uint8_t)strtoul(byte, NULL, 16);
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+struct firehose_sha256_result {
+	uint8_t digest[SHA256_DIGEST_LENGTH];
+	bool valid;
+};
+
+static int firehose_sha256_parser(xmlNode *node, void *data, bool *rawmode)
+{
+	struct firehose_sha256_result *result = data;
+	xmlChar *value;
+	int ret;
+
+	if (xmlStrcmp(node->name, (xmlChar *)"log") == 0) {
+		value = xmlGetProp(node, (xmlChar *)"value");
+		if (!value)
+			return -EINVAL;
+
+		if (!result->valid && extract_sha256_hex((const char *)value, result->digest))
+			result->valid = true;
+
+		ux_log("LOG: %s\n", value);
+		xmlFree(value);
+		return -EAGAIN;
+	}
+
+	ret = firehose_generic_parser(node, NULL, rawmode);
+
+	/*
+	 * Some Firehose implementations attach the digest as an attribute on
+	 * the response itself rather than emitting it via <log>. Try a few
+	 * known attribute names.
+	 */
+	if (!result->valid) {
+		static const char * const attrs[] = { "Digest", "SHA256", "sha256" };
+		size_t i;
+
+		for (i = 0; i < ARRAY_SIZE(attrs); i++) {
+			value = xmlGetProp(node, (xmlChar *)attrs[i]);
+			if (!value)
+				continue;
+			if (extract_sha256_hex((const char *)value, result->digest))
+				result->valid = true;
+			xmlFree(value);
+			if (result->valid)
+				break;
+		}
 	}
 
 	return ret;
@@ -784,6 +872,66 @@ static int firehose_read_op(struct qdl_device *qdl, struct firehose_op *op)
 	return ret;
 }
 
+static int firehose_getsha256digest(struct qdl_device *qdl, struct firehose_op *op)
+{
+	struct firehose_sha256_result result = { 0 };
+	unsigned int sector_size;
+	xmlNode *root;
+	xmlNode *node;
+	xmlDoc *doc;
+	char hex[SHA256_DIGEST_STRING_LENGTH];
+	size_t i;
+	int ret;
+
+	sector_size = op->sector_size ? : qdl->sector_size;
+
+	doc = xmlNewDoc((xmlChar *)"1.0");
+	root = xmlNewNode(NULL, (xmlChar *)"data");
+	xmlDocSetRootElement(doc, root);
+
+	node = xmlNewChild(root, NULL, (xmlChar *)"getsha256digest", NULL);
+	xml_setpropf(node, "SECTOR_SIZE_IN_BYTES", "%d", sector_size);
+	xml_setpropf(node, "num_partition_sectors", "%d", op->num_sectors);
+	xml_setpropf(node, "physical_partition_number", "%d", op->partition);
+	xml_setpropf(node, "start_sector", "%s", op->start_sector);
+	if (qdl->slot != UINT_MAX)
+		xml_setpropf(node, "slot", "%u", qdl->slot);
+
+	ret = firehose_write(qdl, doc);
+	if (ret < 0) {
+		ux_err("failed to send getsha256digest command\n");
+		goto out;
+	}
+
+	ret = firehose_read(qdl, 30000, firehose_sha256_parser, &result);
+	if (ret != FIREHOSE_ACK) {
+		ux_err("getsha256digest failed for %s+0x%x\n",
+		       op->start_sector, op->num_sectors);
+		ret = -1;
+		goto out;
+	}
+
+	if (!result.valid) {
+		ux_err("getsha256digest returned no digest for %s+0x%x\n",
+		       op->start_sector, op->num_sectors);
+		ret = -1;
+		goto out;
+	}
+
+	for (i = 0; i < SHA256_DIGEST_LENGTH; i++)
+		snprintf(hex + i * 2, 3, "%02x", result.digest[i]);
+	hex[SHA256_DIGEST_STRING_LENGTH - 1] = '\0';
+
+	printf("%s\n", hex);
+	fflush(stdout);
+
+	ret = 0;
+
+out:
+	xmlFreeDoc(doc);
+	return ret;
+}
+
 static int firehose_apply_patch(struct qdl_device *qdl, struct firehose_op *patch)
 {
 	xmlNode *root;
@@ -1153,6 +1301,11 @@ static int firehose_execute_ops(struct qdl_device *qdl, struct list_head *ops)
 			break;
 		case FIREHOSE_OP_READ:
 			ret = firehose_read_op(qdl, op);
+			if (ret < 0)
+				return ret;
+			break;
+		case FIREHOSE_OP_GET_SHA256_DIGEST:
+			ret = firehose_getsha256digest(qdl, op);
 			if (ret < 0)
 				return ret;
 			break;

--- a/firehose.h
+++ b/firehose.h
@@ -18,6 +18,7 @@ enum firehose_op_type {
 	FIREHOSE_OP_PATCH,
 	FIREHOSE_OP_SET_BOOTABLE,
 	FIREHOSE_OP_RESET,
+	FIREHOSE_OP_GET_SHA256_DIGEST,
 };
 
 struct firehose_op {

--- a/gpt.c
+++ b/gpt.c
@@ -293,7 +293,8 @@ int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops)
 	list_for_each_entry(op, ops, node) {
 		if (op->type != FIREHOSE_OP_PROGRAM &&
 		    op->type != FIREHOSE_OP_ERASE &&
-		    op->type != FIREHOSE_OP_READ)
+		    op->type != FIREHOSE_OP_READ &&
+		    op->type != FIREHOSE_OP_GET_SHA256_DIGEST)
 			continue;
 
 		if (!op->gpt_partition)

--- a/qdl.c
+++ b/qdl.c
@@ -42,6 +42,7 @@ enum {
 	QDL_CMD_WRITE,
 	QDL_CMD_ERASE,
 	QDL_CMD_FLASH,
+	QDL_CMD_SHA256,
 };
 
 bool qdl_debug;
@@ -61,6 +62,8 @@ static int detect_type(const char *verb)
 		return QDL_CMD_ERASE;
 	if (!strcmp(verb, "flash"))
 		return QDL_CMD_FLASH;
+	if (!strcmp(verb, "sha256"))
+		return QDL_CMD_SHA256;
 
 	if (access(verb, F_OK)) {
 		ux_err("%s is not a verb and not a XML file\n", verb);
@@ -446,6 +449,7 @@ static void print_usage(FILE *out)
 	fprintf(out, "Usage: %s [options] <prog.mbn> (<program-xml> | <patch-xml> | <read-xml>)...\n", __progname);
 	fprintf(out, "       %s [options] <prog.mbn> ((read | write) <address> <binary>)...\n", __progname);
 	fprintf(out, "       %s [options] <prog.mbn> (erase <address>)...\n", __progname);
+	fprintf(out, "       %s [options] <prog.mbn> (sha256 <address>)...\n", __progname);
 	fprintf(out, "       %s list\n", __progname);
 	fprintf(out, "       %s ramdump [--debug] [-o <ramdump-path>] [<segment-filter>,...]\n", __progname);
 	fprintf(out, " -d, --debug\t\t\tPrint detailed debug info\n");
@@ -891,6 +895,14 @@ static int qdl_flash(int argc, char **argv)
 			ret = erase_cmd_add(&firehose_ops, argv[optind + 1]);
 			if (ret < 0)
 				errx(1, "failed to add erase command");
+			optind += 1;
+			break;
+		case QDL_CMD_SHA256:
+			if (optind + 1 >= argc)
+				errx(1, "sha256 command missing address");
+			ret = sha256_cmd_add(&firehose_ops, argv[optind + 1]);
+			if (ret < 0)
+				errx(1, "failed to add sha256 command");
 			optind += 1;
 			break;
 		case QDL_CMD_FLASH:

--- a/read.c
+++ b/read.c
@@ -109,3 +109,38 @@ int read_cmd_add(struct list_head *ops, const char *address, const char *filenam
 
 	return 0;
 }
+
+int sha256_cmd_add(struct list_head *ops, const char *address)
+{
+	struct firehose_op *op;
+	unsigned int start_sector;
+	unsigned int num_sectors;
+	char *gpt_partition;
+	int partition;
+	char buf[20];
+	int ret;
+
+	ret = parse_storage_address(address, &partition, &start_sector, &num_sectors, &gpt_partition);
+	if (ret < 0)
+		return ret;
+
+	if (num_sectors == 0 && !gpt_partition) {
+		ux_err("sha256 command without length specifier not supported\n");
+		return -1;
+	}
+
+	op = firehose_alloc_op(FIREHOSE_OP_GET_SHA256_DIGEST);
+	if (!op)
+		return -1;
+
+	op->sector_size = 0;
+	op->partition = partition;
+	op->num_sectors = num_sectors;
+	sprintf(buf, "%u", start_sector);
+	op->start_sector = strdup(buf);
+	op->gpt_partition = gpt_partition;
+
+	list_append(ops, &op->node);
+
+	return 0;
+}

--- a/read.h
+++ b/read.h
@@ -11,5 +11,6 @@ struct firehose_op;
 
 int read_op_load(struct list_head *ops, const char *read_op_file, const char *incdir);
 int read_cmd_add(struct list_head *ops, const char *address, const char *filename);
+int sha256_cmd_add(struct list_head *ops, const char *address);
 
 #endif


### PR DESCRIPTION
Expose the FIREHOSE_OP_GET_SHA256_DIGEST primitive as a user-facing
verb. The syntax mirrors the existing read / write / erase verbs and
reuses parse_storage_address(), so addresses can be expressed as
`<P>/<S>+<L>`, by GPT partition name, or any of the other supported
forms.

Each invocation prints one lowercase 64-character hex digest per region
to stdout, so the output can be diffed against a sha256sum(1) line or
piped into other tooling without further parsing.

Typical use is verifying that what is on the device matches a known
local image - useful on shared bench machines where multiple people
flash the same board:

```bash
$ qdl prog_firehose_ddr.elf sha256 xbl_a
...
c288e50a94687a130a64db608c83678777ce5e7f9229248696c6f0dc41406cc9

$ qdl prog_firehose_ddr.elf read xbl_a xbl_a.bin
...
$ sha256sum xbl_a.bin
c288e50a94687a130a64db608c83678777ce5e7f9229248696c6f0dc41406cc9  xbl_a.bin
```

Multiple sha256 verbs can be chained in a single invocation, with one
digest line emitted per region in order.

Link: https://github.com/linux-msm/qdl/issues/237