### PR TITLE
Fix critical correctness issues (silent failures, crashes, OOB accesses)

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -397,7 +397,6 @@ static int firehose_vip_send_table(struct qdl_device *qdl)
 
 static int firehose_write(struct qdl_device *qdl, xmlDoc *doc)
 {
-	int saved_errno;
 	xmlChar *s;
 	int len;
 	int ret;
@@ -405,8 +404,10 @@ static int firehose_write(struct qdl_device *qdl, xmlDoc *doc)
 	xmlDocDumpMemory(doc, &s, &len);
 
 	ret = firehose_vip_send_table(qdl);
-	if (ret)
+	if (ret) {
+		xmlFree(s);
 		return -1;
+	}
 
 	vip_gen_chunk_init(qdl);
 
@@ -414,23 +415,24 @@ static int firehose_write(struct qdl_device *qdl, xmlDoc *doc)
 		ux_debug("FIREHOSE WRITE: %s\n", s);
 		vip_gen_chunk_update(qdl, s, len);
 		ret = qdl_write(qdl, s, len, 1000);
-		saved_errno = errno;
 
 		/*
-		 * db410c sometimes sense a <response> followed by <log>
+		 * db410c sometimes sends a <response> followed by <log>
 		 * entries and won't accept write commands until these are
 		 * drained, so attempt to read any pending data and then retry
-		 * the write.
+		 * the write. The qdl_write() backends report the timeout via
+		 * the return value, not errno, so key the retry on that.
 		 */
-		if (ret < 0 && errno == ETIMEDOUT) {
+		if (ret == -ETIMEDOUT) {
 			firehose_read(qdl, 100, firehose_generic_parser, NULL);
-		} else {
-			break;
+			continue;
 		}
+
+		break;
 	}
 	xmlFree(s);
 	vip_gen_chunk_store(qdl);
-	return ret < 0 ? -saved_errno : 0;
+	return ret < 0 ? ret : 0;
 }
 
 /**
@@ -471,8 +473,10 @@ static int firehose_configure_response_parser(xmlNode *node, void *data,
 	 */
 	if (!xmlStrcmp(value, (xmlChar *)"ACK")) {
 		payload = xmlGetProp(node, (xmlChar *)"MaxPayloadSizeToTargetInBytesSupported");
-		if (!payload)
+		if (!payload) {
+			xmlFree(value);
 			return -EINVAL;
+		}
 
 		max_size = strtoul((char *)payload, NULL, 10);
 		xmlFree(payload);
@@ -762,6 +766,7 @@ static int firehose_program_raw_region(struct qdl_device *qdl,
 	ret = firehose_read(qdl, 10000, firehose_generic_parser, NULL);
 	if (ret) {
 		ux_err("failed to setup programming\n");
+		ret = -1;
 		goto out;
 	}
 
@@ -970,6 +975,11 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	num_sectors = program->num_sectors;
 	sector_size = program->sector_size ? : qdl->sector_size;
 
+	if (!sector_size) {
+		ux_err("unable to determine sector size for %s\n", program->filename);
+		goto err_close_fd;
+	}
+
 	if (!program->sparse) {
 		num_sectors = (qdl_file_getsize(&file) + sector_size - 1) / sector_size;
 
@@ -1082,8 +1092,10 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 		vip_gen_chunk_update(qdl, buf, chunk_size * sector_size);
 
 		ret = firehose_vip_send_table(qdl);
-		if (ret)
-			return -1;
+		if (ret) {
+			ret = -1;
+			goto err_free_doc;
+		}
 
 		n = qdl_write(qdl, buf, chunk_size * sector_size, zlp_timeout);
 		if (n < 0) {
@@ -1091,7 +1103,7 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 			ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
 			if (ret)
 				ux_err("flashing of chunk failed\n");
-
+			ret = -1;
 			goto err_free_doc;
 		}
 
@@ -1167,6 +1179,12 @@ static int firehose_issue_read(struct qdl_device *qdl, struct firehose_op *read_
 	xmlDocSetRootElement(doc, root);
 
 	sector_size = read_op->sector_size ? : qdl->sector_size;
+	if (!sector_size) {
+		ux_err("unable to determine sector size for read operation\n");
+		free(buf);
+		xmlFreeDoc(doc);
+		return -1;
+	}
 
 	node = xmlNewChild(root, NULL, (xmlChar *)"read", NULL);
 	xml_setpropf(node, "SECTOR_SIZE_IN_BYTES", "%d", sector_size);
@@ -1189,6 +1207,7 @@ static int firehose_issue_read(struct qdl_device *qdl, struct firehose_op *read_
 	if (ret) {
 		if (!quiet)
 			ux_err("failed to setup reading operation\n");
+		ret = -1;
 		goto out;
 	}
 
@@ -1259,6 +1278,7 @@ static int firehose_issue_read(struct qdl_device *qdl, struct firehose_op *read_
 	ret = firehose_read(qdl, 10000, firehose_generic_parser, NULL);
 	if (ret) {
 		ux_err("read operation failed\n");
+		ret = -1;
 		goto out;
 	}
 
@@ -1618,7 +1638,7 @@ static int firehose_detect_and_configure(struct qdl_device *qdl,
 			qdl->vip_data.state = VIP_DISABLED;
 		}
 
-		ret = firehose_try_configure(qdl, false, storage);
+		ret = firehose_try_configure(qdl, skip_storage_init, storage);
 		if (ret != FIREHOSE_ACK) {
 			ux_err("configure request failed\n");
 			return -1;

--- a/src/firehose.c
+++ b/src/firehose.c
@@ -269,7 +269,8 @@ static int firehose_read(struct qdl_device *qdl, int timeout_ms,
 	 * consumption of incoming data.
 	 */
 	for (;;) {
-		n = qdl_read(qdl, buf, sizeof(buf), 100);
+		/* Reserve one byte for the NUL terminator written below. */
+		n = qdl_read(qdl, buf, sizeof(buf) - 1, 100);
 
 		/* Timeout after seeing a response, we're done waiting for logs */
 		if (n == -ETIMEDOUT && resp >= 0)

--- a/src/firehose.c
+++ b/src/firehose.c
@@ -1111,7 +1111,11 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	ret = firehose_read(qdl, 120000, firehose_generic_parser, NULL);
 	if (ret != FIREHOSE_ACK) {
 		ux_err("flashing of %s failed\n", program->label);
-	} else if (t) {
+		ret = -1;
+		goto err_free_doc;
+	}
+
+	if (t) {
 		ux_info("flashed \"%s\" successfully at %lukB/s\n",
 			program->label,
 			(unsigned long)sector_size * num_sectors / t / 1024);

--- a/src/flashmap.c
+++ b/src/flashmap.c
@@ -262,6 +262,8 @@ static int flashmap_enumerate_programmables(struct json_value *list, struct list
 		is_nand = !strcmp(memory, "nand");
 
 		op = firehose_alloc_op(FIREHOSE_OP_CONFIGURE);
+		if (!op)
+			return -1;
 		op->storage_type = decode_storage_type(memory);
 		list_append(ops, &op->node);
 
@@ -454,12 +456,15 @@ int flashmap_load(struct list_head *ops, const char *filename, char *specifier,
 
 	json_blob = qdl_file_load(&flashmap, &json_size);
 	qdl_file_close(&flashmap);
-	if (!json_blob)
+	if (!json_blob) {
+		ret = -1;
 		goto out_put_zip;
+	}
 
 	json = json_parse_buf(json_blob, json_size);
 	if (!json) {
 		ux_err("failed to parse flashmap json\n");
+		ret = -1;
 		goto out_free_blob;
 	}
 

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -58,8 +59,8 @@ struct gpt_entry {
 struct gpt_partition {
 	const char *name;
 	unsigned int partition;
-	unsigned int start_sector;
-	unsigned int num_sectors;
+	uint64_t start_sector;
+	uint64_t num_sectors;
 
 	struct gpt_partition *next;
 };
@@ -82,7 +83,7 @@ static void utf16le_to_utf8(uint16_t *in, size_t in_len, uint8_t *out, size_t ou
 		if (w >= 0xd800 && w <= 0xdbff) {
 			high = w - 0xd800;
 
-			if (i < in_len) {
+			if (i + 1 < in_len) {
 				w = in[++i];
 				if (w >= 0xdc00 && w <= 0xdfff) {
 					low = w - 0xdc00;
@@ -169,7 +170,15 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 		return 0;
 	}
 
-	if (gpt.part_entry_size > qdl->sector_size || gpt.num_part_entries > 1024) {
+	/*
+	 * The entry read loop below assumes entries never straddle a sector
+	 * boundary, which only holds when the entry size is a non-zero divisor
+	 * of the sector size and is at least as large as a GPT entry.
+	 */
+	if (gpt.part_entry_size < sizeof(struct gpt_entry) ||
+	    gpt.part_entry_size > qdl->sector_size ||
+	    qdl->sector_size % gpt.part_entry_size != 0 ||
+	    gpt.num_part_entries > 1024) {
 		ux_debug("partition %d has invalid GPT header\n", phys_partition);
 		return -1;
 	}
@@ -186,7 +195,8 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 			memset(buf, 0, sizeof(buf));
 			ret = firehose_read_buf(qdl, &op, buf, sizeof(buf));
 			if (ret) {
-				ux_err("failed to read GPT partition entries from %d:%u\n", phys_partition, lba);
+				ux_err("failed to read GPT partition entries from %d:%" PRIu64 "\n",
+				       phys_partition, lba);
 				return -1;
 			}
 		}
@@ -200,14 +210,16 @@ static int gpt_load_table_from_partition(struct qdl_device *qdl, unsigned int ph
 		utf16le_to_utf8(name_utf16le, 36, (uint8_t *)name, sizeof(name));
 
 		partition = calloc(1, sizeof(*partition));
+		if (!partition)
+			return -1;
 		partition->name = strdup(name);
 		partition->partition = phys_partition;
 		partition->start_sector = entry->first_lba;
 		/* if first_lba == last_lba there is 1 sector worth of data (IE: add 1 below) */
 		partition->num_sectors = entry->last_lba - entry->first_lba + 1;
 
-		ux_debug("  %3d: %s start sector %u, num sectors %u\n", i, partition->name,
-			 partition->start_sector, partition->num_sectors);
+		ux_debug("  %3d: %s start sector %" PRIu64 ", num sectors %" PRIu64 "\n", i,
+			 partition->name, partition->start_sector, partition->num_sectors);
 
 		if (gpt_partitions) {
 			gpt_partitions_last->next = partition;
@@ -240,14 +252,17 @@ static int gpt_load_tables(struct qdl_device *qdl)
 }
 
 int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *phys_partition,
-		     unsigned int *start_sector, unsigned int *num_sectors)
+		     uint64_t *start_sector, uint64_t *num_sectors)
 {
 	struct gpt_partition *gpt_part;
 	bool found = false;
 	int ret;
 
-	if (qdl->dev_type == QDL_DEVICE_SIM)
+	if (qdl->dev_type == QDL_DEVICE_SIM) {
+		*start_sector = 0;
+		*num_sectors = 0;
 		return 0;
+	}
 
 	ret = gpt_load_tables(qdl);
 	if (ret < 0)
@@ -285,9 +300,10 @@ int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *phys_partiti
 
 int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops)
 {
-	unsigned int start_sector;
+	uint64_t start_sector;
+	uint64_t num_sectors;
 	struct firehose_op *op;
-	char buf[20];
+	char buf[21];
 	int ret;
 
 	list_for_each_entry(op, ops, node) {
@@ -301,11 +317,18 @@ int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops)
 			continue;
 
 		ret = gpt_find_by_name(qdl, op->gpt_partition, &op->partition,
-				       &start_sector, &op->num_sectors);
+				       &start_sector, &num_sectors);
 		if (ret < 0)
 			return -1;
 
-		sprintf(buf, "%u", start_sector);
+		if (num_sectors > UINT_MAX) {
+			ux_err("partition \"%s\" has too many sectors (%" PRIu64 ")\n",
+			       op->gpt_partition, num_sectors);
+			return -1;
+		}
+		op->num_sectors = (unsigned int)num_sectors;
+
+		snprintf(buf, sizeof(buf), "%" PRIu64, start_sector);
 		op->start_sector = strdup(buf);
 	}
 

--- a/src/gpt.h
+++ b/src/gpt.h
@@ -2,13 +2,15 @@
 #ifndef __GPT_H__
 #define __GPT_H__
 
+#include <stdint.h>
+
 #include "list.h"
 
 struct qdl_device;
 struct list_head;
 
 int gpt_find_by_name(struct qdl_device *qdl, const char *name, int *partition,
-		     unsigned int *start_sector, unsigned int *num_sectors);
+		     uint64_t *start_sector, uint64_t *num_sectors);
 int gpt_resolve_deferrals(struct qdl_device *qdl, struct list_head *ops);
 
 #endif

--- a/src/program.c
+++ b/src/program.c
@@ -81,16 +81,27 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 		 * for a partition node but lacks a sparse header,
 		 * it will be validated against the defined partition size.
 		 * If the sizes match, it is likely that the 'sparse="true"' attribute
-		 * was set by mistake, fix the sparse flag and add the
-		 * program entry to the list.
+		 * was set by mistake, fix the sparse flag and let the caller add the
+		 * program entry to the list as a regular (non-sparse) program.
 		 */
 		if ((off_t)program->sector_size * program->num_sectors == qdl_file_seek(file, 0, SEEK_END)) {
 			program->sparse = false;
-			list_append(ops, &program->node);
-			return 0;
+			return 1;
 		}
 
 		ux_err("[PROGRAM] Unable to parse sparse header at %s...failed\n",
+		       program->filename);
+		return -1;
+	}
+
+	if (program->sector_size == 0) {
+		ux_err("[PROGRAM] SECTOR_SIZE_IN_BYTES is zero for sparse image %s\n",
+		       program->filename);
+		return -1;
+	}
+
+	if (!program->start_sector) {
+		ux_err("[PROGRAM] missing start_sector for sparse image %s\n",
 		       program->filename);
 		return -1;
 	}
@@ -127,12 +138,14 @@ static int program_load_sparse(struct list_head *ops, struct firehose_op *progra
 
 		if (chunk_type == CHUNK_TYPE_RAW || chunk_type == CHUNK_TYPE_FILL) {
 			program_sparse = firehose_alloc_op(FIREHOSE_OP_PROGRAM);
+			if (!program_sparse)
+				return -1;
 
 			program_sparse->pages_per_block = program->pages_per_block;
 			program_sparse->sector_size = program->sector_size;
 			program_sparse->file_offset = program->file_offset;
 			program_sparse->filename = strdup(program->filename);
-			program_sparse->label = strdup(program->label);
+			program_sparse->label = program->label ? strdup(program->label) : NULL;
 			program_sparse->partition = program->partition;
 			program_sparse->sparse = program->sparse;
 			program_sparse->start_sector = strdup(program->start_sector);
@@ -286,11 +299,16 @@ static int load_program_tag(struct list_head *ops, xmlNode *node, bool is_nand,
 			goto err_free_op;
 
 		/*
-		 * Chunks were added to the program list, drop the filename of
-		 * the parent, to prevent this from being written to the device
+		 * ret == 0 means the sparse chunks were added to the program
+		 * list as separate ops; drop the filename of the parent to
+		 * prevent it from being written to the device. ret == 1 means
+		 * the image was not actually sparse and the parent op should be
+		 * programmed normally, so keep its filename.
 		 */
-		free((void *)program->filename);
-		program->filename = NULL;
+		if (ret == 0) {
+			free((void *)program->filename);
+			program->filename = NULL;
+		}
 	}
 
 	list_append(ops, &program->node);

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -227,13 +227,18 @@ static int decode_programmer_archive(struct sahara_image *blob, struct sahara_im
 			goto err;
 		}
 
-		if (namesize > sizeof(name)) {
+		if (namesize == 0 || namesize > sizeof(name)) {
 			ux_err("unexpected filename length in programmer archive\n");
 			goto err;
 		}
 		memcpy(name, ptr, namesize);
 
-		if (!memcmp(name, "TRAILER!!!", 11))
+		if (name[namesize - 1] != '\0') {
+			ux_err("malformed filename in programmer archive\n");
+			goto err;
+		}
+
+		if (!strcmp(name, "TRAILER!!!"))
 			break;
 
 		tok = strtok_r(name, ":", &save);
@@ -242,7 +247,7 @@ static int decode_programmer_archive(struct sahara_image *blob, struct sahara_im
 			goto err;
 		}
 		id = strtoul(tok, NULL, 0);
-		if (id == 0 || id >= MAPPING_SZ) {
+		if (id <= 0 || id >= MAPPING_SZ) {
 			ux_err("invalid image id \"%s\" in programmer archive\n", tok);
 			goto err;
 		}
@@ -345,7 +350,7 @@ int decode_sahara_config(struct sahara_image *blob, struct sahara_image *images,
 		image_id = attr_as_unsigned(image_node, "image_id", &errors);
 		image_path = attr_as_string(image_node, "image_path", &errors);
 
-		if (image_id == 0 || image_id >= MAPPING_SZ || errors) {
+		if (image_id == 0 || image_id >= MAPPING_SZ || errors || !image_path) {
 			ux_err("invalid sahara_config image in \"%s\"\n", blob->name);
 			free((void *)image_path);
 			goto err_free_doc;
@@ -437,7 +442,7 @@ static int decode_programmer(char *s, struct sahara_image *images)
 				return -1;
 			}
 
-			if (id == 0 || id >= MAPPING_SZ) {
+			if (id <= 0 || id >= MAPPING_SZ) {
 				ux_err("invalid image id \"%s\"\n", pair);
 				return -1;
 			}

--- a/src/sahara.c
+++ b/src/sahara.c
@@ -213,7 +213,7 @@ static int sahara_read(struct qdl_device *qdl, struct sahara_pkt *pkt,
 		 pkt->read_req.image, pkt->read_req.offset, pkt->read_req.length);
 
 	image_idx = pkt->read_req.image;
-	if (image_idx >= MAPPING_SZ || !images[image_idx].ptr) {
+	if (!images || image_idx >= MAPPING_SZ || !images[image_idx].ptr) {
 		ux_err("device requested unknown image id %u, ensure that all Sahara images are provided\n",
 		       image_idx);
 		sahara_send_reset(qdl);
@@ -224,7 +224,7 @@ static int sahara_read(struct qdl_device *qdl, struct sahara_pkt *pkt,
 	len = pkt->read_req.length;
 
 	image = &images[image_idx];
-	if (offset > image->len || offset + len > image->len) {
+	if (offset > image->len || len > image->len - offset) {
 		ux_err("device requested invalid range of image %d\n", image_idx);
 		return -1;
 	}
@@ -262,7 +262,7 @@ static int sahara_read64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 		 pkt->read64_req.image, pkt->read64_req.offset, pkt->read64_req.length);
 
 	image_idx = pkt->read64_req.image;
-	if (image_idx >= MAPPING_SZ || !images[image_idx].ptr) {
+	if (!images || image_idx >= MAPPING_SZ || !images[image_idx].ptr) {
 		ux_err("device requested unknown image id %u, ensure that all Sahara images are provided\n",
 		       image_idx);
 		sahara_send_reset(qdl);
@@ -273,7 +273,7 @@ static int sahara_read64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 	len = pkt->read64_req.length;
 
 	image = &images[image_idx];
-	if (offset > image->len || offset + len > image->len) {
+	if (offset > image->len || len > image->len - offset) {
 		ux_err("device requested invalid range of image %d\n", image_idx);
 		return -1;
 	}
@@ -338,7 +338,8 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 	uint64_t remain;
 	size_t offset, buf_offset;
 	size_t chunk;
-	size_t written;
+	ssize_t written;
+	ssize_t ret = -1;
 	ssize_t n;
 	void *buf;
 	int fd;
@@ -349,9 +350,20 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 
 	char path[PATH_MAX];
 
+	/*
+	 * region.filename is provided by the device. Reject empty names and
+	 * any name containing a path separator so a malicious or malformed
+	 * device cannot direct the dump outside of ramdump_path.
+	 */
+	if (region.filename[0] == '\0' || strpbrk(region.filename, "/\\")) {
+		ux_err("device provided unsafe ramdump region filename\n");
+		free(buf);
+		return -1;
+	}
+
 	snprintf(path, sizeof(path), "%s/%s", ramdump_path, region.filename);
 
-	fd = open(path, O_WRONLY | O_CREAT | O_BINARY, 0644);
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
 	if (fd < 0) {
 		warn("failed to open \"%s\"", region.filename);
 		free(buf);
@@ -367,8 +379,10 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 		read_req.debug64_req.addr = region.addr + chunk;
 		read_req.debug64_req.length = remain;
 		n = qdl_write(qdl, &read_req, read_req.length, SAHARA_CMD_TIMEOUT_MS);
-		if (n < 0)
-			break;
+		if (n < 0) {
+			warn("failed to send ramdump read request");
+			goto out;
+		}
 
 		offset = 0;
 		while (offset < remain) {
@@ -397,12 +411,14 @@ static ssize_t sahara_debug64_one(struct qdl_device *qdl,
 
 		ux_progress("%s", chunk, region.length, region.filename);
 	}
+
+	ret = 0;
 out:
 
 	close(fd);
 	free(buf);
 
-	return 0;
+	return ret;
 }
 
 // simple pattern matching function supporting * and ?
@@ -694,6 +710,7 @@ static void sahara_debug64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 {
 	struct sahara_debug_region64 *table;
 	struct sahara_pkt read_req;
+	size_t num_regions;
 	ssize_t n;
 	size_t i;
 
@@ -725,13 +742,22 @@ static void sahara_debug64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 	if (!table)
 		return;
 
-	n = qdl_read(qdl, table, pkt->debug64_req.length, SAHARA_CMD_TIMEOUT_MS);
+	n = qdl_read(qdl, table, read_req.debug64_req.length, SAHARA_CMD_TIMEOUT_MS);
 	if (n < 0) {
 		free(table);
 		return;
 	}
 
-	for (i = 0; i < pkt->debug64_req.length / sizeof(table[0]); i++) {
+	/* Only iterate over region entries actually received. */
+	num_regions = (size_t)n / sizeof(table[0]);
+
+	/* The device-provided name fields may not be NUL-terminated. */
+	for (i = 0; i < num_regions; i++) {
+		table[i].region[sizeof(table[i].region) - 1] = '\0';
+		table[i].filename[sizeof(table[i].filename) - 1] = '\0';
+	}
+
+	for (i = 0; i < num_regions; i++) {
 		if (sahara_debug64_filter(table[i].filename, filter)) {
 			ux_info("%s skipped per filter\n", table[i].filename);
 			continue;
@@ -749,8 +775,7 @@ static void sahara_debug64(struct qdl_device *qdl, struct sahara_pkt *pkt,
 		ux_info("%s dumped successfully\n", table[i].filename);
 	}
 
-	sahara_build_minidump_elf(ramdump_path, filter, table,
-				  pkt->debug64_req.length / sizeof(table[0]));
+	sahara_build_minidump_elf(ramdump_path, filter, table, num_regions);
 
 	free(table);
 
@@ -761,6 +786,9 @@ static bool sahara_has_done_pending_quirk(const struct sahara_image *images)
 {
 	unsigned int count = 0;
 	int i;
+
+	if (!images)
+		return false;
 
 	/*
 	 * E.g MSM8916 EDL reports done = pending, allow this when one a single

--- a/src/zipper.c
+++ b/src/zipper.c
@@ -133,25 +133,16 @@ static int zipper_add_name_entry(struct list_head *names, const char *name)
 	return 0;
 }
 
-static int zipper_add_buffer(zip_t *zip, const char *name, const void *data, size_t len)
+/* Takes ownership of "data"; the buffer is freed on error as well. */
+static int zipper_add_buffer_owned(zip_t *zip, const char *name, void *data, size_t len)
 {
 	zip_source_t *source;
 	zip_int64_t idx;
-	void *copy = NULL;
 
-	if (len) {
-		copy = malloc(len);
-		if (!copy) {
-			ux_err("failed to allocate zip member \"%s\"\n", name);
-			return -1;
-		}
-		memcpy(copy, data, len);
-	}
-
-	source = zip_source_buffer(zip, copy, len, 1);
+	source = zip_source_buffer(zip, data, len, 1);
 	if (!source) {
 		ux_err("failed to create zip source for \"%s\"\n", name);
-		free(copy);
+		free(data);
 		return -1;
 	}
 
@@ -163,6 +154,22 @@ static int zipper_add_buffer(zip_t *zip, const char *name, const void *data, siz
 	}
 
 	return 0;
+}
+
+static int zipper_add_buffer(zip_t *zip, const char *name, const void *data, size_t len)
+{
+	void *copy = NULL;
+
+	if (len) {
+		copy = malloc(len);
+		if (!copy) {
+			ux_err("failed to allocate zip member \"%s\"\n", name);
+			return -1;
+		}
+		memcpy(copy, data, len);
+	}
+
+	return zipper_add_buffer_owned(zip, name, copy, len);
 }
 
 static int zipper_add_file(zip_t *zip, const char *name, const char *path)
@@ -434,8 +441,7 @@ static int zipper_register_fill_program_file(zip_t *zip, struct list_head *name_
 		i++;
 	}
 
-	ret = zipper_add_buffer(zip, filename, buf, fill_size);
-	free(buf);
+	ret = zipper_add_buffer_owned(zip, filename, buf, fill_size);
 	if (ret) {
 		free(filename);
 		return -1;
@@ -1052,6 +1058,7 @@ int zipper_write(const char *filename, struct list_head *ops, struct sahara_imag
 	goto out_cleanup;
 
 out_discard_zip:
+	ret = -1;
 	zip_discard(zip);
 
 out_cleanup:


### PR DESCRIPTION
This series fixes the high-severity issues found while auditing the
codebase. Each commit is self-contained and independently reviewable;
they touch separate subsystems and can be reviewed one at a time.

### Silent failures reported as success
- **firehose:** `firehose_program()` logged a NAK/timeout on the final
  programming response but then returned 0, so flashing continued and
  qdl exited successfully with a partition left unwritten.
- **zipper:** `zipper_write()` reused its return variable as loop
  scratch, so several error paths returned 0 - `create-zip` exited
  successfully with no output file.
- **flashmap:** `flashmap_load()` returned success on a failed load or
  JSON parse, and qdl proceeded with an empty op list instead of
  aborting.
  
### Crashes / memory safety
- **sahara:** `qdl ramdump` passes a NULL images array, but the
  READ_DATA handlers dereferenced it and crashed when the device
  requested an image.
- **program:** a `sparse="true"` entry without a sparse header was
  appended to the op list twice, self-linking the node (infinite loop /
  use-after-free) and dropping its filename so it was never flashed.
- **qdl:** the image-id range check missed negative values (id comes
  from `strtoul()`), allowing an out-of-bounds write into the
  sahara_image array.

### Data corruption
- **gpt:** 64-bit GPT LBAs were truncated to `unsigned int`, so a
  name-addressed write/erase on storage beyond 2 TB targeted the wrong
  sectors.