### PR TITLE
Address oscompat warnings on Windows

### DIFF
--- a/src/oscompat.h
+++ b/src/oscompat.h
@@ -44,7 +44,9 @@ static inline bool path_is_absolute(const char *path)
 #ifndef _WIN32
 	return path[0] == '/';
 #else
-	return (isalpha(path[0]) && path[1] == ':') ||
+	if (path[0] == '\0')
+		return false;
+	return (isalpha((unsigned char)path[0]) && path[1] == ':') ||
 	       (path[0] == '\\' && path[1] == '\\');
 #endif
 }

--- a/tests/test_oscompat.c
+++ b/tests/test_oscompat.c
@@ -39,7 +39,13 @@ static void rmtree(const char *path)
 			if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
 				continue;
 
-			snprintf(child, sizeof(child), "%s/%s", path, ent->d_name);
+			if (snprintf(child, sizeof(child), "%s/%s", path,
+				     ent->d_name) >= (int)sizeof(child)) {
+				fprintf(stderr,
+					"skipping overly-long path %s/%s\n",
+					path, ent->d_name);
+				continue;
+			}
 			if (stat(child, &st) == 0 && S_ISDIR(st.st_mode))
 				rmtree(child);
 			else


### PR DESCRIPTION
-  rmtree() concatenates the directory path and entry name into a
   PATH_MAX buffer without checking for truncation, which -Wformat-
   truncation flags on the Windows build where PATH_MAX is 260. A
   truncated path would also make the cleanup delete the wrong file in
   principle.

- The Windows branch reads path[1] guarded only by short-circuit
   evaluation, which is correct at runtime but trips -Warray-bounds when
   the function is inlined with a string literal shorter than two bytes,
   as the oscompat unit tests do with "". It also passes a plain char
   to isalpha(), which is undefined behavior for negative values.
