### PR TITLE
README: describe how to use QDL from WSL2 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,58 @@ or those with locked bootloaders.
 
 Please consult your device’s documentation for instructions on how to enter EDL mode.
 
+### Flashing from WSL2 (usbipd-win)
+
+On Windows, QDL can run inside a WSL2 distribution, but WSL2 does not see USB
+devices by default — they must be forwarded from the Windows host with
+[usbipd-win](https://github.com/dorssel/usbipd-win). Install it on the Windows
+side (`winget install usbipd`), then forward the EDL device into WSL.
+
+EDL devices enumerate under Vendor ID `05c6` with Product ID `9008` (Firehose),
+`900e` (crash dump), or `901d`. From a Windows terminal, list the connected
+devices and note the **BUSID** of the EDL device:
+
+```powershell
+usbipd list
+```
+
+Each device must be *bound* once before it can be attached. Binding requires an
+**elevated (Administrator)** PowerShell, but it persists across reboots, so this
+is a one-time step per device:
+
+```powershell
+usbipd bind --busid <BUSID>
+```
+
+Attaching the device to WSL does **not** require Administrator and can be run
+from inside WSL by calling the Windows binary:
+
+```bash
+usbipd.exe attach --wsl --busid <BUSID>
+```
+
+Once attached, the device appears in WSL (check with `lsusb` for `05c6:9008`)
+and QDL can flash it as usual.
+
+#### Re-attaching after EDL re-enumeration
+
+The EDL device is a USB gadget that only exists while the board is in EDL mode.
+Whenever the board re-enters EDL — including after QDL finishes and the target
+reboots — the USB device is torn down and re-created. The `bind` persists, but
+the **attach is dropped**, and the host may assign a **different BUSID** than
+before. A QDL run that reports no device found is almost always this: the device
+simply needs to be re-attached.
+
+After each entry into EDL, re-detect the BUSID and attach again. This can be
+scripted from WSL so the BUSID does not have to be looked up by hand:
+
+```bash
+BUSID=$(usbipd.exe list | grep -iE '9008|900e|901d' | awk '{print $1}' | tr -d '\r')
+usbipd.exe attach --wsl --busid "$BUSID"
+```
+
+If you flash repeatedly, run this re-attach step before every `qdl` invocation.
+
 ### Flash device
 
 Run QDL with the `--help` option to view detailed usage information.


### PR DESCRIPTION
Add a section on how to set up the USB forwarding to WSL on Windows machines and how to use qdl for flashing from the linux shell.