### PR TITLE
program: Cast away const when freeing start_sector in erase

### DIFF
--- a/program.c
+++ b/program.c
@@ -46,14 +46,14 @@ static int load_erase_tag(struct list_head *ops, xmlNode *node, bool is_nand)
 
 	if (errors) {
 		ux_err("errors while parsing erase tag\n");
-		free(program->start_sector);
+		free((void *)program->start_sector);
 		free(program);
 		return -EINVAL;
 	}
 
 	if (!program->num_sectors) {
 		ux_err("erase tag with num_sectors=0 not allowed\n");
-		free(program->start_sector);
+		free((void *)program->start_sector);
 		free(program);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The recently added free() calls in load_erase_tag() pass program->start_sector directly to free(), but the field is declared as const char * in struct firehose_op. GCC emits a -Wdiscarded-qualifiers warning for both call sites.

Cast through (void *) to match the pattern already used at the other free sites for the same field (program.c, patch.c, firehose.c).