### PR TITLE
tree: drop unused .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,4 +1,0 @@
-[gerrit]
-host=review.linaro.org
-port=29418
-project=landing-teams/working/qualcomm/qdl


### PR DESCRIPTION
The .gitreview file configured git-review to push changes for code review to a Gerrit instance at review.linaro.org. The project's review workflow has since moved to GitHub pull requests against github.com/linux-msm/qdl, and the Linaro Gerrit project is no longer used. Remove the stale config so contributors are not misled into sending patches to an abandoned review server.