### PR TITLE
qdl: add --skipblock=sha256 to skip programs already on flash

### DIFF
--- a/file.c
+++ b/file.c
@@ -151,6 +151,34 @@ ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len)
 	return -1;
 }
 
+/*
+ * Loop around qdl_file_read() until @len bytes have been read into
+ * @buf. Returns the number of bytes read, which equals @len for full
+ * reads and is less than @len only on EOF; negative on a read error.
+ *
+ * Wraps the underlying read() / zip_fread() so callers that don't
+ * tolerate short reads don't have to roll their own loop. The bytes
+ * past the returned length are left untouched - callers that need a
+ * fixed-size buffer must zero them themselves.
+ */
+ssize_t qdl_file_read_exact(struct qdl_file *file, void *buf, size_t len)
+{
+	uint8_t *p = buf;
+	size_t got = 0;
+	ssize_t n;
+
+	while (got < len) {
+		n = qdl_file_read(file, p + got, len - got);
+		if (n < 0)
+			return -1;
+		if (n == 0)
+			break;
+		got += (size_t)n;
+	}
+
+	return (ssize_t)got;
+}
+
 off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence)
 {
 	switch (file->type) {

--- a/file.h
+++ b/file.h
@@ -31,6 +31,7 @@ void *qdl_file_load(struct qdl_file *file, size_t *len);
 void qdl_file_close(struct qdl_file *file);
 size_t qdl_file_getsize(struct qdl_file *file);
 ssize_t qdl_file_read(struct qdl_file *file, void *buf, size_t len);
+ssize_t qdl_file_read_exact(struct qdl_file *file, void *buf, size_t len);
 off_t qdl_file_seek(struct qdl_file *file, off_t offset, int whence);
 
 int qdl_zip_open(const char *filename, struct qdl_zip **__qdl_zip);

--- a/firehose.c
+++ b/firehose.c
@@ -595,6 +595,88 @@ out:
 	return ret == FIREHOSE_ACK ? 0 : -1;
 }
 
+static int firehose_getsha256digest(struct qdl_device *qdl, struct firehose_op *op);
+
+/*
+ * Decide whether the @program op can be skipped because its bytes are
+ * already on flash. Returns 1 if the program path can be bypassed, 0
+ * to defer to the normal write. @buf is a scratch buffer of size
+ * qdl->max_payload_size owned by the caller.
+ *
+ * Hash the bytes that would have been written, ask the device for the
+ * digest of the same region, and compare. Any failure on the way (read error,
+ * digest query failure, mismatch) returns 0 so the caller proceeds with
+ * the normal program flow; the file pointer is restored by the
+ * qdl_file_seek() at the top of the write loop.
+ *
+ * Restricted to non-sparse, non-NAND programs with VIP disabled:
+ *   - Sparse chunks would each need their own digest; v1 keeps them on
+ *     the normal program path.
+ *   - NAND has spare/OOB bytes whose semantics differ across
+ *     programmers.
+ *   - <getsha256digest> is not part of pre-built VIP digest tables.
+ */
+static int qdl_should_skipblock(struct qdl_device *qdl,
+				struct firehose_op *program,
+				struct qdl_file *file,
+				unsigned int num_sectors,
+				unsigned int sector_size,
+				void *buf)
+{
+	uint8_t local_digest[SHA256_DIGEST_LENGTH];
+	size_t total = (size_t)num_sectors * sector_size;
+	struct firehose_op digest_op;
+	size_t hashed = 0;
+	SHA2_CTX ctx;
+	ssize_t hn;
+
+	if (qdl->skipblock_mode != QDL_SKIPBLOCK_SHA256 ||
+	    program->sparse ||
+	    program->is_nand ||
+	    qdl->vip_data.state != VIP_DISABLED)
+		return 0;
+
+	SHA256Init(&ctx);
+	qdl_file_seek(file, (off_t)program->file_offset * sector_size, SEEK_SET);
+
+	while (hashed < total) {
+		size_t want = MIN(qdl->max_payload_size, total - hashed);
+
+		hn = qdl_file_read_exact(file, buf, want);
+		if (hn < 0)
+			return 0;
+		if (hn == 0 || (size_t)hn < want) {
+			/*
+			 * EOF before completing the requested region: the
+			 * device's digest is over `total` bytes from flash,
+			 * so we can't construct a matching local digest.
+			 * Defer to the normal program path.
+			 */
+			if (hn > 0)
+				SHA256Update(&ctx, buf, hn);
+			return 0;
+		}
+		SHA256Update(&ctx, buf, hn);
+		hashed += (size_t)hn;
+	}
+
+	SHA256Final(local_digest, &ctx);
+
+	digest_op = (struct firehose_op){
+		.type = FIREHOSE_OP_GET_SHA256_DIGEST,
+		.sector_size = sector_size,
+		.num_sectors = num_sectors,
+		.partition = program->partition,
+		.start_sector = program->start_sector,
+	};
+
+	if (firehose_getsha256digest(qdl, &digest_op) == 0 &&
+	    !memcmp(local_digest, digest_op.digest, SHA256_DIGEST_LENGTH))
+		return 1;
+
+	return 0;
+}
+
 static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 {
 	unsigned int num_sectors;
@@ -649,6 +731,13 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	if (!buf) {
 		ux_err("failed to allocate sector buffer\n");
 		goto err_close_fd;
+	}
+
+	if (qdl_should_skipblock(qdl, program, &file, num_sectors, sector_size, buf)) {
+		ux_info("skipped \"%s\" (sha256 match)\n", program->label);
+		free(buf);
+		qdl_file_close(&file);
+		return 0;
 	}
 
 	doc = xmlNewDoc((xmlChar *)"1.0");
@@ -717,14 +806,21 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 		chunk_size = MIN(qdl->max_payload_size / sector_size, left);
 
 		if (!program->sparse || program->sparse_chunk_type != CHUNK_TYPE_FILL) {
-			n = qdl_file_read(&file, buf, chunk_size * sector_size);
+			n = qdl_file_read_exact(&file, buf, chunk_size * sector_size);
 			if (n < 0) {
 				ux_err("failed to read %s\n", program->filename);
 				goto err_free_doc;
 			}
 
-			if ((size_t)n < qdl->max_payload_size)
-				memset(buf + n, 0, qdl->max_payload_size - n);
+			/*
+			 * qdl_file_read_exact() only returns short on true
+			 * EOF. The wire protocol expects exactly
+			 * chunk_size * sector_size bytes, so zero-pad the
+			 * residue (which is at most the trailing partial
+			 * sector of the file).
+			 */
+			if ((size_t)n < chunk_size * sector_size)
+				memset(buf + n, 0, chunk_size * sector_size - n);
 		}
 
 		vip_gen_chunk_update(qdl, buf, chunk_size * sector_size);

--- a/firehose.c
+++ b/firehose.c
@@ -154,14 +154,9 @@ static bool extract_sha256_hex(const char *str, uint8_t digest[SHA256_DIGEST_LEN
 	return false;
 }
 
-struct firehose_sha256_result {
-	uint8_t digest[SHA256_DIGEST_LENGTH];
-	bool valid;
-};
-
 static int firehose_sha256_parser(xmlNode *node, void *data, bool *rawmode)
 {
-	struct firehose_sha256_result *result = data;
+	struct firehose_op *op = data;
 	xmlChar *value;
 	int ret;
 
@@ -170,8 +165,8 @@ static int firehose_sha256_parser(xmlNode *node, void *data, bool *rawmode)
 		if (!value)
 			return -EINVAL;
 
-		if (!result->valid && extract_sha256_hex((const char *)value, result->digest))
-			result->valid = true;
+		if (!op->digest_valid && extract_sha256_hex((const char *)value, op->digest))
+			op->digest_valid = true;
 
 		ux_log("LOG: %s\n", value);
 		xmlFree(value);
@@ -185,7 +180,7 @@ static int firehose_sha256_parser(xmlNode *node, void *data, bool *rawmode)
 	 * the response itself rather than emitting it via <log>. Try a few
 	 * known attribute names.
 	 */
-	if (!result->valid) {
+	if (!op->digest_valid) {
 		static const char * const attrs[] = { "Digest", "SHA256", "sha256" };
 		size_t i;
 
@@ -193,10 +188,10 @@ static int firehose_sha256_parser(xmlNode *node, void *data, bool *rawmode)
 			value = xmlGetProp(node, (xmlChar *)attrs[i]);
 			if (!value)
 				continue;
-			if (extract_sha256_hex((const char *)value, result->digest))
-				result->valid = true;
+			if (extract_sha256_hex((const char *)value, op->digest))
+				op->digest_valid = true;
 			xmlFree(value);
-			if (result->valid)
+			if (op->digest_valid)
 				break;
 		}
 	}
@@ -946,15 +941,20 @@ static int firehose_read_op(struct qdl_device *qdl, struct firehose_op *op)
 	return ret;
 }
 
+/*
+ * Issue a <getsha256digest> request and store the result on @op. On
+ * success op->digest is populated and op->digest_valid is set; callers
+ * that want to surface the digest (the qdl `sha256` subcommand prints
+ * it after firehose_run() returns; the --skipblock=sha256 fast-path
+ * compares it against a locally-computed digest) consume the field
+ * themselves.
+ */
 static int firehose_getsha256digest(struct qdl_device *qdl, struct firehose_op *op)
 {
-	struct firehose_sha256_result result = { 0 };
 	unsigned int sector_size;
 	xmlNode *root;
 	xmlNode *node;
 	xmlDoc *doc;
-	char hex[SHA256_DIGEST_STRING_LENGTH];
-	size_t i;
 	int ret;
 
 	sector_size = op->sector_size ? : qdl->sector_size;
@@ -971,13 +971,15 @@ static int firehose_getsha256digest(struct qdl_device *qdl, struct firehose_op *
 	if (qdl->slot != UINT_MAX)
 		xml_setpropf(node, "slot", "%u", qdl->slot);
 
+	op->digest_valid = false;
+
 	ret = firehose_write(qdl, doc);
 	if (ret < 0) {
 		ux_err("failed to send getsha256digest command\n");
 		goto out;
 	}
 
-	ret = firehose_read(qdl, 30000, firehose_sha256_parser, &result);
+	ret = firehose_read(qdl, 30000, firehose_sha256_parser, op);
 	if (ret != FIREHOSE_ACK) {
 		ux_err("getsha256digest failed for %s+0x%x\n",
 		       op->start_sector, op->num_sectors);
@@ -985,19 +987,12 @@ static int firehose_getsha256digest(struct qdl_device *qdl, struct firehose_op *
 		goto out;
 	}
 
-	if (!result.valid) {
+	if (!op->digest_valid) {
 		ux_err("getsha256digest returned no digest for %s+0x%x\n",
 		       op->start_sector, op->num_sectors);
 		ret = -1;
 		goto out;
 	}
-
-	for (i = 0; i < SHA256_DIGEST_LENGTH; i++)
-		snprintf(hex + i * 2, 3, "%02x", result.digest[i]);
-	hex[SHA256_DIGEST_STRING_LENGTH - 1] = '\0';
-
-	printf("%s\n", hex);
-	fflush(stdout);
 
 	ret = 0;
 

--- a/firehose.h
+++ b/firehose.h
@@ -8,6 +8,7 @@
 
 #include "list.h"
 #include "qdl.h"
+#include "sha2.h"
 
 enum firehose_op_type {
 	FIREHOSE_OP_NONE,
@@ -58,6 +59,10 @@ struct firehose_op {
 
 	/* configure */
 	enum qdl_storage_type storage_type;
+
+	/* getsha256digest */
+	uint8_t digest[SHA256_DIGEST_LENGTH];
+	bool digest_valid;
 };
 
 struct firehose_op *firehose_alloc_op(int type);

--- a/qdl.c
+++ b/qdl.c
@@ -488,6 +488,8 @@ static void print_usage(FILE *out)
 	fprintf(out, " -D, --vip-table-path=T\t\tUse digest tables in the T folder for VIP\n");
 	fprintf(out, " -R, --skip-reset\t\tDo not send the reset command after flashing completes\n");
 	fprintf(out, "     --backend=B\t\tSelect device backend B: <auto|usb|qud> (default: auto)\n");
+	fprintf(out, "     --skipblock=M\t\tUse readback mechanism M to skip <program> entries already on flash;\n");
+	fprintf(out, "                 \t\tM: <none|sha256> (default: none)\n");
 	fprintf(out, " -h, --help\t\t\tPrint this usage info\n");
 	fprintf(out, " <program-xml>\t\txml file containing <program> or <erase> directives\n");
 	fprintf(out, " <patch-xml>\t\txml file containing <patch> directives\n");
@@ -539,6 +541,7 @@ static int qdl_list(FILE *out)
 /* Long-only option ids, distinct from any short option character. */
 enum {
 	OPT_BACKEND = 0x100,
+	OPT_SKIPBLOCK,
 };
 
 static int qdl_ramdump(int argc, char **argv)
@@ -865,6 +868,7 @@ static int qdl_flash(int argc, char **argv)
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
 	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_AUTO;
+	enum qdl_skipblock_mode skipblock_mode = QDL_SKIPBLOCK_NONE;
 
 	static struct option options[] = {
 		{"debug", no_argument, 0, 'd'},
@@ -882,6 +886,7 @@ static int qdl_flash(int argc, char **argv)
 		{"slot", required_argument, 0, 'T'},
 		{"skip-reset", no_argument, 0, 'R'},
 		{"backend", required_argument, 0, OPT_BACKEND},
+		{"skipblock", required_argument, 0, OPT_SKIPBLOCK},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
@@ -943,6 +948,15 @@ static int qdl_flash(int argc, char **argv)
 			    decode_backend(optarg, &qdl_dev_type) < 0)
 				errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
 			break;
+		case OPT_SKIPBLOCK:
+			if (!strcmp(optarg, "none"))
+				skipblock_mode = QDL_SKIPBLOCK_NONE;
+			else if (!strcmp(optarg, "sha256"))
+				skipblock_mode = QDL_SKIPBLOCK_SHA256;
+			else
+				errx(1, "unknown --skipblock mode \"%s\", valid options are none and sha256",
+				     optarg);
+			break;
 		case 'h':
 			print_usage(stdout);
 			return 0;
@@ -965,6 +979,7 @@ static int qdl_flash(int argc, char **argv)
 	}
 
 	qdl->slot = slot;
+	qdl->skipblock_mode = skipblock_mode;
 
 	if (vip_table_path) {
 		if (vip_generate_dir)

--- a/qdl.c
+++ b/qdl.c
@@ -809,6 +809,42 @@ static int qdl_determine_bootable(struct list_head *ops)
 	return 0;
 }
 
+/*
+ * Walk the firehose op list and emit one hex line per
+ * FIREHOSE_OP_GET_SHA256_DIGEST entry. firehose_run() fills op->digest;
+ * formatting and printing live here so firehose.c stays out of the
+ * user-facing output policy.
+ *
+ * If the request shipped but the device returned no digest
+ * (digest_valid stayed false), surface that to the user instead of
+ * silently skipping the region.
+ */
+static void print_sha256_results(struct list_head *ops)
+{
+	struct firehose_op *op;
+
+	list_for_each_entry(op, ops, node) {
+		char hex[SHA256_DIGEST_STRING_LENGTH];
+		size_t i;
+
+		if (op->type != FIREHOSE_OP_GET_SHA256_DIGEST)
+			continue;
+
+		if (!op->digest_valid) {
+			ux_err("no sha256 digest returned for %s+0x%x\n",
+			       op->start_sector, op->num_sectors);
+			continue;
+		}
+
+		for (i = 0; i < SHA256_DIGEST_LENGTH; i++)
+			snprintf(hex + i * 2, 3, "%02x", op->digest[i]);
+		hex[SHA256_DIGEST_STRING_LENGTH - 1] = '\0';
+
+		printf("%s\n", hex);
+		fflush(stdout);
+	}
+}
+
 static int qdl_flash(int argc, char **argv)
 {
 	enum qdl_storage_type storage_type = QDL_STORAGE_UFS;
@@ -1080,6 +1116,8 @@ static int qdl_flash(int argc, char **argv)
 		ret = firehose_run(qdl, &firehose_ops);
 	if (ret < 0)
 		goto out_cleanup;
+
+	print_sha256_results(&firehose_ops);
 
 out_cleanup:
 	if (qdl) {

--- a/qdl.h
+++ b/qdl.h
@@ -67,12 +67,18 @@ enum qdl_storage_type {
 	QDL_STORAGE_SPINOR,
 };
 
+enum qdl_skipblock_mode {
+	QDL_SKIPBLOCK_NONE,
+	QDL_SKIPBLOCK_SHA256,
+};
+
 struct qdl_device {
 	enum QDL_DEVICE_TYPE dev_type;
 	int fd;
 	size_t max_payload_size;
 	size_t sector_size;
 	enum qdl_storage_type current_storage_type;
+	enum qdl_skipblock_mode skipblock_mode;
 	unsigned int slot;
 
 	int (*open)(struct qdl_device *qdl, const char *serial);


### PR DESCRIPTION
Automated flashing pipelines often re-program identical content on every
run, which dominates total flash time on slow storage like spinor. With
the <getsha256digest> primitive now exposed, qdl can ask the device for
the SHA-256 of the target region before each <program> and skip the
write when it already matches what would have been sent.

Add `--skipblock=<none|sha256>`, defaulting to none. When sha256 is
selected, firehose_program() hashes the bytes it would otherwise stream
to the device - reading `num_partition_sectors * SECTOR_SIZE_IN_BYTES`
from the file with zero-padding for the trailing partial sector, exactly
matching what the existing chunked write path puts on the wire - then
asks the device for the digest of the same region via
`firehose_getsha256digest()`, reusing the op->digest field that the
sha256 subcommand path also reads. On a match, the `<program>` is skipped
entirely and "skipped \"<label>\" (sha256 match)" is logged in place of
the usual flashed-at-rate line.

The optimization is gated on three conditions, all enforced silently:

  - !program->sparse: each sparse chunk would need its own digest;
    keeping sparse images on the normal program path avoids per-chunk
    round trips and the bookkeeping that would come with them.
  - !program->is_nand: NAND spare/OOB byte semantics differ across
    programmers, so the digest the device returns is not guaranteed to
    correspond to the bytes qdl would compute locally.
  - VIP disabled: `<getsha256digest>` is not part of pre-built VIP
    digest tables, so issuing it under VIP would cause a hash mismatch
    on the device.

Any failure on the optimization path - file read error, query failure,
digest absent, or digest mismatch - falls through to the normal program
flow. The file position is restored unconditionally by the existing
`qdl_file_seek()` at the top of the write loop, so the fall-through path
is byte-identical to `--skipblock=none`.

Hash collisions are theoretically possible, so the default stays at
none. sha256 is offered for developer-facing iteration where collision
risk is acceptable and the latency savings are large.

Link: https://github.com/linux-msm/qdl/issues/237