### PR TITLE
README: use consistent dash bullets for unordered lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Please consult your device’s documentation for instructions on how to enter ED
 
 See:
 
-* <https://github.com/dorssel/usbipd-win/issues/924>
-* <https://github.com/dorssel/usbipd-win/issues/1022>
-* <https://github.com/dorssel/usbipd-win/issues/1067>
+- <https://github.com/dorssel/usbipd-win/issues/924>
+- <https://github.com/dorssel/usbipd-win/issues/1022>
+- <https://github.com/dorssel/usbipd-win/issues/1067>
 
 On Windows, QDL can run inside a WSL2 distribution, but WSL2 does not see USB
 devices by default — they must be forwarded from the Windows host with


### PR DESCRIPTION
mdl's MD004 rule defaults to "consistent" style, taking the first unordered list's marker as the expected one for the whole file. The first list used "*" while every other list used "-", so the dash lists were flagged. Switch the three "*" bullets to "-" to match the dominant style and satisfy the linter.