### PR TITLE
vip: open signed tables in binary mode on Windows

### DIFF
--- a/src/vip.c
+++ b/src/vip.c
@@ -367,7 +367,7 @@ int vip_transfer_init(struct qdl_device *qdl, const char *vip_table_path)
 
 	snprintf(fullpath, sizeof(fullpath), "%s/%s",
 		 vip_table_path, DIGEST_TABLE_TO_SIGN_FILE_MBN);
-	qdl->vip_data.signed_table_fd = open(fullpath, O_RDONLY);
+	qdl->vip_data.signed_table_fd = open(fullpath, O_RDONLY | O_BINARY);
 	if (!qdl->vip_data.signed_table_fd) {
 		ux_err("Can't open signed table %s\n", fullpath);
 		return -1;
@@ -379,7 +379,7 @@ int vip_transfer_init(struct qdl_device *qdl, const char *vip_table_path)
 		snprintf(fullpath, sizeof(fullpath), "%s/%s%d%s",
 			 vip_table_path, CHAINED_TABLE_FILE_PREF, i, ".bin");
 
-		int fd = open(fullpath, O_RDONLY);
+		int fd = open(fullpath, O_RDONLY | O_BINARY);
 
 		if (fd == -1) {
 			if (errno == ENOENT)


### PR DESCRIPTION
The signed VIP table (DigestsToSign.bin.mbn) and the chained digest tables are opened in vip_transfer_init() with a plain O_RDONLY. On Windows/MSYS2 a descriptor opened without O_BINARY defaults to text mode, which performs CRLF translation and treats a 0x1A (Ctrl-Z) byte as end-of-file.

These tables are arbitrary binary data (e.g. the 8192-byte signed table). As soon as read() hits a 0x1A byte or collapses a CRLF pair it returns fewer bytes than the file size, so vip_transfer_send_raw() fails its n == sb.st_size length check and aborts with "failed to read binary". The VIP configure request then fails. On Linux there is no text/binary distinction (O_BINARY is defined as 0) so the same code works fine.

Add O_BINARY to both open() calls in vip_transfer_init(), matching what write_digests_to_table() already does, so the tables are read verbatim on Windows as well.