### PR TITLE
contents: Don't ignore ignored entries

### DIFF
--- a/contents.c
+++ b/contents.c
@@ -112,22 +112,6 @@ out_free_str:
 	return ret;
 }
 
-static bool contents_entry_is_ignored(xmlNode *node)
-{
-	xmlChar *ignore;
-	bool ret;
-
-	ignore = xmlGetProp(node, (xmlChar *)"ignore");
-	if (!ignore)
-		return false;
-
-	ret = !xmlStrcmp(ignore, (xmlChar *)"true");
-
-	xmlFree(ignore);
-
-	return ret;
-}
-
 static int contents_parse_pf(struct contents *contents, xmlNode *node)
 {
 	char **new_flavors;
@@ -334,9 +318,6 @@ static int contents_parse_entry(struct contents *contents, xmlNode *node,
 		ux_err("entry has no build root path in contents.xml\n");
 		return -1;
 	}
-
-	if (contents_entry_is_ignored(node))
-		return 0;
 
 	file_type = contents_detect_file_type(node, &firehose_type);
 	storage = contents_detect_storage_type(node);

--- a/tests/test_contents_xml.c
+++ b/tests/test_contents_xml.c
@@ -404,7 +404,7 @@ static void test_load_xml_parses_file_entries(void **state)
 
 	init_contents(&contents);
 	assert_int_equal(contents_load_xml(&contents, fixture->contents_xml), 0);
-	assert_int_equal(count_entries(&contents), 6);
+	assert_int_equal(count_entries(&contents), 7);
 
 	assert_entry(fixture, &contents, "programmer.xml",
 		     CONTENTS_FILE_PROGRAMMER_XML, QDL_STORAGE_UNKNOWN, NULL, 2,
@@ -424,18 +424,20 @@ static void test_load_xml_parses_file_entries(void **state)
 	assert_entry(fixture, &contents, "spinor_rawprogram.xml",
 		     CONTENTS_FILE_PROGRAM, QDL_STORAGE_SPINOR, "flavor_b", 0,
 		     "spinor/spinor_rawprogram.xml");
+	assert_entry(fixture, &contents, "ignored.bin",
+		     CONTENTS_FILE_OTHER, QDL_STORAGE_UFS, NULL, 0,
+		     "ignored/ignored.bin");
 
 	free_contents(&contents);
 }
 
-static void test_load_xml_skips_ignored_and_wildcards(void **state)
+static void test_load_xml_skips_wildcards(void **state)
 {
 	struct xml_fixture *fixture = *state;
 	struct contents contents = {};
 
 	init_contents(&contents);
 	assert_int_equal(contents_load_xml(&contents, fixture->contents_xml), 0);
-	assert_null(find_entry(&contents, "ignored.bin"));
 	assert_null(find_entry(&contents, "*.bin"));
 
 	free_contents(&contents);
@@ -533,7 +535,7 @@ int main(void)
 						setup_xml_fixture, teardown_xml_fixture),
 		cmocka_unit_test_setup_teardown(test_load_xml_parses_file_entries,
 						setup_xml_fixture, teardown_xml_fixture),
-		cmocka_unit_test_setup_teardown(test_load_xml_skips_ignored_and_wildcards,
+		cmocka_unit_test_setup_teardown(test_load_xml_skips_wildcards,
 						setup_xml_fixture, teardown_xml_fixture),
 		cmocka_unit_test_setup_teardown(test_load_xml_rejects_non_contents_document,
 						setup_xml_fixture, teardown_xml_fixture),


### PR DESCRIPTION
While it would make sense to ignore entries explicitly marked to be ignored, some builds apparently depend on these ignored files.

Drop the check for ignored to make it possible to flash those builds.