### PR TITLE
[RFC] github: request reviews from qdl-maintainers via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @linux-msm/qdl-maintainers


### PR DESCRIPTION
Add a CODEOWNERS file so every pull request automatically requests a review from the @linux-msm/qdl-maintainers team, instead of relying on contributors to add reviewers by hand. The wildcard pattern covers the whole tree; ownership can later be narrowed per path if needed.