### PR TITLE
meson: don't require git when overriding the version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,10 +5,18 @@ project('qdl', 'c',
 )
 
 # Determine version
-git_check_ver = run_command('git', 'describe', '--dirty', '--always', '--tags', check: false).stdout().strip()
-git_v = git_check_ver != '' ? git_check_ver : 'unknown-version'
 env_v = get_option('VERSION')
-ver   = env_v != '' ? env_v : git_v
+if env_v != ''
+  ver = env_v
+else
+  git = find_program('git', required: false)
+  git_v = 'unknown-version'
+  if git.found()
+    git_check_ver = run_command(git, 'describe', '--dirty', '--always', '--tags', check: false).stdout().strip()
+    git_v = git_check_ver != '' ? git_check_ver : git_v
+  endif
+  ver = git_v
+endif
 
 # Dependencies
 libusb_dep = dependency('libusb-1.0')


### PR DESCRIPTION
The build system determines the version from the output of `git describe` then allowing it to be overwritten from the `VERSION` meson configuration option.

This is the wrong way around for build environments where the git binary (or even the upstream VCS) is unavailable, such as Debian where packages are built from source tarballs.

To allow build environments without git or VCS metadata to inject their own version, or even just build without needing git, rework the order of the version determinism logic in the build system:

 1. Use the value of the `VERSION` meson configuratuin option (if set).
 2. Use the output of `git describe` (if the git binary is found).
 3. Fallback to `unknown-version` in all other cases.

This avoids calling a potentially missing git binary and still lets the build system pick the version up from the VERSION option when a git checkout may not be possible.