### PR TITLE
doc: add RELEASING.md describing the release process 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,130 @@
+# Changelog
+
+All notable changes to QDL, mirroring the [GitHub releases](https://github.com/linux-msm/qdl/releases). Each entry lists the pull requests merged for that release.
+
+This project uses `vMAJOR.MINOR` tags. Releases prior to v2.4 were tagged but not published as GitHub releases; see the [git tags](https://github.com/linux-msm/qdl/tags) for their history.
+
+## [v2.7](https://github.com/linux-msm/qdl/releases/tag/v2.7) - 2026-06-08
+
+### What's Changed
+- [RFC] meson: replace GNU Make-based build system with Meson by @igoropaniuk in [#150](https://github.com/linux-msm/qdl/pull/150)
+- tests: replace monolithic test wrapper with per-suite Meson tests by @igoropaniuk in [#208](https://github.com/linux-msm/qdl/pull/208)
+- meson: rename ks to qdl-ks by @obbardc in [#211](https://github.com/linux-msm/qdl/pull/211)
+- Update ks/ramdump description by @igoropaniuk in [#212](https://github.com/linux-msm/qdl/pull/212)
+- sahara: increase MAPPING_SZ to 128 by @mukeshojha-linux in [#215](https://github.com/linux-msm/qdl/pull/215)
+- For linux msm/flashmap support by @andersson in [#210](https://github.com/linux-msm/qdl/pull/210)
+- Unify markdown-lint and checkpatch checks by @igoropaniuk in [#222](https://github.com/linux-msm/qdl/pull/222)
+- tests: stop fixture generation from timing out CI on slow runners by @igoropaniuk in [#230](https://github.com/linux-msm/qdl/pull/230)
+- tests: give each integration test its own fixture directory by @igoropaniuk in [#231](https://github.com/linux-msm/qdl/pull/231)
+- commitlint: Recognize kernel-style trailers as footer items by @igoropaniuk in [#229](https://github.com/linux-msm/qdl/pull/229)
+- [RFC] ux: Route libxml2 parser diagnostics through ux_err() by @igoropaniuk in [#227](https://github.com/linux-msm/qdl/pull/227)
+- usb: Allow devices with no serial number to show in the usb list by @Zephyrus29 in [#213](https://github.com/linux-msm/qdl/pull/213)
+- qdl: fix list/ramdump subcommands ignored when flags precede them by @mukeshojha-linux in [#217](https://github.com/linux-msm/qdl/pull/217)
+- meson: avoid duplicate library entries on executable link lines by @igoropaniuk in [#228](https://github.com/linux-msm/qdl/pull/228)
+- For linux msm/program search relative xml by @quic-bjorande in [#223](https://github.com/linux-msm/qdl/pull/223)
+- Add --skip-reset and auto-skip Sahara when programmer is already running by @igoropaniuk in [#232](https://github.com/linux-msm/qdl/pull/232)
+- qdl: Drop alloca definition by @quic-bjorande in [#236](https://github.com/linux-msm/qdl/pull/236)
+- For linux msm/contents xml flashing by @quic-bjorande in [#225](https://github.com/linux-msm/qdl/pull/225)
+- qdl: add QUD backend so on Windows flashing via the official QDLoader 9008 driver works by @igoropaniuk in [#233](https://github.com/linux-msm/qdl/pull/233)
+- [RFC] qdl: add sha256 subcommand by @igoropaniuk in [#239](https://github.com/linux-msm/qdl/pull/239)
+- github: Include missing build artifacts in Windows build by @quic-bjorande in [#240](https://github.com/linux-msm/qdl/pull/240)
+- qdl: add --skipblock=sha256 to skip programs already on flash by @igoropaniuk in [#242](https://github.com/linux-msm/qdl/pull/242)
+- For linux msm/erase all by @quic-bjorande in [#244](https://github.com/linux-msm/qdl/pull/244)
+- contents: Look for OS-specific path tag by @quic-bjorande in [#245](https://github.com/linux-msm/qdl/pull/245)
+- sahara: Deal with QUD discarding the HELLO request by @quic-bjorande in [#246](https://github.com/linux-msm/qdl/pull/246)
+- firehose: detect VIP mode mismatch from programmer startup logs by @igoropaniuk in [#252](https://github.com/linux-msm/qdl/pull/252)
+- program: Cast away const when freeing start_sector in erase by @igoropaniuk in [#253](https://github.com/linux-msm/qdl/pull/253)
+- tree: drop unused .gitreview by @igoropaniuk in [#251](https://github.com/linux-msm/qdl/pull/251)
+- sahara: auto-assemble minidump ELF after ramdump download by @mukeshojha-linux in [#243](https://github.com/linux-msm/qdl/pull/243)
+
+### New Contributors
+- @mukeshojha-linux made their first contribution in [#215](https://github.com/linux-msm/qdl/pull/215)
+- @Zephyrus29 made their first contribution in [#213](https://github.com/linux-msm/qdl/pull/213)
+
+**Full Changelog**: [v2.6...v2.7](https://github.com/linux-msm/qdl/compare/v2.6...v2.7)
+
+## [v2.6](https://github.com/linux-msm/qdl/releases/tag/v2.6) - 2026-04-06
+
+### What's Changed
+- Documentation improvements by @igoropaniuk in [#194](https://github.com/linux-msm/qdl/pull/194)
+- Address VIP mode regressions by @igoropaniuk in [#189](https://github.com/linux-msm/qdl/pull/189)
+- A collection of bug fixes and a small refactor across vip/usb/firehose by @igoropaniuk in [#195](https://github.com/linux-msm/qdl/pull/195)
+- usb: reinitialise libusb on each poll iteration in usb_open by @igoropaniuk in [#199](https://github.com/linux-msm/qdl/pull/199)
+- A second batch of bug fixes and code quality improvements by @igoropaniuk in [#196](https://github.com/linux-msm/qdl/pull/196)
+- qdl: fix absolute image_path handling in sahara_config by @MrCry0 in [#198](https://github.com/linux-msm/qdl/pull/198)
+- program: Add erase command by @jcreedon in [#190](https://github.com/linux-msm/qdl/pull/190)
+- [RFC] ci: enforce commit message formatting in PRs by @igoropaniuk in [#203](https://github.com/linux-msm/qdl/pull/203)
+- Add qdl-ramdump usage documentation and fix segment filter matching by @igoropaniuk in [#202](https://github.com/linux-msm/qdl/pull/202)
+- sahara, usb: improve robustness and user feedback by @igoropaniuk in [#204](https://github.com/linux-msm/qdl/pull/204)
+- [RFC] sim: implement proper Firehose protocol state machine by @igoropaniuk in [#192](https://github.com/linux-msm/qdl/pull/192)
+- [RFC] sim: validate VIP digest tables and chunk hashes in dry-run mode by @igoropaniuk in [#205](https://github.com/linux-msm/qdl/pull/205)
+
+### New Contributors
+- @MrCry0 made their first contribution in [#198](https://github.com/linux-msm/qdl/pull/198)
+
+**Full Changelog**: [v2.5...v2.6](https://github.com/linux-msm/qdl/compare/v2.5...v2.6)
+
+## [v2.5](https://github.com/linux-msm/qdl/releases/tag/v2.5) - 2026-02-25
+
+### What's Changed
+- makefile: Allow cross-building by @obbardc in [#174](https://github.com/linux-msm/qdl/pull/174)
+- qdl: Allow absolute paths in Windows again by @andersson in [#179](https://github.com/linux-msm/qdl/pull/179)
+- sahara: Unbreak ramdump by making images optional again by @andersson in [#180](https://github.com/linux-msm/qdl/pull/180)
+- firehose: Increase reset delay after flashing by @ykaire-qti in [#175](https://github.com/linux-msm/qdl/pull/175)
+- firehose: Increase timeout for read of program-ack by @andersson in [#182](https://github.com/linux-msm/qdl/pull/182)
+- usb: add --list flag for list devices  by @lucarin91 in [#176](https://github.com/linux-msm/qdl/pull/176)
+- For linux msm/drop single image hack by @andersson in [#181](https://github.com/linux-msm/qdl/pull/181)
+- For linux msm/ramdump subcmd by @andersson in [#183](https://github.com/linux-msm/qdl/pull/183)
+- qdl: Propagate the success of decode_sahara_config() by @andersson in [#185](https://github.com/linux-msm/qdl/pull/185)
+- firehose: ensure we properly set skip_storage_init in provision by @kcxt in [#186](https://github.com/linux-msm/qdl/pull/186)
+- Address memory leaks/mitigate buffer overflows by @igoropaniuk in [#161](https://github.com/linux-msm/qdl/pull/161)
+
+### New Contributors
+- @lucarin91 made their first contribution in [#176](https://github.com/linux-msm/qdl/pull/176)
+- @kcxt made their first contribution in [#186](https://github.com/linux-msm/qdl/pull/186)
+
+**Full Changelog**: [v2.4...v2.5](https://github.com/linux-msm/qdl/compare/v2.4...v2.5)
+
+## [v2.4](https://github.com/linux-msm/qdl/releases/tag/v2.4) - 2025-12-19
+
+### What's Changed
+- For linux msm/read write gpt by @andersson in [#130](https://github.com/linux-msm/qdl/pull/130)
+- For linux msm/missing files early and list h by @andersson in [#128](https://github.com/linux-msm/qdl/pull/128)
+- checkpatch: Skip list.h by @quic-bjorande in [#138](https://github.com/linux-msm/qdl/pull/138)
+- firehose: Provide progress bar on read as well by @quic-bjorande in [#142](https://github.com/linux-msm/qdl/pull/142)
+- For linux msm/db410c timeout and improvements by @quic-bjorande in [#139](https://github.com/linux-msm/qdl/pull/139)
+- sahara: Print an error when device isn't reachable by @quic-bjorande in [#140](https://github.com/linux-msm/qdl/pull/140)
+- patch: Don't spam the log when no patch file was loaded by @quic-bjorande in [#141](https://github.com/linux-msm/qdl/pull/141)
+- gpt: gpt_load_table_from_partition: fix off-by-one error for num_sectors by @mike-scott in [#143](https://github.com/linux-msm/qdl/pull/143)
+- Add build instructions for MacPorts by @idlethread in [#144](https://github.com/linux-msm/qdl/pull/144)
+- usb: increase bulk transfer timeout for firehose raw write by @loicpoulain in [#145](https://github.com/linux-msm/qdl/pull/145)
+- Misc fixes by @igoropaniuk in [#147](https://github.com/linux-msm/qdl/pull/147)
+- For linux msm/spinor by @andersson in [#146](https://github.com/linux-msm/qdl/pull/146)
+- github: Bump macos runner versions by @andersson in [#151](https://github.com/linux-msm/qdl/pull/151)
+- Add -h/--help support to ks and ramdump by @rogers0 in [#136](https://github.com/linux-msm/qdl/pull/136)
+- github: Two improvements for --version on CI build by @z3ntu in [#152](https://github.com/linux-msm/qdl/pull/152)
+- Suppress unused var warnings by @igoropaniuk in [#153](https://github.com/linux-msm/qdl/pull/153)
+- Move __unused macro after variable definitions by @igoropaniuk in [#155](https://github.com/linux-msm/qdl/pull/155)
+- Add manpages generated by help2man by @rogers0 in [#137](https://github.com/linux-msm/qdl/pull/137)
+- For linux msm/multi programmer by @quic-bjorande in [#154](https://github.com/linux-msm/qdl/pull/154)
+- README/CI updates/improvements by @igoropaniuk in [#157](https://github.com/linux-msm/qdl/pull/157)
+- [housekeeping] Integer-related compiler warnings by @igoropaniuk in [#159](https://github.com/linux-msm/qdl/pull/159)
+- Address more -Wsign-compare issues by @igoropaniuk in [#160](https://github.com/linux-msm/qdl/pull/160)
+- firehose: Add slot flag by @jcreedon in [#158](https://github.com/linux-msm/qdl/pull/158)
+- Check for empty patch filenames. by @ykaire-qti in [#156](https://github.com/linux-msm/qdl/pull/156)
+- firehose/usb: Explicitly handle ZLP on USB read transfers by @loicpoulain in [#162](https://github.com/linux-msm/qdl/pull/162)
+- github: Resolve liblzma-related failure in Windows builds by @andersson in [#165](https://github.com/linux-msm/qdl/pull/165)
+- firehose: Increase image write timeout to 60 seconds by @andersson in [#166](https://github.com/linux-msm/qdl/pull/166)
+- usb: Fix checkpatch warning about unnecessary parenthesis by @andersson in [#167](https://github.com/linux-msm/qdl/pull/167)
+- vip: Fix integer underflow in digest count by @jerry-skydio in [#172](https://github.com/linux-msm/qdl/pull/172)
+
+### New Contributors
+- @mike-scott made their first contribution in [#143](https://github.com/linux-msm/qdl/pull/143)
+- @idlethread made their first contribution in [#144](https://github.com/linux-msm/qdl/pull/144)
+- @loicpoulain made their first contribution in [#145](https://github.com/linux-msm/qdl/pull/145)
+- @rogers0 made their first contribution in [#136](https://github.com/linux-msm/qdl/pull/136)
+- @jcreedon made their first contribution in [#158](https://github.com/linux-msm/qdl/pull/158)
+- @ykaire-qti made their first contribution in [#156](https://github.com/linux-msm/qdl/pull/156)
+- @jerry-skydio made their first contribution in [#172](https://github.com/linux-msm/qdl/pull/172)
+
+**Full Changelog**: [v2.2...v2.4](https://github.com/linux-msm/qdl/compare/v2.2...v2.4)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,177 @@
+# Releasing QDL
+
+This document describes how a new QDL release is cut, from preparing the
+changelog to publishing the GitHub release with prebuilt artifacts.
+
+Releases are versioned `vMAJOR.MINOR` (for example `v2.8`). Release
+candidates append an `-rcN` suffix (`v2.8-rc1`, `v2.8-rc2`, ...).
+
+The process is, in short:
+
+- [Releasing QDL](#releasing-qdl)
+  - [1. Populate the changelog](#1-populate-the-changelog)
+  - [2. Open the changelog PR and tag a release candidate](#2-open-the-changelog-pr-and-tag-a-release-candidate)
+  - [3. Iterate on release candidates](#3-iterate-on-release-candidates)
+  - [4. Merge the changelog PR and apply the release tag](#4-merge-the-changelog-pr-and-apply-the-release-tag)
+  - [5. Create the GitHub release](#5-create-the-github-release)
+
+Throughout, export the version once so the commands below can be copied
+verbatim:
+
+```bash
+VERSION=v2.8
+```
+
+## 1. Populate the changelog
+
+`CHANGELOG.md` mirrors the GitHub releases: one section per version, listing
+the pull requests merged since the previous release. Add a new section at the
+top for the upcoming version.
+
+GitHub can produce the raw list of merged PRs for the range, which is the same
+content used in the existing entries:
+
+```bash
+# Everything merged since the previous release:
+gh api repos/linux-msm/qdl/releases/generate-notes \
+    -f tag_name="${VERSION}" -f target_commitish=master \
+    -f previous_tag_name="$(git describe --tags --abbrev=0 master)" \
+    --jq .body
+```
+
+Format the output to match the existing entries (PR references as `#NNN`
+links, a `### What's Changed` and `### New Contributors` subsection, and a
+`**Full Changelog**` compare link), and prepend it to `CHANGELOG.md` under a
+new `## [vX.Y](...) - YYYY-MM-DD` heading.
+
+Once the changelog draft is ready, ask people to start testing the current
+`master` so issues are found before the tag is cut.
+
+## 2. Open the changelog PR and tag a release candidate
+
+Open a pull request with the changelog update. With that PR up, tag the latest
+`master` as the first release candidate so testers have a stable reference
+point to build from:
+
+```bash
+git fetch upstream
+git tag "${VERSION}-rc1" upstream/master
+git push upstream "${VERSION}-rc1"
+```
+
+Ask testers to exercise the hardware-in-the-loop (HIL) suite against real
+hardware. The suite is skipped by default and only runs when pointed at an
+attached EDL device:
+
+```bash
+meson setup build
+QDL_HIL_BUILD=/path/to/build-images \
+QDL_HIL_STORAGE=<emmc|ufs|nvme|...> \
+    meson test -C build --suite hil --print-errorlogs
+```
+
+The release must be validated across all four supported host/driver
+combinations:
+
+- Windows + QUD driver: the official Qualcomm QDLoader 9008 driver
+  (`qdl --backend=qud ...`).
+- Windows + WinUSB driver / libusb (`qdl --backend=usb ...`).
+- Linux.
+- macOS.
+
+In addition, validate VIP (Validated Image Programming) mode: generate the
+digest tables with `--create-digests`, sign them, and flash a board with
+`--vip-table-path` to confirm secure-boot flashing still works end to end. See
+the VIP section in [README.md](README.md) for the full workflow.
+
+## 3. Iterate on release candidates
+
+Collect the testing results. If a regression is found, fix it on `master` and
+cut the next candidate (`-rc2`, `-rc3`, ...):
+
+```bash
+git fetch upstream
+git tag "${VERSION}-rc2" upstream/master
+git push upstream "${VERSION}-rc2"
+```
+
+Repeat until a candidate passes all four configurations (and VIP validation)
+cleanly. That commit becomes the stable release.
+
+## 4. Merge the changelog PR and apply the release tag
+
+Merge the changelog PR. Then tag the resulting `master` commit with the final,
+immutable release tag.
+
+Note on tag type: the history is mixed. `v2.4` is an annotated tag while
+`v2.5`, `v2.6` and `v2.7` are lightweight tags (that is what GitHub's "create
+release" UI produces). Prefer an annotated tag for releases: it records the
+tagger, date and a message, and is what `git describe` expects.
+
+```bash
+git fetch upstream
+git tag -a "${VERSION}" -m "qdl ${VERSION}" upstream/master
+git push upstream "${VERSION}"
+```
+
+A tag is a ref, not a branch. `git push upstream "${VERSION}"` publishes the
+tag itself; it does not push to the `master` branch. Once pushed, treat the tag
+as immutable: never move or delete it.
+
+(If matching the recent lightweight-tag convention is preferred instead, drop
+the `-a`/`-m` flags: `git tag "${VERSION}" upstream/master`.)
+
+## 5. Create the GitHub release
+
+The `Buildtest` workflow already builds and uploads per-platform binaries for
+every push. Reuse those artifacts for the release rather than rebuilding.
+
+Download the artifacts from the green `Buildtest` run for the tagged commit and
+bundle each platform into its own archive:
+
+```bash
+# Find the successful Buildtest run that built the tagged commit. Filtering
+# with --commit happens server-side, so it is not limited to the most recent
+# runs (a plain `gh run list` only fetches the latest 20).
+SHA=$(git rev-parse "${VERSION}^{commit}")
+RUN_ID=$(gh run list --workflow build.yml --commit "${SHA}" --status success \
+    --json databaseId --jq '.[0].databaseId')
+
+# Pull every platform artifact into dist/<artifact-name>/...
+rm -rf dist && gh run download "${RUN_ID}" -D dist
+
+# Zip each platform directory into a single release asset
+( cd dist && for d in */; do
+      name="${d%/}"
+      zip -r "${name}-${VERSION}.zip" "${d}"
+  done )
+```
+
+Extract this release's notes straight from `CHANGELOG.md` (the block between
+this version's heading and the next `## [` heading) and create the release,
+attaching the zipped artifacts:
+
+```bash
+NOTES=$(awk -v v="${VERSION}" '
+    $0 ~ ("^## \\[" v "\\]") { found=1; next }
+    /^## \[/ && found        { exit }
+    found                    { print }
+' CHANGELOG.md | sed '1{/^$/d}')
+
+echo "Release notes preview:"
+echo "---"
+echo "${NOTES}"
+echo "---"
+read -r -p "Create GitHub release ${VERSION}? [y/N] " reply
+[ "${reply}" = "y" ] || { echo "GitHub release skipped"; exit 0; }
+
+gh release create "${VERSION}" dist/*.zip \
+    --title "${VERSION}" \
+    --notes "${NOTES}"
+
+echo "GitHub release created: $(gh release view "${VERSION}" --json url -q .url)"
+```
+
+The release name matches the existing convention (the tag itself, for example
+`v2.8`). After publishing, sanity-check the release page: confirm the notes
+rendered correctly and that every platform archive is attached.


### PR DESCRIPTION
Cutting a release has so far been an informal, tribal-knowledge activity:
the exact steps, the tag conventions, which hardware/driver combinations
must be validated, and how the GitHub release is assembled from CI
artifacts.

Add RELEASING.md to formalize and standardize that process so any
maintainer can cut a release the same way. It documents, end to end:

  - how to populate CHANGELOG.md from the merged PRs and start testing;
  - opening the changelog PR and tagging release candidates;
  - the validation matrix - HIL suite across Windows+QUD, Windows+WinUSB,
    Linux and macOS, plus VIP-mode validation - and iterating on rc tags;
  - applying the final immutable release tag (with a note on the
    annotated vs lightweight tag history);
  - creating the GitHub release from the existing Buildtest artifacts,
    with release notes extracted straight from CHANGELOG.md.