### PR TITLE
usb: recognize 0x90db as an EDL ramdump product ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![Packaging status](https://repology.org/badge/tiny-repos/qdl.svg)](https://repology.org/project/qdl/versions)
 
 This tool communicates with Qualcomm EDL USB devices (Vendor ID `05c6`, Product
-IDs `9008`, `900e`, `901d`) to upload a flash loader and use it to flash images.
+IDs `9008`, `900e`, `901d`, `90db`) to upload a flash loader and use it to
+flash images.
 
 ## Build
 
@@ -91,8 +92,8 @@ devices by default — they must be forwarded from the Windows host with
 side (`winget install usbipd`), then forward the EDL device into WSL.
 
 EDL devices enumerate under Vendor ID `05c6` with Product ID `9008` (Firehose),
-`900e` (crash dump), or `901d`. From a Windows terminal, list the connected
-devices and note the **BUSID** of the EDL device:
+`900e` (crash dump), `90db` (diag dump), or `901d`. From a Windows terminal,
+list the connected devices and note the **BUSID** of the EDL device:
 
 ```powershell
 usbipd list
@@ -129,7 +130,8 @@ After each entry into EDL, re-detect the BUSID and attach again. This can be
 scripted from WSL so the BUSID does not have to be looked up by hand:
 
 ```bash
-BUSID=$(usbipd.exe list | grep -iE '9008|900e|901d' | awk '{print $1}' | tr -d '\r')
+BUSID=$(usbipd.exe list | grep -iE '9008|900e|901d|90db' |
+        awk '{print $1}' | tr -d '\r')
 usbipd.exe attach --wsl --busid "$BUSID"
 ```
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -26,6 +26,11 @@ struct qdl_device_usb {
 	size_t out_chunk_size;
 };
 
+static bool usb_is_edl_pid(uint16_t pid)
+{
+	return pid == 0x9008 || pid == 0x900e || pid == 0x901d || pid == 0x90db;
+}
+
 /*
  * libusb commit f0cce43f882d ("core: Fix definition and use of enum
  * libusb_transfer_type") split transfer type and endpoint transfer types.
@@ -101,7 +106,7 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 	/* Consider only devices with vid 0x0506 and known product id */
 	if (desc.idVendor != 0x05c6)
 		return 0;
-	if (desc.idProduct != 0x9008 && desc.idProduct != 0x900e && desc.idProduct != 0x901d)
+	if (!usb_is_edl_pid(desc.idProduct))
 		return 0;
 
 	ret = libusb_get_active_config_descriptor(dev, &config);
@@ -188,11 +193,6 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 	libusb_free_config_descriptor(config);
 
 	return !!qdl->usb_handle;
-}
-
-static bool usb_is_edl_pid(uint16_t pid)
-{
-	return pid == 0x9008 || pid == 0x900e || pid == 0x901d;
 }
 
 /*
@@ -372,7 +372,7 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 
 		if (desc.idVendor != 0x05c6)
 			continue;
-		if (desc.idProduct != 0x9008 && desc.idProduct != 0x900e && desc.idProduct != 0x901d)
+		if (!usb_is_edl_pid(desc.idProduct))
 			continue;
 
 		ret = libusb_open(dev, &handle);


### PR DESCRIPTION
8538 platform could enter ramdump with product id 0x90db, thus we add this id into the list.