### PR TITLE
qdl: let kickstart use the standard device backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,20 +399,33 @@ images from the host to the device. It targets *flashless boot* devices
 such as the Qualcomm Cloud AI 100, which fetch their runtime firmware
 from the host on every boot rather than storing it on-device.
 
-Unlike normal flashing, kickstart does not use USB or Firehose; it
-talks to a kernel-provided device node using plain open/read/write
-operations. Its argument set is correspondingly minimal.
+Unlike normal flashing, kickstart stops once Sahara is done: no Firehose
+programmer is uploaded and nothing is written to storage.
 
-Two arguments are required: `-p` selects the Sahara port (a device node)
-and `-s id:path` registers an image mapping. The `-s` option may be
-specified more than once, one mapping per Sahara image id the device may
-request.
+One argument is required: `-s id:path` registers an image mapping. It
+may be specified more than once, one mapping per Sahara image id the
+device may request.
+
+By default the device is found through the same backends the other
+subcommands use, so `--backend` and `--serial` select it just as they do
+when flashing:
+
+```bash
+qdl ks -s 13:prog_firehose_ddr.elf
+```
+
+Devices that a kernel driver exposes as a node instead - such as the MHI
+Sahara endpoints - are addressed with `-p`, which is driven with plain
+open/read/write operations rather than through a backend:
 
 ```bash
 qdl ks -p /dev/mhi0_QAIC_SAHARA \
        -s 1:/opt/qti-aic/firmware/fw1.bin \
        -s 2:/opt/qti-aic/firmware/fw2.bin
 ```
+
+Because `-p` names the transport outright, it cannot be combined with
+`--serial` or `--backend`.
 
 The mapped files do not need to exist at invocation time. If `qdl ks`
 cannot open a requested file, the device decides the next action. This

--- a/src/oscompat.h
+++ b/src/oscompat.h
@@ -4,6 +4,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <string.h>
@@ -12,6 +13,8 @@
 
 #include <err.h>
 #include <sys/stat.h>
+#include <termios.h>
+#include <unistd.h>
 
 #define O_BINARY 0
 
@@ -48,6 +51,59 @@ static inline bool path_is_absolute(const char *path)
 		return false;
 	return (isalpha((unsigned char)path[0]) && path[1] == ':') ||
 	       (path[0] == '\\' && path[1] == '\\');
+#endif
+}
+
+/**
+ * qdl_open_device_node() - open a device node for binary protocol traffic
+ * @path: device node to open, e.g. "/dev/mhi0_QAIC_SAHARA" or "/dev/ttyUSB0"
+ *
+ * Opens @path read-write in binary mode, so that the Windows CRT does not
+ * rewrite 0x0a on the way out or end a read at the first 0x1a.
+ *
+ * Serial ports arrive in canonical mode, where the line discipline echoes
+ * input and rewrites the stream; a protocol carrying binary payloads cannot
+ * survive that, so a node that turns out to be a terminal is switched to raw
+ * mode. Nodes that are not terminals - character devices such as the MHI
+ * Sahara endpoints - pass data through untouched and need no such setup.
+ *
+ * Returns: an open file descriptor, or -1 with errno set on failure.
+ */
+static inline int qdl_open_device_node(const char *path)
+{
+	int fd;
+#ifndef _WIN32
+	struct termios tio;
+	int saved_errno;
+
+	fd = open(path, O_RDWR | O_BINARY);
+	if (fd < 0)
+		return -1;
+
+	if (!isatty(fd))
+		return fd;
+
+	if (tcgetattr(fd, &tio) < 0)
+		goto err_close;
+
+	cfmakeraw(&tio);
+
+	if (tcsetattr(fd, TCSANOW, &tio) < 0)
+		goto err_close;
+
+	return fd;
+
+err_close:
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	return -1;
+#else
+	fd = open(path, O_RDWR | O_BINARY);
+	if (fd < 0)
+		return -1;
+
+	return fd;
 #endif
 }
 

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -360,7 +360,7 @@ static void print_usage(FILE *out)
 	fprintf(out, "       %s list\n", __progname);
 	fprintf(out, "       %s chipinfo\n", __progname);
 	fprintf(out, "       %s ramdump [--debug] [-o <ramdump-path>] [<segment-filter>,...]\n", __progname);
-	fprintf(out, "       %s ks -p <sahara-dev-node> -s <id:file-path>...\n", __progname);
+	fprintf(out, "       %s ks [-p <sahara-dev-node> | --serial=T] -s <id:file-path>...\n", __progname);
 	fprintf(out, "       %s flash (<flashmap>[::specifier] | <contents>[::<specifier>])\n", __progname);
 	fprintf(out, "       %s create-zip <zipfile> <contents>[::<specifier>]\n", __progname);
 	fprintf(out, " -d, --debug\t\t\tPrint detailed debug info\n");
@@ -388,7 +388,8 @@ static void print_usage(FILE *out)
 	fprintf(out, "          \t\tnumber S, the number of sectors to follow L, or partition by \"name\"\n");
 	fprintf(out, " <ramdump-path>\t\tpath where ramdump should stored\n");
 	fprintf(out, " <segment-filter>\toptional glob-pattern to select which segments to ramdump\n");
-	fprintf(out, " <sahara-dev-node>\tSahara device node, e.g. /dev/mhi0_QAIC_SAHARA (ks)\n");
+	fprintf(out, " <sahara-dev-node>\tSahara device node, e.g. /dev/mhi0_QAIC_SAHARA (ks);\n");
+	fprintf(out, "                 \tomit to use the selected device backend (ks)\n");
 	fprintf(out, " <id:file-path>\t\tmap a Sahara image id to a host file, repeatable (ks)\n");
 	fprintf(out, " <flashmap>\tflashmap JSON file, or ZIP archive with flashmap.json\n");
 	fprintf(out, " <contents>\tcontents XML file\n");
@@ -434,6 +435,7 @@ static int qdl_list(FILE *out)
 enum {
 	OPT_BACKEND = 0x100,
 	OPT_SKIPBLOCK,
+	OPT_SERIAL,
 };
 
 static int qdl_ramdump(int argc, char **argv)
@@ -610,10 +612,15 @@ out_cleanup:
 /*
  * Sahara kickstart ("ks") subcommand.
  *
- * Kickstart talks to a kernel-provided Sahara device node (such as
- * /dev/mhi0_QAIC_SAHARA) with plain read()/write() rather than going through
- * USB/QUD, so it plugs raw-fd hooks into the device read/write vtable instead
- * of allocating a backend via qdl_init().
+ * Kickstart serves Sahara images to devices that fetch their firmware from the
+ * host rather than from local storage, and stops once Sahara is done: no
+ * Firehose programmer is involved and nothing is written to storage.
+ *
+ * Two transports are available. A kernel-provided Sahara device node (such as
+ * /dev/mhi0_QAIC_SAHARA) is selected with -p and driven with plain
+ * read()/write() through the raw-fd hooks below. When -p is omitted the same
+ * backends the other subcommands use are allocated instead, so an EDL device
+ * on the USB bus can be kickstarted directly.
  */
 static int ks_read(struct qdl_device *qdl, void *buf, size_t len,
 		   unsigned int timeout __unused)
@@ -627,19 +634,49 @@ static int ks_write(struct qdl_device *qdl, const void *buf, size_t len,
 	return write(qdl->fd, buf, len);
 }
 
+/**
+ * ks_add_mapping() - record a "<id>:<path>" image mapping
+ * @arg: option argument to parse
+ * @mappings: image array to populate, indexed by Sahara image id
+ *
+ * Returns: 0 on success, -1 on failure.
+ */
+static int ks_add_mapping(const char *arg, struct sahara_image *mappings)
+{
+	const char *filename;
+	const char *colon;
+	long file_id;
+
+	file_id = strtol(arg, NULL, 10);
+	colon = strchr(arg, ':');
+	if (file_id < 0 || file_id >= MAPPING_SZ || !colon) {
+		ux_err("invalid sahara mapping \"%s\", expected <id:path> with id in 0..%d\n",
+		       arg, MAPPING_SZ - 1);
+		return -1;
+	}
+
+	filename = colon + 1;
+	if (load_sahara_image(NULL, filename, &mappings[file_id]) < 0)
+		return -1;
+
+	ux_debug("mapped sahara image id %ld to %s\n", file_id, filename);
+
+	return 0;
+}
+
 static int qdl_ks(int argc, char **argv)
 {
 	struct sahara_image mappings[MAPPING_SZ] = {};
-	struct qdl_device qdl = {
+	struct qdl_device node_dev = {
 		.fd = -1,
 		.read = ks_read,
 		.write = ks_write,
 	};
+	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_AUTO;
+	struct qdl_device *qdl = NULL;
 	bool found_mapping = false;
 	const char *dev_node = NULL;
-	const char *filename;
-	long file_id;
-	char *colon;
+	char *serial = NULL;
 	int ret = 0;
 	int opt;
 
@@ -648,6 +685,8 @@ static int qdl_ks(int argc, char **argv)
 		{"version", no_argument, 0, 'v'},
 		{"port", required_argument, 0, 'p'},
 		{"sahara", required_argument, 0, 's'},
+		{"serial", required_argument, 0, OPT_SERIAL},
+		{"backend", required_argument, 0, OPT_BACKEND},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
@@ -663,22 +702,19 @@ static int qdl_ks(int argc, char **argv)
 		case 'p':
 			dev_node = optarg;
 			break;
+		case OPT_SERIAL:
+			serial = optarg;
+			break;
+		case OPT_BACKEND:
+			if (decode_backend(optarg, &qdl_dev_type) < 0)
+				errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
+			break;
 		case 's':
-			file_id = strtol(optarg, NULL, 10);
-			colon = strchr(optarg, ':');
-			if (file_id < 0 || file_id >= MAPPING_SZ || !colon) {
-				ux_err("invalid sahara mapping \"%s\", expected <id:path> with id in 0..%d\n",
-				       optarg, MAPPING_SZ - 1);
-				ret = 1;
-				goto out;
-			}
-			filename = colon + 1;
-			if (load_sahara_image(NULL, filename, &mappings[file_id]) < 0) {
+			if (ks_add_mapping(optarg, mappings) < 0) {
 				ret = 1;
 				goto out;
 			}
 			found_mapping = true;
-			ux_debug("mapped sahara image id %ld to %s\n", file_id, filename);
 			break;
 		case 'h':
 			print_usage(stdout);
@@ -690,9 +726,19 @@ static int qdl_ks(int argc, char **argv)
 		}
 	}
 
-	/* A device node (-p) and at least one image mapping (-s) are required */
-	if (!dev_node || !found_mapping) {
+	/* At least one image mapping (-s) is required */
+	if (!found_mapping) {
 		print_usage(stderr);
+		ret = 1;
+		goto out;
+	}
+
+	/*
+	 * -p names the transport explicitly, so device selection options that
+	 * only apply to the enumerated backends would be silently ignored.
+	 */
+	if (dev_node && (serial || qdl_dev_type != QDL_DEVICE_AUTO)) {
+		ux_err("--port cannot be combined with --serial or --backend\n");
 		ret = 1;
 		goto out;
 	}
@@ -702,17 +748,38 @@ static int qdl_ks(int argc, char **argv)
 	if (qdl_debug)
 		print_version();
 
-	qdl.fd = qdl_open_device_node(dev_node);
-	if (qdl.fd < 0) {
-		ux_err("unable to open %s: %s\n", dev_node, strerror(errno));
-		ret = 1;
-		goto out;
+	if (dev_node) {
+		node_dev.fd = qdl_open_device_node(dev_node);
+		if (node_dev.fd < 0) {
+			ux_err("unable to open %s: %s\n", dev_node, strerror(errno));
+			ret = 1;
+			goto out;
+		}
+		qdl = &node_dev;
+	} else {
+		qdl = qdl_init(qdl_dev_type);
+		if (!qdl) {
+			ux_err("backend not available\n");
+			ret = 1;
+			goto out;
+		}
+
+		if (qdl_open(qdl, serial)) {
+			ret = 1;
+			goto out_cleanup;
+		}
 	}
 
-	if (sahara_run(&qdl, mappings, NULL, NULL) < 0)
+	if (sahara_run(qdl, mappings, NULL, NULL) < 0)
 		ret = 1;
 
-	close(qdl.fd);
+out_cleanup:
+	if (dev_node)
+		close(node_dev.fd);
+	else if (qdl) {
+		qdl_close(qdl);
+		qdl_deinit(qdl);
+	}
 out:
 	sahara_images_free(mappings, MAPPING_SZ);
 	return ret;

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -702,9 +702,9 @@ static int qdl_ks(int argc, char **argv)
 	if (qdl_debug)
 		print_version();
 
-	qdl.fd = open(dev_node, O_RDWR);
+	qdl.fd = qdl_open_device_node(dev_node);
 	if (qdl.fd < 0) {
-		ux_err("unable to open %s\n", dev_node);
+		ux_err("unable to open %s: %s\n", dev_node, strerror(errno));
 		ret = 1;
 		goto out;
 	}


### PR DESCRIPTION
qdl ks required -p and drove the named node with raw read()/write(),
bypassing the device backends entirely. That limits the subcommand to
devices some kernel driver has already exposed as a node, and leaves
the common case unreachable: an EDL device sitting on the USB bus has
no node to name.

It rules out Windows altogether. There an EDL device is bound either to
the Qualcomm QDLoader driver, which the QUD backend speaks, or to
WinUSB, which libusb speaks; neither is reachable through a file
descriptor. Users were told to find a serial port that qdl could not
have used even if they found it.

Make -p optional. When it is omitted, allocate a backend exactly as
ramdump and chipinfo do, so --backend and --serial pick the device and
the transport is libusb or QUD. The Sahara layer only needs read and
write hooks, so both transports share it unchanged and kickstart keeps
stopping after Sahara. Reject -p combined with --serial or --backend
rather than silently ignoring options that cannot apply.

This makes qdl a drop-in replacement for QSaharaServer on boards that
boot flashlessly, where the SoC pulls each image over Sahara and no
Firehose programmer is ever involved. A sequence that needed a COM port
and a separate tool:

```bash
    QSaharaServer.exe -u COM8 -s 13:sbl1_flashless.mbn
    QSaharaServer.exe -u COM8 -s 1:cdt.bin -s 25:tz.mbn \
                              -s 34:devcfg.mbn -s 5:u-boot.mbn
```
becomes, with the device found the same way every other subcommand
finds it:

```bash
    qdl ks -s 13:sbl1_flashless.mbn
    qdl ks -s 1:cdt.bin -s 25:tz.mbn -s 34:devcfg.mbn -s 5:u-boot.mbn
```