### PR TITLE
[RFC] usb: decouple open/list paths and share EDL device identity across backends

### DIFF
--- a/include/qdl.h
+++ b/include/qdl.h
@@ -144,6 +144,25 @@ struct qdl_device *auto_init(void);
 int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out);
 int qud_probe_present(void);
 
+/*
+ * EDL device identity, shared by all transport backends: Qualcomm's
+ * vendor id plus the known EDL/ramdump product ids. The libusb backend
+ * additionally requires a matching vendor-specific interface (see
+ * usb_match_edl_interface() in usb.c); on Windows the QDLoader driver
+ * performs the equivalent match before the QUD backend sees the device.
+ */
+#define QUALCOMM_VID 0x05c6
+
+static inline bool qdl_is_edl_pid(unsigned int pid)
+{
+	return pid == 0x9008 || pid == 0x900e || pid == 0x901d || pid == 0x90db;
+}
+
+static inline bool qdl_is_edl_device(unsigned int vid, unsigned int pid)
+{
+	return vid == QUALCOMM_VID && qdl_is_edl_pid(pid);
+}
+
 struct qdl_device_desc {
 	int vid;
 	int pid;

--- a/include/qdl.h
+++ b/include/qdl.h
@@ -130,7 +130,7 @@ struct qdl_device *qud_init(void);
 struct qdl_device *auto_init(void);
 
 /*
- * try_usb_open() - single libusb scan-and-open pass; shared between
+ * usb_open_once() - single libusb scan-and-open pass; shared between
  * the --backend usb wait loop in usb.c and the unified auto_open() loop.
  * Returns 0 on success (and emits the "Flashing/Collecting device" UX
  * line), -ENODEV when no EDL device is visible, -EBUSY when one is
@@ -141,7 +141,7 @@ struct qdl_device *auto_init(void);
  * qud_probe_present() returns the number of Qualcomm COM ports the QUD
  * backend enumerated via SetupAPI; 0 on non-Windows hosts.
  */
-int try_usb_open(struct qdl_device *qdl, const char *serial, int *visible_out);
+int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out);
 int qud_probe_present(void);
 
 struct qdl_device_desc {

--- a/src/auto.c
+++ b/src/auto.c
@@ -63,7 +63,7 @@ static int auto_open(struct qdl_device *qdl, const char *serial)
 #endif
 
 	for (;;) {
-		ret = try_usb_open(usb_dev, serial, &visible);
+		ret = usb_open_once(usb_dev, serial, &visible);
 		if (ret == 0) {
 #ifdef _WIN32
 			qdl_deinit(qud_dev);

--- a/src/qud.c
+++ b/src/qud.c
@@ -200,6 +200,7 @@ static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 		return -1;
 
 	for (i = 0; SetupDiEnumDeviceInfo(devinfo, i, &info); i++) {
+		unsigned int pid;
 		DWORD type = 0;
 		DWORD size = 0;
 
@@ -214,6 +215,17 @@ static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 			    sizeof(QCOM_HWID_PREFIX) - 1) != 0)
 			continue;
 
+		/*
+		 * The prefix match already guarantees Qualcomm's vid; apply
+		 * the same EDL pid policy as the libusb backend, so that all
+		 * backends agree on what an EDL device is and other Qualcomm
+		 * COM ports (for example the diag port of a phone in normal
+		 * composite mode) are not mistaken for one.
+		 */
+		pid = win_parse_pid(hwid);
+		if (!qdl_is_edl_device(QUALCOMM_VID, pid))
+			continue;
+
 		if (!SetupDiGetDeviceInstanceIdA(devinfo, &info, instance_id,
 						 sizeof(instance_id), NULL))
 			continue;
@@ -223,7 +235,7 @@ static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 			continue;
 
 		if (count < out_max) {
-			out[count].pid = win_parse_pid(hwid);
+			out[count].pid = pid;
 			if (!win_read_iproduct_sn(devinfo, &info,
 						  out[count].serial,
 						  sizeof(out[count].serial)))

--- a/src/usb.c
+++ b/src/usb.c
@@ -365,11 +365,8 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 	struct qdl_device_desc *result;
 	struct libusb_device **devices;
 	struct libusb_device *dev;
-	unsigned long serial_len;
-	unsigned char buf[128];
 	ssize_t device_count;
 	unsigned int count = 0;
-	char *serial;
 	int ret;
 	int i;
 
@@ -415,29 +412,9 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 		if (ret < 0)
 			continue;
 
-		ret = libusb_get_string_descriptor_ascii(handle, desc.iProduct, buf, sizeof(buf) - 1);
-		if (ret < 0) {
-			warnx("failed to read iProduct descriptor: %s", libusb_strerror(ret));
-			libusb_close(handle);
-			continue;
-		}
-		buf[ret] = '\0';
-
-		serial = strstr((char *)buf, "_SN:");
-		if (!serial) {
+		if (!usb_read_serial(handle, &desc, result[count].serial,
+				     sizeof(result[count].serial)))
 			memcpy(result[count].serial, "(none)", sizeof("(none)"));
-		} else {
-			serial += strlen("_SN:");
-			serial_len = strcspn(serial, " _");
-			if (serial_len + 1 > sizeof(result[count].serial)) {
-				ux_err("ignoring device with unexpectedly long serial number\n");
-				libusb_close(handle);
-				continue;
-			}
-
-			memcpy(result[count].serial, serial, serial_len);
-			result[count].serial[serial_len] = '\0';
-		}
 
 		result[count].vid = desc.idVendor;
 		result[count].pid = desc.idProduct;

--- a/src/usb.c
+++ b/src/usb.c
@@ -133,8 +133,8 @@ static bool usb_read_serial(struct libusb_device_handle *handle,
 	return true;
 }
 
-static bool usb_match_usb_serial(struct libusb_device_handle *handle, const char *serial,
-				 const struct libusb_device_descriptor *desc)
+static bool usb_match_serial(struct libusb_device_handle *handle, const char *serial,
+			     const struct libusb_device_descriptor *desc)
 {
 	char buf[64];
 
@@ -206,71 +206,93 @@ static bool usb_match_edl_interface(const struct libusb_interface_descriptor *if
 	return true;
 }
 
-static int usb_open_device(libusb_device *dev,
-			   const struct libusb_device_descriptor *desc,
-			   struct qdl_device_usb *qdl, const char *serial)
+/*
+ * Device-level match, run on an opened EDL candidate: the unit must
+ * carry the serial the user asked for (if any) and expose an EDL
+ * interface. On a match, returns the number of the interface to
+ * claim and its bulk endpoint pair.
+ */
+static bool usb_match_device(struct libusb_device_handle *handle,
+			     const struct libusb_device_descriptor *desc,
+			     const char *serial,
+			     int *ifc_num, struct usb_edl_interface *edl)
 {
 	const struct libusb_interface_descriptor *ifc;
 	struct libusb_config_descriptor *config;
-	struct libusb_device_handle *handle;
-	struct usb_edl_interface edl;
+	bool found = false;
 	int ret;
 	int k;
 
-	ret = libusb_get_active_config_descriptor(dev, &config);
+	if (!usb_match_serial(handle, serial, desc))
+		return false;
+
+	ret = libusb_get_active_config_descriptor(libusb_get_device(handle), &config);
 	if (ret < 0) {
 		warnx("failed to acquire USB device's active config descriptor");
-		return -1;
+		return false;
 	}
 
-	for (k = 0; k < config->bNumInterfaces; k++) {
+	for (k = 0; k < config->bNumInterfaces && !found; k++) {
 		ifc = config->interface[k].altsetting;
 
-		if (!usb_match_edl_interface(ifc, &edl))
-			continue;
-
-		ret = libusb_open(dev, &handle);
-		if (ret < 0) {
-			warnx("unable to open USB device");
-			continue;
+		if (usb_match_edl_interface(ifc, edl)) {
+			*ifc_num = ifc->bInterfaceNumber;
+			found = true;
 		}
-
-		if (!usb_match_usb_serial(handle, serial, desc)) {
-			libusb_close(handle);
-			continue;
-		}
-
-		libusb_detach_kernel_driver(handle, ifc->bInterfaceNumber);
-
-		ret = libusb_claim_interface(handle, ifc->bInterfaceNumber);
-		if (ret < 0) {
-			warnx("failed to claim USB interface");
-			libusb_close(handle);
-			continue;
-		}
-
-		qdl->usb_handle = handle;
-		qdl->in_ep = edl.in_ep;
-		qdl->out_ep = edl.out_ep;
-		qdl->in_maxpktsize = edl.in_maxpktsize;
-		qdl->out_maxpktsize = edl.out_maxpktsize;
-
-		if (qdl->out_chunk_size && qdl->out_chunk_size % edl.out_maxpktsize) {
-			ux_err("WARNING: requested out-chunk-size must be multiple of the device's wMaxPacketSize %ld, using %ld\n",
-			       edl.out_maxpktsize, edl.out_maxpktsize);
-			qdl->out_chunk_size = edl.out_maxpktsize;
-		} else if (!qdl->out_chunk_size) {
-			qdl->out_chunk_size = DEFAULT_OUT_CHUNK_SIZE;
-		}
-
-		ux_debug("USB: using out-chunk-size of %ld\n", qdl->out_chunk_size);
-
-		break;
 	}
 
 	libusb_free_config_descriptor(config);
 
-	return !!qdl->usb_handle;
+	return found;
+}
+
+static int usb_open_device(libusb_device *dev,
+			   const struct libusb_device_descriptor *desc,
+			   struct qdl_device_usb *qdl, const char *serial)
+{
+	struct libusb_device_handle *handle;
+	struct usb_edl_interface edl;
+	int ifc_num;
+	int ret;
+
+	ret = libusb_open(dev, &handle);
+	if (ret < 0) {
+		warnx("unable to open USB device");
+		return 0;
+	}
+
+	if (!usb_match_device(handle, desc, serial, &ifc_num, &edl))
+		goto close;
+
+	libusb_detach_kernel_driver(handle, ifc_num);
+
+	ret = libusb_claim_interface(handle, ifc_num);
+	if (ret < 0) {
+		warnx("failed to claim USB interface");
+		goto close;
+	}
+
+	qdl->usb_handle = handle;
+	qdl->in_ep = edl.in_ep;
+	qdl->out_ep = edl.out_ep;
+	qdl->in_maxpktsize = edl.in_maxpktsize;
+	qdl->out_maxpktsize = edl.out_maxpktsize;
+
+	if (qdl->out_chunk_size && qdl->out_chunk_size % edl.out_maxpktsize) {
+		ux_err("WARNING: requested out-chunk-size must be multiple of the device's wMaxPacketSize %ld, using %ld\n",
+		       edl.out_maxpktsize, edl.out_maxpktsize);
+		qdl->out_chunk_size = edl.out_maxpktsize;
+	} else if (!qdl->out_chunk_size) {
+		qdl->out_chunk_size = DEFAULT_OUT_CHUNK_SIZE;
+	}
+
+	ux_debug("USB: using out-chunk-size of %ld\n", qdl->out_chunk_size);
+
+	return 1;
+
+close:
+	libusb_close(handle);
+	return 0;
 }
 
 /*

--- a/src/usb.c
+++ b/src/usb.c
@@ -9,10 +9,16 @@
  *                       QUD probes until one reaches an EDL device
  *   usb_open()        - this backend's .open op: wait loop retrying
  *                       usb_open_once() every 250 ms
- *   usb_open_once()   - one enumeration pass over the bus: counts
- *                       visible EDL devices, tries to open each
- *   usb_open_device() - matches and opens a single candidate device,
- *                       claiming its EDL interface
+ *   usb_open_once()   - one enumeration pass over the bus: selects and
+ *                       counts the visible EDL devices, tries to open
+ *                       each
+ *   usb_open_device() - opens one already-selected candidate, claiming
+ *                       its EDL interface
+ *
+ * Candidate selection itself (enumeration plus the EDL identity
+ * policy) lives in usb_enumerate_edl_devices(), shared between the
+ * open path above and usb_list(), which reads descriptors without
+ * claiming anything.
  */
 #include <sys/types.h>
 #include <errno.h>
@@ -45,6 +51,51 @@ struct qdl_device_usb {
 static bool usb_is_edl_device(const struct libusb_device_descriptor *desc)
 {
 	return qdl_is_edl_device(desc->idVendor, desc->idProduct);
+}
+
+typedef int (*usb_edl_device_cb_t)(struct libusb_device *dev,
+				   const struct libusb_device_descriptor *desc,
+				   void *data);
+
+/*
+ * Enumerate the bus and hand every EDL candidate to @cb, stopping
+ * early if @cb returns nonzero. The single place the EDL identity
+ * policy is applied to libusb devices; shared by the open and list
+ * paths, which differ only in what they do with a candidate. The
+ * caller owns the libusb session.
+ *
+ * Returns the number of candidates seen up to and including the one
+ * @cb stopped at, or -EIO if the bus could not be enumerated.
+ */
+static int usb_enumerate_edl_devices(usb_edl_device_cb_t cb, void *data)
+{
+	struct libusb_device_descriptor desc;
+	struct libusb_device **devs;
+	int visible = 0;
+	ssize_t n;
+	int i;
+
+	n = libusb_get_device_list(NULL, &devs);
+	if (n < 0) {
+		ux_err("failed to list USB devices: %s\n", libusb_strerror(n));
+		return -EIO;
+	}
+
+	for (i = 0; devs[i]; i++) {
+		if (libusb_get_device_descriptor(devs[i], &desc) < 0)
+			continue;
+		if (!usb_is_edl_device(&desc))
+			continue;
+
+		visible++;
+
+		if (cb(devs[i], &desc, data))
+			break;
+	}
+
+	libusb_free_device_list(devs, 1);
+
+	return visible;
 }
 
 /*
@@ -155,24 +206,16 @@ static bool usb_match_edl_interface(const struct libusb_interface_descriptor *if
 	return true;
 }
 
-static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
+static int usb_open_device(libusb_device *dev,
+			   const struct libusb_device_descriptor *desc,
+			   struct qdl_device_usb *qdl, const char *serial)
 {
 	const struct libusb_interface_descriptor *ifc;
 	struct libusb_config_descriptor *config;
-	struct libusb_device_descriptor desc;
 	struct libusb_device_handle *handle;
 	struct usb_edl_interface edl;
 	int ret;
 	int k;
-
-	ret = libusb_get_device_descriptor(dev, &desc);
-	if (ret < 0) {
-		warnx("failed to get USB device descriptor");
-		return -1;
-	}
-
-	if (!usb_is_edl_device(&desc))
-		return 0;
 
 	ret = libusb_get_active_config_descriptor(dev, &config);
 	if (ret < 0) {
@@ -192,7 +235,7 @@ static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const
 			continue;
 		}
 
-		if (!usb_match_usb_serial(handle, serial, &desc)) {
+		if (!usb_match_usb_serial(handle, serial, desc)) {
 			libusb_close(handle);
 			continue;
 		}
@@ -256,19 +299,37 @@ static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const
  * fresh enumeration (libusb's udev-less backends otherwise cache the
  * list, which would mask newly-attached devices in containerised setups).
  */
+struct usb_open_ctx {
+	struct qdl_device_usb *qdl;
+	const char *serial;
+	char matched_serial[64];
+	uint16_t matched_pid;
+	bool found;
+};
+
+static int usb_open_cb(libusb_device *dev,
+		       const struct libusb_device_descriptor *desc, void *data)
+{
+	struct usb_open_ctx *ctx = data;
+
+	if (usb_open_device(dev, desc, ctx->qdl, ctx->serial) != 1)
+		return 0;
+
+	ctx->found = true;
+	ctx->matched_pid = desc->idProduct;
+	if (!usb_read_serial(ctx->qdl->usb_handle, desc,
+			     ctx->matched_serial, sizeof(ctx->matched_serial)))
+		ctx->matched_serial[0] = '\0';
+
+	return 1;
+}
+
 int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out)
 {
 	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
-	struct libusb_device_descriptor desc;
-	struct libusb_device **devs;
-	struct libusb_device *dev;
-	char matched_serial[64];
-	uint16_t matched_pid = 0;
-	bool found = false;
-	int visible = 0;
-	ssize_t n;
+	struct usb_open_ctx ctx = { .qdl = qdl_usb, .serial = serial };
+	int visible;
 	int ret;
-	int i;
 
 	if (visible_out)
 		*visible_out = 0;
@@ -279,50 +340,27 @@ int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out)
 		return -EIO;
 	}
 
-	n = libusb_get_device_list(NULL, &devs);
-	if (n < 0) {
-		ux_err("failed to list USB devices: %s\n", libusb_strerror(n));
+	visible = usb_enumerate_edl_devices(usb_open_cb, &ctx);
+	if (visible < 0) {
 		libusb_exit(NULL);
 		return -EIO;
-	}
-
-	for (i = 0; devs[i]; i++) {
-		dev = devs[i];
-
-		if (libusb_get_device_descriptor(dev, &desc) < 0)
-			continue;
-		if (!usb_is_edl_device(&desc))
-			continue;
-
-		visible++;
-
-		ret = usb_open_device(dev, qdl_usb, serial);
-		if (ret == 1) {
-			found = true;
-			matched_pid = desc.idProduct;
-			if (!usb_read_serial(qdl_usb->usb_handle, &desc,
-					     matched_serial, sizeof(matched_serial)))
-				matched_serial[0] = '\0';
-			break;
-		}
 	}
 
 	if (visible_out)
 		*visible_out = visible;
 
-	if (found) {
-		const char *action = matched_pid == 0x900e ? "Collecting crash dump from" : "Talking to";
+	if (ctx.found) {
+		const char *action = ctx.matched_pid == 0x900e ?
+				     "Collecting crash dump from" : "Talking to";
 
-		libusb_free_device_list(devs, 1);
-		if (matched_serial[0])
+		if (ctx.matched_serial[0])
 			ux_info("%s device (PID 0x%04x, serial: %s)\n",
-				action, matched_pid, matched_serial);
+				action, ctx.matched_pid, ctx.matched_serial);
 		else
-			ux_info("%s device (PID 0x%04x)\n", action, matched_pid);
+			ux_info("%s device (PID 0x%04x)\n", action, ctx.matched_pid);
 		return 0;
 	}
 
-	libusb_free_device_list(devs, 1);
 	libusb_exit(NULL);
 
 	return visible == 0 ? -ENODEV : -EBUSY;
@@ -358,17 +396,50 @@ static int usb_open(struct qdl_device *qdl, const char *serial)
 	}
 }
 
+struct usb_list_ctx {
+	struct qdl_device_desc *result;
+	unsigned int capacity;
+	unsigned int count;
+};
+
+static int usb_list_cb(libusb_device *dev,
+		       const struct libusb_device_descriptor *desc, void *data)
+{
+	struct libusb_device_handle *handle;
+	struct usb_list_ctx *ctx = data;
+	struct qdl_device_desc *entry;
+
+	if (ctx->count == ctx->capacity) {
+		unsigned int capacity = ctx->capacity ? ctx->capacity * 2 : 8;
+
+		entry = realloc(ctx->result, capacity * sizeof(*entry));
+		if (!entry) {
+			ux_err("failed to allocate devices array\n");
+			return 1;
+		}
+		ctx->result = entry;
+		ctx->capacity = capacity;
+	}
+	entry = &ctx->result[ctx->count];
+
+	if (libusb_open(dev, &handle) < 0)
+		return 0;
+
+	if (!usb_read_serial(handle, desc, entry->serial, sizeof(entry->serial)))
+		memcpy(entry->serial, "(none)", sizeof("(none)"));
+
+	entry->vid = desc->idVendor;
+	entry->pid = desc->idProduct;
+	libusb_close(handle);
+	ctx->count++;
+
+	return 0;
+}
+
 struct qdl_device_desc *usb_list(unsigned int *devices_found)
 {
-	struct libusb_device_descriptor desc;
-	struct libusb_device_handle *handle;
-	struct qdl_device_desc *result;
-	struct libusb_device **devices;
-	struct libusb_device *dev;
-	ssize_t device_count;
-	unsigned int count = 0;
+	struct usb_list_ctx ctx = { 0 };
 	int ret;
-	int i;
 
 	ret = libusb_init(NULL);
 	if (ret < 0) {
@@ -376,57 +447,17 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 		return NULL;
 	}
 
-	device_count = libusb_get_device_list(NULL, &devices);
-	if (device_count < 0) {
-		ux_err("failed to list USB devices: %s\n", libusb_strerror(device_count));
-		libusb_exit(NULL);
-		return NULL;
-	}
-	if (device_count == 0) {
-		libusb_free_device_list(devices, 1);
-		libusb_exit(NULL);
-		return NULL;
-	}
-
-	result = calloc(device_count, sizeof(struct qdl_device_desc));
-	if (!result) {
-		ux_err("failed to allocate devices array\n");
-		libusb_free_device_list(devices, 1);
-		libusb_exit(NULL);
-		return NULL;
-	}
-
-	for (i = 0; i < device_count; i++) {
-		dev = devices[i];
-
-		ret = libusb_get_device_descriptor(dev, &desc);
-		if (ret < 0) {
-			warnx("failed to get USB device descriptor");
-			continue;
-		}
-
-		if (!usb_is_edl_device(&desc))
-			continue;
-
-		ret = libusb_open(dev, &handle);
-		if (ret < 0)
-			continue;
-
-		if (!usb_read_serial(handle, &desc, result[count].serial,
-				     sizeof(result[count].serial)))
-			memcpy(result[count].serial, "(none)", sizeof("(none)"));
-
-		result[count].vid = desc.idVendor;
-		result[count].pid = desc.idProduct;
-		libusb_close(handle);
-		count++;
-	}
-
-	libusb_free_device_list(devices, 1);
+	ret = usb_enumerate_edl_devices(usb_list_cb, &ctx);
 	libusb_exit(NULL);
-	*devices_found = count;
 
-	return result;
+	if (ret < 0) {
+		free(ctx.result);
+		return NULL;
+	}
+
+	*devices_found = ctx.count;
+
+	return ctx.result;
 }
 
 static void usb_close(struct qdl_device *qdl)

--- a/src/usb.c
+++ b/src/usb.c
@@ -1,4 +1,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
+/*
+ * libusb transport backend.
+ *
+ * Open-path layering, top to bottom:
+ *
+ *   auto_open()       - meta-backend (auto.c): picks the transport by
+ *                       alternating usb_open_once() with (on Windows)
+ *                       QUD probes until one reaches an EDL device
+ *   usb_open()        - this backend's .open op: wait loop retrying
+ *                       usb_open_once() every 250 ms
+ *   usb_open_once()   - one enumeration pass over the bus: counts
+ *                       visible EDL devices, tries to open each
+ *   usb_open_device() - matches and opens a single candidate device,
+ *                       claiming its EDL interface
+ */
 #include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -81,7 +96,7 @@ static bool usb_match_usb_serial(struct libusb_device_handle *handle, const char
 	return strcmp(buf, serial) == 0;
 }
 
-static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
+static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
 {
 	const struct libusb_endpoint_descriptor *endpoint;
 	const struct libusb_interface_descriptor *ifc;
@@ -196,7 +211,7 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 }
 
 /*
- * try_usb_open() - one libusb scan-and-open pass.
+ * usb_open_once() - one libusb scan-and-open pass.
  *
  * Used as the single iteration unit by both usb_open() (the --backend usb
  * wait loop) and auto_open() (the unified Windows libusb+QUD wait loop).
@@ -221,7 +236,7 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
  * fresh enumeration (libusb's udev-less backends otherwise cache the
  * list, which would mask newly-attached devices in containerised setups).
  */
-int try_usb_open(struct qdl_device *qdl, const char *serial, int *visible_out)
+int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out)
 {
 	struct qdl_device_usb *qdl_usb = container_of(qdl, struct qdl_device_usb, base);
 	struct libusb_device_descriptor desc;
@@ -261,7 +276,7 @@ int try_usb_open(struct qdl_device *qdl, const char *serial, int *visible_out)
 
 		visible++;
 
-		ret = usb_try_open(dev, qdl_usb, serial);
+		ret = usb_open_device(dev, qdl_usb, serial);
 		if (ret == 1) {
 			found = true;
 			matched_pid = desc.idProduct;
@@ -300,7 +315,7 @@ static int usb_open(struct qdl_device *qdl, const char *serial)
 	int ret;
 
 	for (;;) {
-		ret = try_usb_open(qdl, serial, &visible);
+		ret = usb_open_once(qdl, serial, &visible);
 		if (ret == 0)
 			return 0;
 		if (ret == -EIO)

--- a/src/usb.c
+++ b/src/usb.c
@@ -350,8 +350,11 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 		libusb_exit(NULL);
 		return NULL;
 	}
-	if (device_count == 0)
+	if (device_count == 0) {
+		libusb_free_device_list(devices, 1);
+		libusb_exit(NULL);
 		return NULL;
+	}
 
 	result = calloc(device_count, sizeof(struct qdl_device_desc));
 	if (!result) {
@@ -410,6 +413,7 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 	}
 
 	libusb_free_device_list(devices, 1);
+	libusb_exit(NULL);
 	*devices_found = count;
 
 	return result;

--- a/src/usb.c
+++ b/src/usb.c
@@ -41,9 +41,10 @@ struct qdl_device_usb {
 	size_t out_chunk_size;
 };
 
-static bool usb_is_edl_pid(uint16_t pid)
+/* libusb-typed wrapper around the shared EDL identity check */
+static bool usb_is_edl_device(const struct libusb_device_descriptor *desc)
 {
-	return pid == 0x9008 || pid == 0x900e || pid == 0x901d || pid == 0x90db;
+	return qdl_is_edl_device(desc->idVendor, desc->idProduct);
 }
 
 /*
@@ -96,21 +97,73 @@ static bool usb_match_usb_serial(struct libusb_device_handle *handle, const char
 	return strcmp(buf, serial) == 0;
 }
 
-static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
+/*
+ * The EDL interface of a matched device: the bulk endpoint pair the
+ * Sahara/Firehose protocols run over.
+ */
+struct usb_edl_interface {
+	int in_ep;
+	int out_ep;
+	size_t in_maxpktsize;
+	size_t out_maxpktsize;
+};
+
+/*
+ * Check whether one interface descriptor carries the EDL service and,
+ * if so, extract its bulk endpoint pair into @edl.
+ */
+static bool usb_match_edl_interface(const struct libusb_interface_descriptor *ifc,
+				    struct usb_edl_interface *edl)
 {
 	const struct libusb_endpoint_descriptor *endpoint;
+	uint8_t type;
+	int l;
+
+	if (ifc->bInterfaceClass != 0xff)
+		return false;
+
+	if (ifc->bInterfaceSubClass != 0xff)
+		return false;
+
+	/* bInterfaceProtocol of 0xff, 0x10 and 0x11 has been seen */
+	if (ifc->bInterfaceProtocol != 0xff &&
+	    ifc->bInterfaceProtocol != 16 &&
+	    ifc->bInterfaceProtocol != 17)
+		return false;
+
+	edl->in_ep = -1;
+	edl->out_ep = -1;
+	edl->in_maxpktsize = 0;
+	edl->out_maxpktsize = 0;
+
+	for (l = 0; l < ifc->bNumEndpoints; l++) {
+		endpoint = &ifc->endpoint[l];
+
+		type = endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK;
+		if (type != LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK)
+			continue;
+
+		if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN) {
+			edl->in_ep = endpoint->bEndpointAddress;
+			edl->in_maxpktsize = endpoint->wMaxPacketSize;
+		} else {
+			edl->out_ep = endpoint->bEndpointAddress;
+			edl->out_maxpktsize = endpoint->wMaxPacketSize;
+		}
+	}
+
+	return true;
+}
+
+static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
+{
 	const struct libusb_interface_descriptor *ifc;
 	struct libusb_config_descriptor *config;
 	struct libusb_device_descriptor desc;
 	struct libusb_device_handle *handle;
-	size_t out_size;
-	size_t in_size;
-	uint8_t type;
+	struct usb_edl_interface edl;
 	int ret;
-	int out;
-	int in;
 	int k;
-	int l;
 
 	ret = libusb_get_device_descriptor(dev, &desc);
 	if (ret < 0) {
@@ -118,10 +171,7 @@ static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const
 		return -1;
 	}
 
-	/* Consider only devices with vid 0x0506 and known product id */
-	if (desc.idVendor != 0x05c6)
-		return 0;
-	if (!usb_is_edl_pid(desc.idProduct))
+	if (!usb_is_edl_device(&desc))
 		return 0;
 
 	ret = libusb_get_active_config_descriptor(dev, &config);
@@ -133,37 +183,7 @@ static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const
 	for (k = 0; k < config->bNumInterfaces; k++) {
 		ifc = config->interface[k].altsetting;
 
-		in = -1;
-		out = -1;
-		in_size = 0;
-		out_size = 0;
-
-		for (l = 0; l < ifc->bNumEndpoints; l++) {
-			endpoint = &ifc->endpoint[l];
-
-			type = endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK;
-			if (type != LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK)
-				continue;
-
-			if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN) {
-				in = endpoint->bEndpointAddress;
-				in_size = endpoint->wMaxPacketSize;
-			} else {
-				out = endpoint->bEndpointAddress;
-				out_size = endpoint->wMaxPacketSize;
-			}
-		}
-
-		if (ifc->bInterfaceClass != 0xff)
-			continue;
-
-		if (ifc->bInterfaceSubClass != 0xff)
-			continue;
-
-		/* bInterfaceProtocol of 0xff, 0x10 and 0x11 has been seen */
-		if (ifc->bInterfaceProtocol != 0xff &&
-		    ifc->bInterfaceProtocol != 16 &&
-		    ifc->bInterfaceProtocol != 17)
+		if (!usb_match_edl_interface(ifc, &edl))
 			continue;
 
 		ret = libusb_open(dev, &handle);
@@ -187,15 +207,15 @@ static int usb_open_device(libusb_device *dev, struct qdl_device_usb *qdl, const
 		}
 
 		qdl->usb_handle = handle;
-		qdl->in_ep = in;
-		qdl->out_ep = out;
-		qdl->in_maxpktsize = in_size;
-		qdl->out_maxpktsize = out_size;
+		qdl->in_ep = edl.in_ep;
+		qdl->out_ep = edl.out_ep;
+		qdl->in_maxpktsize = edl.in_maxpktsize;
+		qdl->out_maxpktsize = edl.out_maxpktsize;
 
-		if (qdl->out_chunk_size && qdl->out_chunk_size % out_size) {
+		if (qdl->out_chunk_size && qdl->out_chunk_size % edl.out_maxpktsize) {
 			ux_err("WARNING: requested out-chunk-size must be multiple of the device's wMaxPacketSize %ld, using %ld\n",
-			       out_size, out_size);
-			qdl->out_chunk_size = out_size;
+			       edl.out_maxpktsize, edl.out_maxpktsize);
+			qdl->out_chunk_size = edl.out_maxpktsize;
 		} else if (!qdl->out_chunk_size) {
 			qdl->out_chunk_size = DEFAULT_OUT_CHUNK_SIZE;
 		}
@@ -271,7 +291,7 @@ int usb_open_once(struct qdl_device *qdl, const char *serial, int *visible_out)
 
 		if (libusb_get_device_descriptor(dev, &desc) < 0)
 			continue;
-		if (desc.idVendor != 0x05c6 || !usb_is_edl_pid(desc.idProduct))
+		if (!usb_is_edl_device(&desc))
 			continue;
 
 		visible++;
@@ -388,9 +408,7 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 			continue;
 		}
 
-		if (desc.idVendor != 0x05c6)
-			continue;
-		if (!usb_is_edl_pid(desc.idProduct))
+		if (!usb_is_edl_device(&desc))
 			continue;
 
 		ret = libusb_open(dev, &handle);


### PR DESCRIPTION
The review discussion around [#286 ](https://github.com/linux-msm/qdl/pull/286) exposed a structural problem in the libusb backend: the answer to "what does qdl consider an EDL device" was scattered across three independent call sites (the scan/wait loop, the per-device open path, and `usb_list()`), with the interface-signature check in a fourth place and the QUD backend applying no identity policy at all. Scattered copies of the same policy drift apart - [#286 ](https://github.com/linux-msm/qdl/pull/286) itself updated one call site while the others kept the old behavior.

This series consolidates the policy into single-purpose helpers, decouples matching from opening, and makes the open path read as an explicit hierarchy:

```
auto_open()                        - backend selection (libusb / QUD)
  usb_open()                       - wait loop, the backend's .open op
    usb_open_once()                - one enumeration pass per 250 ms tick
      usb_enumerate_edl_devices()  - enumeration + EDL identity policy
                                     (shared with usb_list())
      usb_open_device()            - open, match, claim one candidate
        usb_match_device()         - serial filter + EDL interface match
```

The transport-agnostic part of the identity policy (`qdl_is_edl_pid()`, `qdl_is_edl_device()`, `EDL_VID`) moves to the shared header, and the QUD backend now enforces it in its Windows enumeration as well. Future changes to device acceptance (for example a new EDL or ramdump pid, or an additional interface protocol such as the 0x13 discussed in #286) become a one-line change that every path and both backends pick up consistently.

Everything is a pure refactor except the following deliberate changes, each documented in its commit:

- `qdl list` no longer hides a device whose `iProduct` string cannot be read or whose serial exceeds the descriptor field; it is listed with (none)/truncated serial instead.
- The serial filter is evaluated once per device instead of once per matching interface, and a device whose EDL interface fails to claim is no longer retried on a hypothetical second interface.
- The QUD backend no longer treats every Qualcomm COM port as an EDL device; ports whose pid is not in the shared allowlist (for example the diag port of a phone in normal composite mode) are ignored.