### PR TITLE
firehose: tolerate zero-length packets while reading sector data

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -1015,11 +1015,18 @@ static int firehose_issue_read(struct qdl_device *qdl, struct firehose_op *read_
 				ret = -1;
 				goto out;
 			}
-			if (n == 0) {
-				ux_err("unexpected EOF while reading sector data\n");
-				ret = -1;
-				goto out;
-			}
+			/*
+			 * A 0-byte return is not EOF on a USB bulk-in pipe: it's
+			 * a zero-length packet. Windows libusb (WinUSB) surfaces
+			 * the ZLP that the device sends when transitioning from
+			 * the XML/ACK phase to the rawmode binary phase before
+			 * the first sector chunk of a large <read>; Linux's
+			 * usbfs path generally hides it. If qdl_read() really
+			 * has nothing more to deliver it will eventually return
+			 * -ETIMEDOUT, which is handled above.
+			 */
+			if (n == 0)
+				continue;
 			got += (size_t)n;
 		}
 


### PR DESCRIPTION
firehose_issue_read() treated a 0-byte qdl_read() return as a fatal "unexpected EOF" and aborted the transfer. On a USB bulk-in pipe a 0-byte completion is not EOF, it is a zero-length packet (ZLP) - a legitimate USB-level event that the transport layer can surface to user space.

In practice this trips on Windows with the libusb (WinUSB) backend when reading a large partition: after the device ACKs a <read> with rawmode="true" and transitions from XML responses to the raw binary phase, it emits a ZLP before the first sector chunk. WinUSB returns that as libusb_bulk_transfer() success with actual=0, usb_read() forwards 0, and the inner accumulation loop in firehose_issue_read() treated it as a terminated stream and bailed out. The same workload succeeds on Linux because the usbfs path does not surface the transitional ZLP on the rawmode boundary, so the first qdl_read() already returns the full payload.

Small reads (the per-sector GPT loads at the start of every session go through the same loop) did not hit this: their request size is a single sector, the device sends the bytes immediately, and there is no preceding boundary ZLP to consume. The failure only showed up on the first big payload, e.g.:

  $ qdl.exe --debug --storage=emmc prog_firehose_ddr.elf \
        read 0/rootfs rootfs.image
  ...
  FIREHOSE READ: <response value="ACK" rawmode="true" />
  unexpected EOF while reading sector data

Treat n == 0 as "no payload yet, keep reading" instead of EOF and continue the inner loop. A genuine stall is still caught: qdl_read() returns -ETIMEDOUT once the 30s timeout passed to libusb expires, and that path already errors out via the n < 0 arm just above.

Fixes: 0512c0b983bd ("firehose: parse multi-document and rawmode-trailed reads")
Closes: https://github.com/linux-msm/qdl/issues/132