### PR TITLE
Harden error paths across parsers, backends and the build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,12 @@ project('qdl', 'c',
   meson_version: '>=1.1.0'
 )
 
+# Use 64-bit file offsets everywhere. This must be consistent across every
+# translation unit: off_t appears in shared types (e.g. struct firehose_op)
+# and in the qdl_file_seek() ABI, so a per-file definition would give
+# mismatched struct layouts on 32-bit builds.
+add_project_arguments('-D_FILE_OFFSET_BITS=64', language : 'c')
+
 # Determine version
 env_v = get_option('VERSION')
 if env_v != ''

--- a/src/contents.c
+++ b/src/contents.c
@@ -521,9 +521,11 @@ static int contents_find_programmers(struct contents *contents, struct sahara_im
 			continue;
 		} else if (ret < 0) {
 			ux_err("failed to parse programmer xml \"%s\"\n", qdl_pathbuf_str(&entry->path));
+			sahara_images_free(&blob, 1);
 			return -1;
 		}
 
+		sahara_images_free(&blob, 1);
 		return 0;
 	}
 
@@ -897,6 +899,10 @@ int contents_load(struct list_head *ops, const char *filename, char *specifier,
 		flavor = selectors[i].flavor;
 
 		op = firehose_alloc_op(FIREHOSE_OP_CONFIGURE);
+		if (!op) {
+			ret = -1;
+			goto out_free_contents;
+		}
 		op->storage_type = storage_type;
 		list_append(ops, &op->node);
 

--- a/src/firehose.c
+++ b/src/firehose.c
@@ -5,7 +5,6 @@
  * All rights reserved.
  */
 #include "list.h"
-#define _FILE_OFFSET_BITS 64
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -5,7 +5,6 @@
 #include "firehose.h"
 #include <stdlib.h>
 #include <string.h>
-#define _FILE_OFFSET_BITS 64
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/json.c
+++ b/src/json.c
@@ -33,7 +33,6 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <ctype.h>
-#include <errno.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>
@@ -434,9 +433,14 @@ static int json_parse_number(struct json_value *value)
 	memcpy(token, input_buf + start, len);
 	token[len] = '\0';
 
-	errno = 0;
 	parsed = strtod(token, &endptr);
-	if (endptr != token + len || errno == ERANGE || !isfinite(parsed)) {
+	/*
+	 * Reject a token that was not fully consumed, and overflow (strtod
+	 * returns +/-inf, caught by !isfinite). Underflow to a subnormal or
+	 * zero also sets ERANGE but yields a finite, valid JSON number, so it
+	 * must not be rejected.
+	 */
+	if (endptr != token + len || !isfinite(parsed)) {
 		json_set_error("invalid or out-of-range number at offset %d", start);
 		free(token);
 		return -1;

--- a/src/json.c
+++ b/src/json.c
@@ -34,6 +34,7 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -553,7 +554,7 @@ static int json_parse_array(struct json_value *array)
 		ret = json_parse_value(value);
 		if (ret <= 0) {
 			json_set_error("invalid array element at offset %d", input_pos);
-			free(value);
+			json_free(value);
 			json_leave_nesting();
 			return -1;
 		}
@@ -613,7 +614,7 @@ static int json_parse_object(struct json_value *object)
 		ret = json_parse_property(value);
 		if (ret <= 0) {
 			json_set_error("invalid object property at offset %d", input_pos);
-			free(value);
+			json_free(value);
 			json_leave_nesting();
 			return -1;
 		}
@@ -675,12 +676,18 @@ static struct json_value *json_parse_internal(const char *json, size_t len)
 	struct json_value *root;
 	int ret;
 
+	json_error[0] = '\0';
+
+	if (len > INT_MAX) {
+		json_set_error("json input too large");
+		return NULL;
+	}
+
 	input_buf = json;
 	input_pos = 0;
 	input_len = len;
 	input_can_unput = false;
 	nesting_depth = 0;
-	json_error[0] = '\0';
 
 	root = calloc(1, sizeof(*root));
 	if (!root) {

--- a/src/patch.c
+++ b/src/patch.c
@@ -15,8 +15,6 @@
 #include "firehose.h"
 #include "qdl.h"
 
-static bool patches_loaded;
-
 int patch_load_xml(struct list_head *ops, xmlDoc *doc, const char *patch_file)
 {
 	struct firehose_op *patch;
@@ -37,6 +35,8 @@ int patch_load_xml(struct list_head *ops, xmlDoc *doc, const char *patch_file)
 		errors = 0;
 
 		patch = firehose_alloc_op(FIREHOSE_OP_PATCH);
+		if (!patch)
+			return -ENOMEM;
 
 		patch->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 		patch->byte_offset = attr_as_unsigned(node, "byte_offset", &errors);
@@ -54,13 +54,11 @@ int patch_load_xml(struct list_head *ops, xmlDoc *doc, const char *patch_file)
 			free((void *)patch->value);
 			free((void *)patch->what);
 			free(patch);
-			continue;
+			return -EINVAL;
 		}
 
 		list_append(ops, &patch->node);
 	}
-
-	patches_loaded = true;
 
 	return 0;
 }

--- a/src/program.c
+++ b/src/program.c
@@ -6,7 +6,6 @@
 #include "contents.h"
 #include "pathbuf.h"
 #include <assert.h>
-#define _FILE_OFFSET_BITS 64
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/read.c
+++ b/src/read.c
@@ -47,6 +47,10 @@ int read_op_load(struct list_head *ops, const char *read_op_file, const char *in
 		errors = 0;
 
 		read_op = firehose_alloc_op(FIREHOSE_OP_READ);
+		if (!read_op) {
+			xmlFreeDoc(doc);
+			return -ENOMEM;
+		}
 
 		read_op->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 		read_op->filename = attr_as_string(node, "filename", &errors);
@@ -56,14 +60,19 @@ int read_op_load(struct list_head *ops, const char *read_op_file, const char *in
 
 		if (errors) {
 			ux_err("errors while parsing read-type file \"%s\"\n", read_op_file);
+			free((void *)read_op->filename);
+			free((void *)read_op->start_sector);
 			free(read_op);
-			continue;
+			xmlFreeDoc(doc);
+			return -EINVAL;
 		}
 
-		if (incdir) {
+		if (incdir && read_op->filename) {
 			snprintf(tmp, PATH_MAX, "%s/%s", incdir, read_op->filename);
-			if (access(tmp, F_OK) != -1)
+			if (access(tmp, F_OK) != -1) {
+				free((void *)read_op->filename);
 				read_op->filename = strdup(tmp);
+			}
 		}
 
 		list_append(ops, &read_op->node);

--- a/src/sim.c
+++ b/src/sim.c
@@ -427,8 +427,21 @@ static int sim_read(struct qdl_device *qdl, void *buf, size_t len,
 	 */
 	resp = qdl_sim->resp_head;
 	if (resp) {
-		copy_len = resp->len;
+		copy_len = MIN(len, resp->len);
 		memcpy(buf, resp->data, copy_len);
+
+		/*
+		 * If the caller's buffer could not hold the whole response,
+		 * keep the remainder queued for the next read instead of
+		 * overflowing @buf or dropping data.
+		 */
+		if (copy_len < resp->len) {
+			memmove(resp->data, resp->data + copy_len,
+				resp->len - copy_len);
+			resp->len -= copy_len;
+			return copy_len;
+		}
+
 		qdl_sim->resp_head = resp->next;
 		if (!qdl_sim->resp_head)
 			qdl_sim->resp_tail = NULL;

--- a/src/sparse.c
+++ b/src/sparse.c
@@ -3,7 +3,6 @@
  * Copyright (c) 2025, Maksim Paimushkin <maxim.paymushkin.development@gmail.com>
  * All rights reserved.
  */
-#define _FILE_OFFSET_BITS 64
 #ifdef _WIN32
 #include <winsock2.h>
 #else

--- a/src/sparse.c
+++ b/src/sparse.c
@@ -70,8 +70,13 @@ int sparse_chunk_header_parse(struct qdl_file *file,
 		return -EINVAL;
 	}
 
-	if (sparse_header->chunk_hdr_sz > sizeof(chunk_header_t))
-		qdl_file_seek(file, sparse_header->chunk_hdr_sz - sizeof(chunk_header_t), SEEK_CUR);
+	if (sparse_header->chunk_hdr_sz > sizeof(chunk_header_t)) {
+		if (qdl_file_seek(file, sparse_header->chunk_hdr_sz - sizeof(chunk_header_t),
+				  SEEK_CUR) < 0) {
+			ux_err("[SPARSE] Unable to seek past extended chunk header\n");
+			return -EINVAL;
+		}
+	}
 
 	type = chunk_header.chunk_type;
 	*chunk_size = (uint64_t)chunk_header.chunk_sz * sparse_header->blk_sz;
@@ -85,9 +90,16 @@ int sparse_chunk_header_parse(struct qdl_file *file,
 
 		/* Save the current file offset in the 'value' variable */
 		*offset = qdl_file_seek(file, 0, SEEK_CUR);
+		if (*offset < 0) {
+			ux_err("[SPARSE] Unable to determine chunk offset\n");
+			return -EINVAL;
+		}
 
 		/* Move the file cursor forward by the size of the chunk */
-		qdl_file_seek(file, *chunk_size, SEEK_CUR);
+		if (qdl_file_seek(file, *chunk_size, SEEK_CUR) < 0) {
+			ux_err("[SPARSE] Unable to seek past raw chunk data\n");
+			return -EINVAL;
+		}
 		break;
 	case CHUNK_TYPE_DONT_CARE:
 		if (chunk_header.total_sz != sparse_header->chunk_hdr_sz) {

--- a/src/usb.c
+++ b/src/usb.c
@@ -207,6 +207,16 @@ static bool usb_match_edl_interface(const struct libusb_interface_descriptor *if
 		}
 	}
 
+	/*
+	 * A matching interface is only usable if it exposes both a bulk
+	 * IN and a bulk OUT endpoint with a non-zero max packet size.
+	 * Without this check a malformed descriptor leads to a division
+	 * by zero (out_maxpktsize == 0) or transfers on endpoint -1.
+	 */
+	if (edl->in_ep < 0 || edl->out_ep < 0 ||
+	    !edl->in_maxpktsize || !edl->out_maxpktsize)
+		return false;
+
 	return true;
 }
 

--- a/src/vip.c
+++ b/src/vip.c
@@ -126,6 +126,10 @@ void vip_gen_chunk_store(struct qdl_device *qdl)
 	if (!vip_gen)
 		return;
 
+	/* A previous store already hit a write error and closed the file. */
+	if (!vip_gen->digest_table_fd)
+		return;
+
 	SHA256Final(vip_gen->hash, &vip_gen->ctx);
 
 	print_digest(vip_gen->hash);
@@ -350,7 +354,8 @@ void vip_gen_finalize(struct qdl_device *qdl)
 	if (!vip_gen)
 		return;
 
-	fclose(vip_gen->digest_table_fd);
+	if (vip_gen->digest_table_fd)
+		fclose(vip_gen->digest_table_fd);
 
 	ux_debug("VIP TABLE DIGESTS: %lu\n", vip_gen->digest_num_written);
 
@@ -368,7 +373,7 @@ int vip_transfer_init(struct qdl_device *qdl, const char *vip_table_path)
 	snprintf(fullpath, sizeof(fullpath), "%s/%s",
 		 vip_table_path, DIGEST_TABLE_TO_SIGN_FILE_MBN);
 	qdl->vip_data.signed_table_fd = open(fullpath, O_RDONLY | O_BINARY);
-	if (!qdl->vip_data.signed_table_fd) {
+	if (qdl->vip_data.signed_table_fd < 0) {
 		ux_err("Can't open signed table %s\n", fullpath);
 		return -1;
 	}

--- a/src/zipper.c
+++ b/src/zipper.c
@@ -3,7 +3,6 @@
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 #define _GNU_SOURCE
-#define _FILE_OFFSET_BITS 64
 #include <limits.h>
 #include <libgen.h>
 #include <errno.h>


### PR DESCRIPTION
Second batch of fixes from the same audit that produced [#284](https://github.com/linux-msm/qdl/pull/284): MEDIUM-severity hardening of error paths, resource cleanup and input validation. No behavior
changes on the happy path.

- **json**: fix error-path leaks, reject oversized input, and accept
  subnormal numbers instead of rejecting them on ERANGE
- **contents**: check op allocation and free the consumed programmer blob
- **patch**: abort on malformed patch entries instead of flashing past them
- **read**: propagate parse failures and fix op string leaks
- **sim**: bound sim_read() to the caller's buffer
- **usb**: reject an EDL interface lacking usable bulk endpoints
  (prevents a division by zero and transfers on endpoint -1)
- **vip**: fix the signed-table fd check (`!fd` -> `fd < 0`) and make a
  disk-full during --create-digest fail cleanly instead of crashing
- **sparse**: detect seek failures on zip-backed images
- **meson**: set _FILE_OFFSET_BITS=64 project-wide instead of per-file