### PR TITLE
github: Include missing build artifacts in Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,8 @@ jobs:
           Copy-Item (Join-Path $BIN_DIR "libzip.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "liblzma-5.dll") $DistDir
           Copy-Item (Join-Path $BIN_DIR "libiconv-2.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libbz2-1.dll") $DistDir
+          Copy-Item (Join-Path $BIN_DIR "libzstd.dll") $DistDir
 
           Copy-Item "./build/qdl.exe" $DistDir
 


### PR DESCRIPTION
The dependencies has been extended, but necessary dll files was not added to the list of artifacts. Fix this to make it possible to run the artifacts.