### PR TITLE
qdl: drop the EDL product id allowlist and match the EDL interface signature when enumerating 

### DIFF
--- a/include/qdl.h
+++ b/include/qdl.h
@@ -146,21 +146,19 @@ int qud_probe_present(void);
 
 /*
  * EDL device identity, shared by all transport backends: Qualcomm's
- * vendor id plus the known EDL/ramdump product ids. The libusb backend
- * additionally requires a matching vendor-specific interface (see
- * usb_match_edl_interface() in usb.c); on Windows the QDLoader driver
- * performs the equivalent match before the QUD backend sees the device.
+ * vendor id. Product ids are deliberately not filtered - EDL, crash-mode
+ * and ramdump devices enumerate with a growing set of ids that no
+ * allowlist keeps up with. The libusb backend requires a matching
+ * vendor-specific interface (see usb_match_edl_interface() in usb.c)
+ * before a device is opened; on Windows the QDLoader driver binding
+ * performs the equivalent selection before the QUD backend sees the
+ * device.
  */
 #define QUALCOMM_VID 0x05c6
 
-static inline bool qdl_is_edl_pid(unsigned int pid)
+static inline bool qdl_is_edl_device(unsigned int vid, unsigned int pid __unused)
 {
-	return pid == 0x9008 || pid == 0x900e || pid == 0x901d || pid == 0x90db;
-}
-
-static inline bool qdl_is_edl_device(unsigned int vid, unsigned int pid)
-{
-	return vid == QUALCOMM_VID && qdl_is_edl_pid(pid);
+	return vid == QUALCOMM_VID;
 }
 
 struct qdl_device_desc {

--- a/src/qud.c
+++ b/src/qud.c
@@ -184,6 +184,45 @@ static unsigned int win_parse_pid(const char *hwid)
 	return pid;
 }
 
+/*
+ * Windows encodes each USB interface's class/subclass/protocol triple
+ * in the devnode's compatible ids as "USB\Class_xx&SubClass_xx&Prot_xx".
+ * Match the same EDL interface signature as the libusb backend
+ * (usb_match_edl_interface() in usb.c): vendor-specific class and
+ * subclass with a known Sahara protocol - 0x10, 0x11 or 0x13 on modern
+ * devices, 0xff on older targets.
+ */
+static bool win_match_edl_interface(HDEVINFO devinfo, SP_DEVINFO_DATA *info)
+{
+	static const char * const edl_ids[] = {
+		"USB\\Class_FF&SubClass_FF&Prot_10",
+		"USB\\Class_FF&SubClass_FF&Prot_11",
+		"USB\\Class_FF&SubClass_FF&Prot_13",
+		"USB\\Class_FF&SubClass_FF&Prot_FF",
+	};
+	char ids[1024];
+	DWORD type = 0;
+	const char *p;
+	size_t i;
+
+	if (!SetupDiGetDeviceRegistryPropertyA(devinfo, info,
+					       SPDRP_COMPATIBLEIDS, &type,
+					       (BYTE *)ids, sizeof(ids), NULL))
+		return false;
+	if (type != REG_MULTI_SZ)
+		return false;
+
+	/* REG_MULTI_SZ: walk the NUL-separated entries */
+	for (p = ids; *p; p += strlen(p) + 1) {
+		for (i = 0; i < ARRAY_SIZE(edl_ids); i++) {
+			if (!_stricmp(p, edl_ids[i]))
+				return true;
+		}
+	}
+
+	return false;
+}
+
 static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 {
 	HDEVINFO devinfo;
@@ -216,12 +255,14 @@ static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 			continue;
 
 		/*
-		 * The prefix match already guarantees Qualcomm's vid; apply
-		 * the same EDL pid policy as the libusb backend, so that all
-		 * backends agree on what an EDL device is and other Qualcomm
-		 * COM ports (for example the diag port of a phone in normal
-		 * composite mode) are not mistaken for one.
+		 * The prefix match already guarantees Qualcomm's vid; require
+		 * the same EDL interface signature the libusb backend
+		 * matches, so both backends filter other Qualcomm COM ports
+		 * the same way.
 		 */
+		if (!win_match_edl_interface(devinfo, &info))
+			continue;
+
 		pid = win_parse_pid(hwid);
 		if (!qdl_is_edl_device(QUALCOMM_VID, pid))
 			continue;

--- a/src/qud.c
+++ b/src/qud.c
@@ -264,8 +264,6 @@ static int win_enumerate_qcom(struct qud_device_desc *out, size_t out_max)
 			continue;
 
 		pid = win_parse_pid(hwid);
-		if (!qdl_is_edl_device(QUALCOMM_VID, pid))
-			continue;
 
 		if (!SetupDiGetDeviceInstanceIdA(devinfo, &info, instance_id,
 						 sizeof(instance_id), NULL))


### PR DESCRIPTION
The QUD backend accepts any Qualcomm COM port whose pid is on the
shared EDL allowlist, while the libusb backend identifies the EDL
function by its interface signature - vendor-specific class and
subclass with a known Sahara protocol. Windows exposes exactly that
triple without opening the device: PnP derives compatible ids of the
form "USB\Class_xx&SubClass_xx&Prot_xx" for every USB devnode,
including each interface of a composite device.

Require the same signature set the libusb backend matches (0x10, 0x11
and 0x13 on modern devices, 0xff on older targets), bringing the two
backends' notion of an EDL device in line and filtering Qualcomm COM
ports that expose no vendor-specific function at all

Also trust the vendor id alone in qdl_is_edl_device() and drop the
now-redundant pid gate in the QUD enumeration. The pid parameter
stays in the signature so call sites are unchanged; the interface
gates are what reject non-EDL Qualcomm devices from here on.
