### PR TITLE
firehose: do not probe sector size when storage init is skipped

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -554,9 +554,16 @@ static int firehose_try_configure(struct qdl_device *qdl, bool skip_storage_init
 	 * are not included in the pre-built VIP digest table (the dry-run that
 	 * builds it exits before reaching this code via the SIM early-return
 	 * above), so sending them would cause a VIP hash mismatch on the device.
+	 *
+	 * Also skip it when the caller asked for SkipStorageInit: the probe
+	 * reads force the programmer to initialize the very storage it was
+	 * told not to touch. On an unprovisioned UFS device the resulting
+	 * failed open can leave the programmer's storage stack in a state
+	 * where the provisioning commit later fails to open the device
+	 * well-known LUN. Provisioning has no use for the sector size.
 	 */
-	if (storage != QDL_STORAGE_NAND && qdl->vip_data.state == VIP_DISABLED &&
-	    !qdl->sector_size) {
+	if (!skip_storage_init && storage != QDL_STORAGE_NAND &&
+	    qdl->vip_data.state == VIP_DISABLED && !qdl->sector_size) {
 		max_sector_size = sector_sizes[ARRAY_SIZE(sector_sizes) - 1];
 		buf = alloca(max_sector_size);
 


### PR DESCRIPTION
firehose_try_configure() discovers the storage sector size by reading sector 1 of partition 0 with each candidate size. The provisioning path also runs this probe, and on a device with unprovisioned UFS the reads fail inside the programmer with "OPEN handle NULL and no error, weird": there is no LU 0 to open. The programmer does not recover from that failed open - the subsequent provisioning commit fails with "ufs_open(0, WLUN_DEV) failed for configure" and the device is left unprovisioned, while the same programmer, device and XML provision fine through QFIL, which sends no reads before the ufs tags.

Gate the probe on skip_storage_init: the probe reads force the programmer to initialize the very storage the caller declared uninitialized, and provisioning - the only path passing skip_storage_init - expresses UFS geometry in kilobytes and never needs a sector size. Reported in issue [1].

[1] https://github.com/linux-msm/qdl/issues/294