### PR TITLE
[RFC] qdl: reject mixing input XML files with command verbs

### DIFF
--- a/src/qdl.c
+++ b/src/qdl.c
@@ -986,6 +986,8 @@ static int qdl_flash(int argc, char **argv)
 	bool allow_fusing = false;
 	bool allow_missing = false;
 	bool skip_reset = false;
+	bool saw_file = false;
+	bool saw_verb = false;
 	long out_chunk_size = 0;
 	unsigned int slot = UINT_MAX;
 	struct qdl_device *qdl = NULL;
@@ -1139,6 +1141,22 @@ static int qdl_flash(int argc, char **argv)
 		type = detect_type(argv[optind]);
 		if (type < 0 || type == QDL_FILE_UNKNOWN)
 			errx(1, "failed to detect file type of %s\n", argv[optind]);
+
+		/*
+		 * The usage synopsis lists input XML files and command verbs
+		 * (read/write/erase/sha256/flash/reset) as separate forms; they
+		 * must not be mixed. Combining them once let a verb like "reset"
+		 * be appended out of order relative to ops added after parsing.
+		 * QDL_CMD_* follow the QDL_FILE_* values in the enum.
+		 */
+		if (type >= QDL_CMD_READ)
+			saw_verb = true;
+		else
+			saw_file = true;
+
+		if (saw_file && saw_verb)
+			errx(1, "input XML files cannot be combined with command "
+			     "verbs (read/write/erase/sha256/flash/reset)");
 
 		switch (type) {
 		case QDL_FILE_PATCH:


### PR DESCRIPTION
The usage synopsis documents input XML files and the command verbs (read/write/erase/sha256/flash/reset) as separate invocation forms, but the argument loop accepted any mixture of them. Combining a bare program XML with the reset verb, for example, appended the reset op during parsing - before qdl_determine_bootable() adds the setbootablestoragedrive op after the loop - so the device could be told to reboot before its bootable storage drive was set. The same mixture on the provisioning path silently performed no reset at all.

Rather than order the two against each other, reject the combination: track whether a file-type and a verb-type argument have both been seen and error out when they have. This keeps each documented form self-consistent and makes the reset verb usable only on its own or alongside other verbs, where ordering is well defined.