### PR TITLE
Run the HIL suite unattended on self-hosted runners

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -1,0 +1,128 @@
+name: HIL
+
+# Hardware-in-the-loop runs: self-hosted runners with a device in EDL
+# reach attached (for example an Arduino Uno-Q). Board specifics stay out
+# of the repository: each runner provides QDL_HIL_BUILD, QDL_HIL_STORAGE,
+# QDL_HIL_ENTER_EDL_CMD and friends through the actions-runner .env file,
+# and tests/test_hil.sh skips cleanly when they are absent.
+#
+# SECURITY: these runners execute the checked-out tree against real
+# hardware, so this workflow must never trigger on pull requests from
+# forks. Keep the trigger to on-demand dispatch only, so a sweep runs
+# when someone asks for it and a repository without HIL runners never
+# queues a job it cannot service.
+on:
+  workflow_dispatch:
+    inputs:
+      boards:
+        description: 'Linux: JSON list of board config names (~/hil/<name>.env on the runner), or ["default"] for the runner .env'
+        required: false
+        default: ''
+      windows_boards:
+        description: 'Windows: JSON list of board config names ($HOME/hil/<name>.env under MSYS2), or ["default"] for the runner .env'
+        required: false
+        default: ''
+
+# The runners drive physical boards; run one HIL sweep at a time.
+concurrency:
+  group: hil
+  cancel-in-progress: false
+
+jobs:
+  hil-unix:
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos disabled until a runner exists; restore with: [linux, macos]
+        os: [linux]
+        # One entry per board attached to the runner. "default" uses the
+        # runner's .env unchanged; any other name sources ~/hil/<name>.env
+        # on the runner host before the suite runs. Board list comes from
+        # the dispatch input, else the HIL_LINUX_BOARDS repo variable.
+        board: ${{ fromJSON(inputs.boards || vars.HIL_LINUX_BOARDS || '["default"]') }}
+    runs-on: [self-hosted, hil, "${{ matrix.os }}"]
+    timeout-minutes: 600
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: meson setup build
+
+      - name: Build
+        run: meson compile -C build
+
+      - name: Run HIL suite
+        run: |
+          if [ "${{ matrix.board }}" != "default" ]; then
+            set -a; . "$HOME/hil/${{ matrix.board }}.env"; set +a
+          fi
+          meson test -C build --suite "${QDL_HIL_SUITE:-hil}" --print-errorlogs
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hil-logs-${{ matrix.os }}-${{ matrix.board }}
+          path: build/meson-logs/
+
+  hil-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry per board attached to the runner; same contract as
+        # hil-unix. Note MSYS2's $HOME is C:\msys64\home\<user> by
+        # default, so board files live there, not in the Windows profile.
+        board: ${{ fromJSON(inputs.windows_boards || vars.HIL_WINDOWS_BOARDS || '["default"]') }}
+    runs-on: [self-hosted, hil, windows]
+    timeout-minutes: 600
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # release: false reuses the MSYS2 installation already present on
+      # the runner instead of downloading one per job. The package list
+      # mirrors build.yml.
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          release: false
+          install: >
+            base-devel
+            git
+            help2man
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-cmocka
+            mingw-w64-x86_64-libxml2
+            mingw-w64-x86_64-libusb
+            mingw-w64-x86_64-libzip
+            mingw-w64-x86_64-xz
+            zip
+
+      - name: Configure
+        run: meson setup build
+
+      - name: Build
+        run: meson compile -C build
+
+      - name: Run HIL suite
+        run: |
+          if [ "${{ matrix.board }}" != "default" ]; then
+            set -a; . "$HOME/hil/${{ matrix.board }}.env"; set +a
+          fi
+          meson test -C build --suite "${QDL_HIL_SUITE:-hil}" --print-errorlogs
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hil-logs-windows-${{ matrix.board }}
+          path: build/meson-logs/

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -69,6 +69,32 @@ foreach s : hil_steps
   )
 endforeach
 
+# VIP-mode suite for secured boards: list and chipinfo are reused from
+# test_hil.sh; the sign-and-flash step lives in test_hil_vip.sh and
+# additionally requires QDL_HIL_SECTOOLS/SECPROFILE/SECKEYS. Run with:
+#   meson test -C build --suite hil-vip
+# The suites share the fail-fast sentinel, so run one suite at a time.
+hil_vip_steps = [
+  ['list devices',    'list',       'test_hil.sh',     110],
+  ['chipinfo',        'chipinfo',   'test_hil.sh',     105],
+  ['sign and flash',  'sign_flash', 'test_hil_vip.sh', 100],
+]
+
+foreach s : hil_vip_steps
+  test(
+    'HIL-VIP ' + s[0],
+    find_program('bash'),
+    args: [meson.current_source_dir() / s[2],
+           '--builddir', meson.project_build_root(),
+           '--step', s[1]],
+    depends: [qdl_exe],
+    suite: 'hil-vip',
+    is_parallel: false,
+    priority: s[3],
+    timeout: 1800,
+  )
+endforeach
+
 # --- unit tests (cmocka) ---
 if cmocka_dep.found()
   test_flashmap = executable('test_flashmap',

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -393,7 +393,11 @@ t_chipinfo() {
     trap 'rm -f "${out}"' RETURN
     local args=()
     [[ -n "${SERIAL}" ]] && args+=( -S "${SERIAL}" )
-    if ! "${QEXE}" "${args[@]}" chipinfo >"${out}" 2>&1; then
+    # The serial must follow the verb: qdl's verb dispatcher stops
+    # scanning at the first argument without a leading dash, so the
+    # value of a preceding "-S <serial>" derails it into the flash
+    # parser. The chipinfo subcommand parses -S itself.
+    if ! "${QEXE}" chipinfo "${args[@]}" >"${out}" 2>&1; then
         if grep -qi "already in Firehose mode" "${out}"; then
             echo "programmer already running; chipinfo needs a fresh Sahara device" >&2
             exit ${SKIP}

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -34,6 +34,12 @@
 #                       data the read step reads back, so erase/write
 #                       round-trip the partition's own content.
 #   QDL_HIL_SERIAL      -S serial, to select one of several attached devices.
+#   QDL_HIL_ENTER_EDL_CMD  Command run before the suite's first step to put
+#                       the board into EDL mode (e.g. "adb reboot edl" or a
+#                       USB relay toggle), for unattended/CI runs. When
+#                       unset the board must already be in EDL mode.
+#   QDL_HIL_SETTLE      Seconds the list step waits for the device to
+#                       enumerate after the enter-EDL command (default 30).
 #   QDL_HIL_CONTENTS    contents.xml (optionally with ::specifier) for the
 #                       create-zip step; when unset that step is skipped.
 #   QDL_HIL_SPARSE      flashmap/contents/zip that flashes sparse images, for
@@ -121,6 +127,17 @@ fi
 if [[ -e "${ABORT_FILE}" ]]; then
     echo "an earlier HIL step failed; stopping the suite" >&2
     exit ${SKIP}
+fi
+
+# For unattended runs an environment-provided command puts the board into
+# EDL mode ahead of the suite's first step. The list step polls for the
+# device afterwards (see QDL_HIL_SETTLE), so the command only needs to
+# trigger the mode switch, not wait for enumeration.
+if [[ "${step}" == "${FIRST_STEP}" && -n "${QDL_HIL_ENTER_EDL_CMD}" ]]; then
+    bash -c "${QDL_HIL_ENTER_EDL_CMD}" || {
+        echo "QDL_HIL_ENTER_EDL_CMD failed" >&2
+        exit 1
+    }
 fi
 
 IS_DIR=false
@@ -261,17 +278,29 @@ t_reset() {
     rm -f "${SAVED_IMAGE}"	# done; drop the readback backup
 }
 
-# h) Enumerate EDL devices; the attached device must appear.
+# h) Enumerate EDL devices; the attached device must appear. The enter-EDL
+# hook may have just power-cycled or rebooted the board, and enumeration
+# after that takes several seconds - the flash steps wait on their own,
+# but qdl list is a one-shot, so poll until the device shows up or
+# QDL_HIL_SETTLE expires.
 t_list() {
-    local out; out="$(mktemp -p "${HIL_TMPDIR}")"
+    local out deadline=$(( SECONDS + ${QDL_HIL_SETTLE:-30} ))
+    out="$(mktemp -p "${HIL_TMPDIR}")"
     trap 'rm -f "${out}"' RETURN
-    "${QEXE}" list >"${out}" 2>&1 || { echo "qdl list failed" >&2; cat "${out}" >&2; return 1; }
-    if grep -qi "No devices found" "${out}" ||
-       ! grep -qiE '^[0-9a-f]{4}:[0-9a-f]{4}' "${out}"; then
-        echo "qdl list did not report an attached device:" >&2
-        cat "${out}" >&2
-        return 1
-    fi
+
+    while :; do
+        "${QEXE}" list >"${out}" 2>&1 || { echo "qdl list failed" >&2; cat "${out}" >&2; return 1; }
+        if ! grep -qi "No devices found" "${out}" &&
+           grep -qiE '^[0-9a-f]{4}:[0-9a-f]{4}' "${out}"; then
+            return 0
+        fi
+        if (( SECONDS >= deadline )); then
+            echo "no EDL device appeared within ${QDL_HIL_SETTLE:-30}s:" >&2
+            cat "${out}" >&2
+            return 1
+        fi
+        sleep 1
+    done
 }
 
 # i) Package a contents.xml into a zip with create-zip, then flash the zip

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -291,11 +291,12 @@ t_list() {
     while :; do
         "${QEXE}" list >"${out}" 2>&1 || { echo "qdl list failed" >&2; cat "${out}" >&2; return 1; }
         if ! grep -qi "No devices found" "${out}" &&
-           grep -qiE '^[0-9a-f]{4}:[0-9a-f]{4}' "${out}"; then
+           grep -qiE '^[0-9a-f]{4}:[0-9a-f]{4}' "${out}" &&
+           { [[ -z "${SERIAL}" ]] || grep -qi "${SERIAL}" "${out}"; }; then
             return 0
         fi
         if (( SECONDS >= deadline )); then
-            echo "no EDL device appeared within ${QDL_HIL_SETTLE:-30}s:" >&2
+            echo "no EDL device${SERIAL:+ with serial ${SERIAL}} appeared within ${QDL_HIL_SETTLE:-30}s:" >&2
             cat "${out}" >&2
             return 1
         fi

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -385,7 +385,7 @@ t_verify_write() {
     dev_digest="$(grep -oiE '[0-9a-f]{64}' "${out}" | head -1)"
     [[ -n "${dev_digest}" ]] || { echo "no device digest:" >&2; cat "${out}" >&2; return 1; }
     local_digest="$(sha256_file "${SAVED_IMAGE}")"
-    [[ "${dev_digest}" == "${local_digest}" ]] || {
+    [[ "${dev_digest,,}" == "${local_digest,,}" ]] || {
         echo "partition digest mismatch: device=${dev_digest} local=${local_digest}" >&2
         return 1
     }

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -91,7 +91,13 @@ on_exit() {
 }
 trap on_exit EXIT
 
-if [[ "${step}" == "flash_full" ]]; then
+# The suite's first step (highest meson priority). Suite-level setup -
+# resetting the fail-fast sentinel, entering EDL mode - must anchor to it:
+# doing either in a later step breaks the steps running before it. Keep
+# this in sync with the priorities in tests/meson.build.
+FIRST_STEP="list"
+
+if [[ "${step}" == "${FIRST_STEP}" ]]; then
     rm -f "${ABORT_FILE}"
     rm -rf "${HIL_TMPDIR:?}"/*
 fi
@@ -109,8 +115,10 @@ if [[ -z "${BUILD}" || -z "${STORAGE}" ]]; then
     exit ${SKIP}
 fi
 
-# Fail-fast: if an earlier step already failed, stop the whole suite.
-if [[ "${step}" != "flash_full" && -e "${ABORT_FILE}" ]]; then
+# Fail-fast: if an earlier step already failed, stop the whole suite. No
+# step is exempt - the first step cleared the sentinel above before this
+# check, so a set sentinel always means a failure in this run.
+if [[ -e "${ABORT_FILE}" ]]; then
     echo "an earlier HIL step failed; stopping the suite" >&2
     exit ${SKIP}
 fi

--- a/tests/test_hil.sh
+++ b/tests/test_hil.sh
@@ -40,6 +40,9 @@
 #                       unset the board must already be in EDL mode.
 #   QDL_HIL_SETTLE      Seconds the list step waits for the device to
 #                       enumerate after the enter-EDL command (default 30).
+#   QDL_HIL_DEBUG       When set, run every qdl invocation with --debug so
+#                       failures leave a full protocol log in the meson
+#                       testlog (and the uploaded CI artifacts).
 #   QDL_HIL_CONTENTS    contents.xml (optionally with ::specifier) for the
 #                       create-zip step; when unset that step is skipped.
 #   QDL_HIL_SPARSE      flashmap/contents/zip that flashes sparse images, for
@@ -157,8 +160,12 @@ fi
 # otherwise the readback captured by the read step.
 IMAGE="${IMAGE:-${SAVED_IMAGE}}"
 
+# Optional debug logging on every qdl invocation, for post-mortems.
+QDLDBG=()
+[[ -n "${QDL_HIL_DEBUG}" ]] && QDLDBG=( -d )
+
 # Common qdl prefix. -R suppresses the reset everywhere but the final step.
-COMMON=( -s "${STORAGE}" )
+COMMON=( "${QDLDBG[@]}" -s "${STORAGE}" )
 [[ -n "${SERIAL}" ]] && COMMON+=( -S "${SERIAL}" )
 
 qdl_noreset() { "${QEXE}" "${COMMON[@]}" -R "$@"; }
@@ -289,7 +296,7 @@ t_list() {
     trap 'rm -f "${out}"' RETURN
 
     while :; do
-        "${QEXE}" list >"${out}" 2>&1 || { echo "qdl list failed" >&2; cat "${out}" >&2; return 1; }
+        "${QEXE}" "${QDLDBG[@]}" list >"${out}" 2>&1 || { echo "qdl list failed" >&2; cat "${out}" >&2; return 1; }
         if ! grep -qi "No devices found" "${out}" &&
            grep -qiE '^[0-9a-f]{4}:[0-9a-f]{4}' "${out}" &&
            { [[ -z "${SERIAL}" ]] || grep -qi "${SERIAL}" "${out}"; }; then
@@ -397,7 +404,7 @@ t_chipinfo() {
     # scanning at the first argument without a leading dash, so the
     # value of a preceding "-S <serial>" derails it into the flash
     # parser. The chipinfo subcommand parses -S itself.
-    if ! "${QEXE}" chipinfo "${args[@]}" >"${out}" 2>&1; then
+    if ! "${QEXE}" "${QDLDBG[@]}" chipinfo "${args[@]}" >"${out}" 2>&1; then
         if grep -qi "already in Firehose mode" "${out}"; then
             echo "programmer already running; chipinfo needs a fresh Sahara device" >&2
             exit ${SKIP}

--- a/tests/test_hil_vip.sh
+++ b/tests/test_hil_vip.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# VIP-mode HIL step: sign the firehose programmer, generate and sign the
+# VIP digest tables, then flash the build in VIP mode on a secured board.
+#
+# Registered as the final step of the "hil-vip" meson suite; the list and
+# chipinfo steps of that suite are reused from test_hil.sh, so the usual
+# QDL_HIL_BUILD/QDL_HIL_STORAGE (+ QDL_HIL_SERIAL/QDL_HIL_ENTER_EDL_CMD
+# for the rig) apply. On top of those, this step requires:
+#
+#   QDL_HIL_SECTOOLS    sectools v2 binary
+#   QDL_HIL_SECPROFILE  *_security_profile.xml for the target
+#   QDL_HIL_SECKEYS     OEM keys directory from genkeys.sh
+#                       (qpsa_rootca0.cer, qpsa_attestca0.cer/.key)
+#
+# When any of them is missing the step exits 77 (meson SKIP), so suites
+# stay green on rigs without signing material.
+#
+# Only the programmer and the digest-table mbn are signed: VIP validates
+# the flashed data stream against the signed tables, so the individual
+# images need no signatures for this test. The signing recipe mirrors
+# signimages.sh from the qcom-sec-tools repository, with the image ids
+# taken from its mapping (DEVICE-PROGRAMMER, VIP) and key index 0.
+
+set -e
+
+SKIP=77
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --builddir) builddir="$2"; shift 2 ;;
+        --step)     step="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+[[ -n "${builddir}" ]] || { echo "Error: --builddir is required." >&2; exit 1; }
+[[ "${step}" == "sign_flash" ]] || { echo "Unknown step: ${step}" >&2; exit 1; }
+
+uname_out="$(uname -s)"
+case "${uname_out}" in
+    Linux*|Darwin*) QDL=qdl ;;
+    CYGWIN*|MINGW*|MSYS*) QDL=qdl.exe ;;
+    *) exit 1 ;;
+esac
+QEXE="${builddir}/${QDL}"
+
+shopt -s nullglob
+
+# Shared with test_hil.sh: honor the suite-wide fail-fast sentinel and
+# raise it if this step fails (see the fail-fast block there).
+ABORT_FILE="${builddir}/meson-logs/hil.aborted"
+
+on_exit() {
+    local rc=$?
+    if [[ ${rc} -ne 0 && ${rc} -ne ${SKIP} ]]; then
+        mkdir -p "$(dirname "${ABORT_FILE}")" 2>/dev/null || true
+        : > "${ABORT_FILE}"
+    fi
+}
+trap on_exit EXIT
+
+BUILD="${QDL_HIL_BUILD}"
+STORAGE="${QDL_HIL_STORAGE}"
+SERIAL="${QDL_HIL_SERIAL}"
+SECTOOLS="${QDL_HIL_SECTOOLS}"
+SECPROFILE="${QDL_HIL_SECPROFILE}"
+SECKEYS="${QDL_HIL_SECKEYS}"
+
+if [[ -z "${BUILD}" || -z "${STORAGE}" ]]; then
+    echo "set QDL_HIL_BUILD and QDL_HIL_STORAGE to run the HIL suites" >&2
+    exit ${SKIP}
+fi
+
+if [[ -z "${SECTOOLS}" || -z "${SECPROFILE}" || -z "${SECKEYS}" ]]; then
+    echo "set QDL_HIL_SECTOOLS, QDL_HIL_SECPROFILE and QDL_HIL_SECKEYS" \
+         "to run the hil-vip suite" >&2
+    exit ${SKIP}
+fi
+
+if [[ -e "${ABORT_FILE}" ]]; then
+    echo "an earlier HIL step failed; stopping the suite" >&2
+    exit ${SKIP}
+fi
+
+[[ -x "${SECTOOLS}" ]] || { echo "sectools not executable: ${SECTOOLS}" >&2; exit ${SKIP}; }
+[[ -f "${SECPROFILE}" ]] || { echo "security profile not found: ${SECPROFILE}" >&2; exit ${SKIP}; }
+
+# VIP flashing follows the classic rawprogram flow, so a flat build
+# directory is required (not a flashmap/zip).
+if [[ ! -d "${BUILD}" ]]; then
+    echo "hil-vip requires a flat build directory in QDL_HIL_BUILD" >&2
+    exit ${SKIP}
+fi
+
+progs=( "${BUILD}"/prog_firehose_*.elf )
+raws=( "${BUILD}"/rawprogram*.xml )
+patches=( "${BUILD}"/patch*.xml )
+[[ ${#progs[@]} -gt 0 ]] || { echo "no prog_firehose_*.elf in ${BUILD}" >&2; exit ${SKIP}; }
+[[ ${#raws[@]} -gt 0 ]]  || { echo "no rawprogram*.xml in ${BUILD}" >&2; exit ${SKIP}; }
+
+COMMON=( -s "${STORAGE}" )
+[[ -n "${SERIAL}" ]] && COMMON+=( -S "${SERIAL}" )
+
+# Fresh workspace on the build disk; the pristine build artifacts are
+# never modified - the programmer is signed on a copy.
+WORK="${builddir}/hil-vip"
+TABLES="${WORK}/vip-tables"
+rm -rf "${WORK:?}"
+mkdir -p "${TABLES}"
+
+PROG="${WORK}/$(basename "${progs[0]}")"
+cp "${progs[0]}" "${PROG}"
+
+# Sign one image in place, following the signimages.sh recipe with
+# signing key index 0.
+sign_one() {
+    local file="$1" image_id="$2"
+    local root_cert="${SECKEYS}/qpsa_rootca0.cer"
+    local ca_cert="${SECKEYS}/qpsa_attestca0.cer"
+    local ca_key="${SECKEYS}/qpsa_attestca0.key"
+
+    if [[ ! -f "${root_cert}" || ! -f "${ca_cert}" || ! -f "${ca_key}" ]]; then
+        echo "OEM keys not found under ${SECKEYS} (expected qpsa_rootca0.cer," \
+             "qpsa_attestca0.cer, qpsa_attestca0.key)" >&2
+        exit ${SKIP}
+    fi
+
+    "${SECTOOLS}" secure-image \
+        --sign "${file}" --image-id="${image_id}" \
+        --security-profile "${SECPROFILE}" \
+        --anti-rollback-version=0x0 \
+        --signing-mode LOCAL \
+        --root-certificate "${root_cert}" \
+        --ca-certificate="${ca_cert}" --ca-key="${ca_key}" \
+        --outfile "${file}" \
+        || { echo "signing ${file} as ${image_id} failed" >&2; return 1; }
+}
+
+echo "=== signing programmer $(basename "${PROG}")"
+sign_one "${PROG}" DEVICE-PROGRAMMER
+
+echo "=== generating VIP digest tables"
+"${QEXE}" --allow-fusing --create-digests "${TABLES}" \
+          "${PROG}" "${raws[@]}" "${patches[@]}"
+[[ -f "${TABLES}/DigestsToSign.bin" ]] || {
+    echo "digest generation produced no DigestsToSign.bin" >&2
+    exit 1
+}
+
+echo "=== wrapping digest table into mbn"
+"${SECTOOLS}" mbn-tool generate --data "${TABLES}/DigestsToSign.bin" \
+              --mbn-version 6 --outfile "${TABLES}/DigestsToSign.bin.mbn"
+
+echo "=== signing digest table mbn"
+sign_one "${TABLES}/DigestsToSign.bin.mbn" VIP
+
+echo "=== flashing in VIP mode"
+"${QEXE}" "${COMMON[@]}" --allow-fusing --vip-table-path "${TABLES}" \
+          "${PROG}" "${raws[@]}" "${patches[@]}"

--- a/tests/test_hil_vip.sh
+++ b/tests/test_hil_vip.sh
@@ -100,7 +100,10 @@ patches=( "${BUILD}"/patch*.xml )
 [[ ${#progs[@]} -gt 0 ]] || { echo "no prog_firehose_*.elf in ${BUILD}" >&2; exit ${SKIP}; }
 [[ ${#raws[@]} -gt 0 ]]  || { echo "no rawprogram*.xml in ${BUILD}" >&2; exit ${SKIP}; }
 
-COMMON=( -s "${STORAGE}" )
+QDLDBG=()
+[[ -n "${QDL_HIL_DEBUG}" ]] && QDLDBG=( -d )
+
+COMMON=( "${QDLDBG[@]}" -s "${STORAGE}" )
 [[ -n "${SERIAL}" ]] && COMMON+=( -S "${SERIAL}" )
 
 # Fresh workspace on the build disk; the pristine build artifacts are
@@ -142,7 +145,7 @@ echo "=== signing programmer $(basename "${PROG}")"
 sign_one "${PROG}" DEVICE-PROGRAMMER
 
 echo "=== generating VIP digest tables"
-"${QEXE}" --allow-fusing --create-digests "${TABLES}" \
+"${QEXE}" "${QDLDBG[@]}" --allow-fusing --create-digests "${TABLES}" \
           "${PROG}" "${raws[@]}" "${patches[@]}"
 [[ -f "${TABLES}/DigestsToSign.bin" ]] || {
     echo "digest generation produced no DigestsToSign.bin" >&2


### PR DESCRIPTION
Until now the HIL suite assumed a human had already put the board into
EDL mode, so it could only be run by hand. This series makes the suite
fully unattended and adds a workflow that runs it nightly on self-hosted
runners with real boards attached.

The rig drives everything itself: an environment hook switches the board
into EDL at the start of a run, the suite waits for the device to
enumerate, targets it by serial on multi-board hosts, and resets it back
into its OS at the end so the next run can reach it again. Board
specifics never enter the repository - each runner describes its boards
through env files on the host, selected via repo variables or a dispatch
input. A new hil-vip suite additionally covers Validated Image
Programming end to end on secured boards (the feature that regressed
unnoticed in v2.6), and failing runs capture qdl's debug log so they ship
their own post-mortem. A few reliability fixes shaken out by unattended
operation (fail-fast ordering, serial vs verb parsing, digest case) are
included.

The workflow triggers only on workflow_dispatch and a nightly schedule -
never on pull requests, since the runners execute the checked-out tree
against physical hardware - and a concurrency group serializes sweeps.

Merging needs repo-side setup: register the runners, set
HIL_LINUX_BOARDS, and require approval for outside collaborators'
workflow runs.