### PR TITLE
firehose: report progress through the skipblock fast-path

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -672,6 +672,9 @@ static int qdl_should_skipblock(struct qdl_device *qdl,
 	    qdl->vip_data.state != VIP_DISABLED)
 		return 0;
 
+	ux_info("hashing \"%s\" locally (%zu MiB)...\n",
+		program->label, total >> 20);
+
 	SHA256Init(&ctx);
 	qdl_file_seek(file, (off_t)program->file_offset * sector_size, SEEK_SET);
 
@@ -720,9 +723,14 @@ static int qdl_should_skipblock(struct qdl_device *qdl,
 		.start_sector = program->start_sector,
 	};
 
+	ux_info("requesting flash digest for \"%s\"...\n", program->label);
+
 	if (firehose_getsha256digest(qdl, &digest_op) == 0 &&
 	    !memcmp(local_digest, digest_op.digest, SHA256_DIGEST_LENGTH))
 		return 1;
+
+	ux_info("sha256 mismatch for \"%s\", flashing partition\n",
+		program->label);
 
 	return 0;
 }


### PR DESCRIPTION
The --skipblock=sha256 fast-path could appear to hang before a large <program> such as rootfs: qdl_should_skipblock() reads the whole file to build a local SHA-256, then waits on the device's <getsha256digest> over the same flash region, all without printing anything. On a multi-hundred MiB partition both steps take a noticeable while and look like a stall.

Narrate each phase so the wait is explained:

 - "hashing ... locally" before the local read/hash,
 - "requesting flash digest" before the device digest query,
 - "sha256 mismatch ..., flashing partition" when the digests differ and the partition falls back to the normal program path.

The messages are emitted only once the skipblock guards have passed, so runs with skipblock disabled or not applicable (sparse/NAND/VIP) stay quiet as before. The existing "skipped ... (sha256 match)" message covers the match case.