### PR TITLE
ramdump: create the output directory if it does not exist

### DIFF
--- a/src/oscompat.h
+++ b/src/oscompat.h
@@ -3,16 +3,21 @@
 #define __OSCOMPAT_H__
 
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
+#include <string.h>
 
 #ifndef _WIN32
 
 #include <err.h>
+#include <sys/stat.h>
 
 #define O_BINARY 0
 
 #else // _WIN32
 
+#include <direct.h>
 #include <sys/time.h>
 
 void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *result);
@@ -42,6 +47,62 @@ static inline bool path_is_absolute(const char *path)
 	return (isalpha(path[0]) && path[1] == ':') ||
 	       (path[0] == '\\' && path[1] == '\\');
 #endif
+}
+
+/**
+ * qdl_mkdir_p() - create @path and any missing parent directories
+ * @path: directory path to create
+ *
+ * Mirrors "mkdir -p": an already existing directory is not an error.
+ * Both '/' and (on Windows) '\\' are treated as path separators.
+ *
+ * Returns: 0 on success, -1 with errno set on failure.
+ */
+static inline int qdl_mkdir_p(const char *path)
+{
+	char tmp[PATH_MAX];
+	size_t len;
+	size_t i;
+
+	len = strlen(path);
+	if (len == 0)
+		return 0;
+	if (len >= sizeof(tmp)) {
+		errno = ENAMETOOLONG;
+		return -1;
+	}
+	memcpy(tmp, path, len + 1);
+
+	/* Create each prefix in turn, then the full path at the terminator. */
+	for (i = 1; i <= len; i++) {
+		char c = tmp[i];
+		char prev = tmp[i - 1];
+		bool sep = c == '\0' || c == '/';
+		bool prev_sep = prev == '/';
+		char saved;
+#ifdef _WIN32
+		sep = sep || c == '\\';
+		prev_sep = prev_sep || prev == '\\';
+		/* Don't try to create a bare drive prefix such as "C:". */
+		if (sep && prev == ':')
+			continue;
+#endif
+		/* Act only at separators, and skip empty components. */
+		if (!sep || prev_sep)
+			continue;
+
+		saved = tmp[i];
+		tmp[i] = '\0';
+#ifdef _WIN32
+		if (_mkdir(tmp) != 0 && errno != EEXIST)
+#else
+		if (mkdir(tmp, 0755) != 0 && errno != EEXIST)
+#endif
+			return -1;
+		tmp[i] = saved;
+	}
+
+	return 0;
 }
 
 #endif

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -605,6 +605,12 @@ static int qdl_ramdump(int argc, char **argv)
 
 	ux_init();
 
+	if (qdl_mkdir_p(ramdump_path) < 0) {
+		ux_err("failed to create ramdump directory \"%s\": %s\n",
+		       ramdump_path, strerror(errno));
+		return 1;
+	}
+
 	qdl = qdl_init(qdl_dev_type);
 	if (!qdl) {
 		ux_err("backend not available\n");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -98,6 +98,22 @@ if cmocka_dep.found()
     protocol: 'tap',
     env: ['CMOCKA_MESSAGE_OUTPUT=TAP'],
   )
+
+  test_oscompat = executable('test_oscompat',
+    sources : [
+      'test_oscompat.c',
+    ],
+    dependencies : common_dep + [cmocka_dep],
+    include_directories : inc,
+  )
+
+  test(
+    'oscompat path helpers',
+    test_oscompat,
+    suite: 'unit',
+    protocol: 'tap',
+    env: ['CMOCKA_MESSAGE_OUTPUT=TAP'],
+  )
 else
   warning('cmocka not found; skipping unit tests')
 endif

--- a/tests/test_oscompat.c
+++ b/tests/test_oscompat.c
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#define _FILE_OFFSET_BITS 64
+
+#include <dirent.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cmocka.h>
+
+#include "oscompat.h"
+
+#define WORKDIR "test_oscompat_workdir"
+
+static bool is_dir(const char *path)
+{
+	struct stat st;
+
+	return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static void rmtree(const char *path)
+{
+	struct dirent *ent;
+	DIR *dir;
+
+	dir = opendir(path);
+	if (dir) {
+		while ((ent = readdir(dir)) != NULL) {
+			char child[PATH_MAX];
+			struct stat st;
+
+			if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
+				continue;
+
+			snprintf(child, sizeof(child), "%s/%s", path, ent->d_name);
+			if (stat(child, &st) == 0 && S_ISDIR(st.st_mode))
+				rmtree(child);
+			else
+				unlink(child);
+		}
+		closedir(dir);
+	}
+
+	rmdir(path);
+}
+
+/* ----------------------------- path_is_absolute -------------------------- */
+
+static void test_path_is_absolute(void **state)
+{
+	(void)state;
+
+#ifndef _WIN32
+	assert_true(path_is_absolute("/"));
+	assert_true(path_is_absolute("/foo/bar"));
+	assert_false(path_is_absolute("foo"));
+	assert_false(path_is_absolute("./foo"));
+	assert_false(path_is_absolute(""));
+#else
+	assert_true(path_is_absolute("C:\\foo"));
+	assert_true(path_is_absolute("C:/foo"));
+	assert_true(path_is_absolute("c:foo"));		/* drive-relative */
+	assert_true(path_is_absolute("\\\\server\\share"));
+	assert_false(path_is_absolute("foo"));
+	assert_false(path_is_absolute("\\foo"));	/* single backslash */
+	assert_false(path_is_absolute(""));
+#endif
+}
+
+/* ------------------------------- qdl_mkdir_p ----------------------------- */
+
+static void test_mkdir_p_creates_nested(void **state)
+{
+	(void)state;
+
+	assert_int_equal(qdl_mkdir_p(WORKDIR "/a/b/c"), 0);
+	assert_true(is_dir(WORKDIR));
+	assert_true(is_dir(WORKDIR "/a"));
+	assert_true(is_dir(WORKDIR "/a/b"));
+	assert_true(is_dir(WORKDIR "/a/b/c"));
+}
+
+static void test_mkdir_p_is_idempotent(void **state)
+{
+	(void)state;
+
+	assert_int_equal(qdl_mkdir_p(WORKDIR "/idem"), 0);
+	/* An already existing directory is not an error. */
+	assert_int_equal(qdl_mkdir_p(WORKDIR "/idem"), 0);
+	assert_true(is_dir(WORKDIR "/idem"));
+}
+
+static void test_mkdir_p_trailing_slash(void **state)
+{
+	(void)state;
+
+	assert_int_equal(qdl_mkdir_p(WORKDIR "/x/y/"), 0);
+	assert_true(is_dir(WORKDIR "/x/y"));
+}
+
+static void test_mkdir_p_existing_and_dot(void **state)
+{
+	(void)state;
+
+	/* The current directory always exists; this must succeed. */
+	assert_int_equal(qdl_mkdir_p("."), 0);
+	/* An empty path is a no-op. */
+	assert_int_equal(qdl_mkdir_p(""), 0);
+}
+
+static void test_mkdir_p_too_long(void **state)
+{
+	char path[PATH_MAX + 16];
+
+	(void)state;
+
+	memset(path, 'a', sizeof(path) - 1);
+	path[sizeof(path) - 1] = '\0';
+
+	assert_int_equal(qdl_mkdir_p(path), -1);
+	assert_int_equal(errno, ENAMETOOLONG);
+}
+
+static void test_mkdir_p_component_not_a_dir(void **state)
+{
+	const char *file = WORKDIR "/afile";
+	FILE *fp;
+
+	(void)state;
+
+	assert_int_equal(qdl_mkdir_p(WORKDIR), 0);
+	fp = fopen(file, "wb");
+	assert_non_null(fp);
+	fclose(fp);
+
+	/* A path component that is a regular file cannot be descended into. */
+	assert_int_equal(qdl_mkdir_p(WORKDIR "/afile/sub"), -1);
+}
+
+static int group_setup(void **state)
+{
+	(void)state;
+	rmtree(WORKDIR);
+	return 0;
+}
+
+static int group_teardown(void **state)
+{
+	(void)state;
+	rmtree(WORKDIR);
+	return 0;
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_path_is_absolute),
+		cmocka_unit_test(test_mkdir_p_creates_nested),
+		cmocka_unit_test(test_mkdir_p_is_idempotent),
+		cmocka_unit_test(test_mkdir_p_trailing_slash),
+		cmocka_unit_test(test_mkdir_p_existing_and_dot),
+		cmocka_unit_test(test_mkdir_p_too_long),
+		cmocka_unit_test(test_mkdir_p_component_not_a_dir),
+	};
+
+	return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
`qdl ramdump -o <dir>` writes each downloaded region to `<dir>/<file>`, but it never created `<dir>` itself. When the directory did not exist every `open()` failed with `ENOENT`, and the user only saw a confusing per-file error with no hint that the missing output directory was the actual problem:
    
```bash
$ qdl ramdump -o ./ramdump
Waiting for EDL device
Collecting crash dump from device (PID 0x900e, serial: 8AE002FE)
qdl: failed to open "OCIMEM.BIN": No such file or directory
```

This PR adds addresses this issue and also introduces unit tests for testing this functionality.

Fixes: https://github.com/linux-msm/qdl/issues/224