### PR TITLE
tests: fix test_contents_selectors link failure at -O0

### DIFF
--- a/tests/test_contents_selectors.c
+++ b/tests/test_contents_selectors.c
@@ -108,6 +108,23 @@ int program_load(struct list_head *ops, const char *program_file, bool is_nand,
 	return -1;
 }
 
+/*
+ * contents.c references firehose_alloc_op(), but this test pulls it in via
+ * #include and links neither firehose.c nor libqdl_common. Provide a stub so
+ * the test links regardless of whether the optimizer drops the unreachable
+ * call (it does at -O2 but not at -O0), matching the other contents tests.
+ */
+struct firehose_op *firehose_alloc_op(int type)
+{
+	struct firehose_op *op = calloc(1, sizeof(*op));
+
+	if (!op)
+		return NULL;
+
+	op->type = type;
+	return op;
+}
+
 int patch_load(struct list_head *ops, const char *patch_file)
 {
 	(void)ops;


### PR DESCRIPTION
test_contents_selectors.c pulls in contents.c via #include, and contents.c calls firehose_alloc_op(). The test target links neither firehose.c nor libqdl_common, so the only reason it linked at all is that at -O2 the compiler drops the (unreachable in this test) call. At -O0 the call survives and the link fails:

  src/contents.c:899: undefined reference to `firehose_alloc_op'

Provide a firehose_alloc_op() stub, like the other contents tests already do, so the test links regardless of optimization level.

Closes: https://github.com/linux-msm/qdl/issues/260