### PR TITLE
firehose: detect VIP mode mismatch from programmer startup logs

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -37,6 +37,33 @@ enum {
 	FIREHOSE_NAK,
 };
 
+/*
+ * Substring emitted by the Firehose programmer's startup logs when VIP is
+ * active on-device (e.g. "INFO: VIP is enabled, receiving the signed table
+ * of size 8192"). Matching a stable prefix avoids coupling to the trailing
+ * byte count, which varies per programmer build.
+ */
+#define VIP_PROGRAMMER_MARKER "VIP is enabled, receiving the signed table"
+
+static void firehose_check_vip_marker(struct qdl_device *qdl, xmlNode *node)
+{
+	xmlChar *value;
+
+	if (qdl->vip_data.programmer_requires_vip)
+		return;
+	if (xmlStrcmp(node->name, (xmlChar *)"log") != 0)
+		return;
+
+	value = xmlGetProp(node, (xmlChar *)"value");
+	if (!value)
+		return;
+
+	if (strstr((const char *)value, VIP_PROGRAMMER_MARKER))
+		qdl->vip_data.programmer_requires_vip = true;
+
+	xmlFree(value);
+}
+
 static void xml_setpropf(xmlNode *node, const char *attr, const char *fmt, ...)
 {
 	xmlChar buf[128];
@@ -306,6 +333,8 @@ static int firehose_read(struct qdl_device *qdl, int timeout_ms,
 			node = firehose_response_parse(start, chunk, &error);
 			if (!node)
 				return error;
+
+			firehose_check_vip_marker(qdl, node);
 
 			ret = response_parser(node, data, &rawmode);
 			xmlFreeDoc(node->doc);
@@ -1343,6 +1372,21 @@ static int firehose_detect_and_configure(struct qdl_device *qdl,
 	 */
 	if (qdl->vip_data.state != VIP_DISABLED) {
 		firehose_read(qdl, timeout_s * 1000, firehose_generic_parser, NULL);
+
+		/*
+		 * The startup-log drain above is our only chance to learn
+		 * whether the programmer expects a VIP table before configure
+		 * is sent.  configure goes through firehose_write(), which
+		 * unconditionally pushes the signed table when state is not
+		 * VIP_DISABLED; if the programmer isn't in VIP mode it will
+		 * try to parse those bytes as XML and reject the configure.
+		 * Demote VIP here so the table is never sent.
+		 */
+		if (!qdl->vip_data.programmer_requires_vip) {
+			ux_info("WARNING: --vip-table-path was provided but programmer did not announce VIP; continuing without VIP\n");
+			qdl->vip_data.state = VIP_DISABLED;
+		}
+
 		ret = firehose_try_configure(qdl, false, storage);
 		if (ret != FIREHOSE_ACK) {
 			ux_err("configure request failed\n");
@@ -1355,6 +1399,17 @@ static int firehose_detect_and_configure(struct qdl_device *qdl,
 	timeradd(&now, &timeout, &timeout);
 	for (;;) {
 		ret = firehose_try_configure(qdl, skip_storage_init, storage);
+
+		/*
+		 * If the programmer's startup logs announced that VIP is
+		 * active but no --vip-table-path was provided, bail out now
+		 * rather than burning the full configure timeout waiting for
+		 * a signed table that will never be sent.
+		 */
+		if (qdl->vip_data.programmer_requires_vip) {
+			ux_err("programmer requires VIP, but no --vip-table-path was provided\n");
+			return -1;
+		}
 
 		if (ret == FIREHOSE_ACK) {
 			break;

--- a/vip.h
+++ b/vip.h
@@ -41,6 +41,13 @@ struct vip_transfer_data {
 	size_t chained_table_size;
 	bool fh_parse_status;
 	bool sending_table; /* set during vip_transfer_send_raw() */
+	/*
+	 * Set when the programmer's startup logs announce that VIP is
+	 * active (it expects a signed digest table). Lets the host detect
+	 * a mismatch between the device's policy and the --vip-table-path
+	 * option before the configure handshake stalls.
+	 */
+	bool programmer_requires_vip;
 };
 
 int vip_transfer_init(struct qdl_device *qdl, const char *vip_table_path);


### PR DESCRIPTION
Both directions of host/device VIP misconfiguration currently surface as opaque failures that operators in the field have to diagnose from raw byte-stream errors, when the right answer is fully derivable from the programmer's own startup logs. Do the detection here so customers don't have to debug this manually on every new platform.

The Firehose programmer announces VIP activation by emitting an "INFO: VIP is enabled, receiving the signed table of size N" log line during startup. Watch for that marker in firehose_read() and use it in firehose_detect_and_configure() to handle the two mismatch cases:

  - --vip-table-path missing, programmer requires VIP: previously qdl would send configure, the programmer would wait silently for a signed table that never comes, and the user would see only a generic 5s configure timeout. Now bail out immediately with an explicit error pointing at the missing option.

  - --vip-table-path given, programmer not in VIP mode: previously qdl would push the signed digest table at the programmer, which tried to parse those binary bytes as XML and bailed out with "Failed to parse xml at offset 4090, 4096". Now detect the absence of the marker after the startup-log drain, print a warning, demote vip_data.state to VIP_DISABLED so the table is never sent, and continue flashing normally.