### PR TITLE
For linux msm/create sahara archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,20 +362,37 @@ Directly providing a list of ids and filenames is cumbersome and error-prone,
 so QDL accepts a "*programmer archive*". This allows the user to use the
 tool in the same fashion as was done for single-programmer targets.
 
-The *programmer archive* is a CPIO archive containing the Sahara images to be
-loaded, identified by the filename **id[:filename]** (*filename* is optional,
-but useful for debugging). Each included file will be used to serve requests
-for the given Sahara *id*.
+The *programmer archive* contains the Sahara images to be loaded, identified by
+the Sahara *id* needed by the target.
 
-Such an archive can be created by putting the target's programmer images in an
-empty directory, then executing the following command from that directory:
+QDL can create such an archive from the same programmer descriptions accepted
+for flashing. To create an archive from a command-line Sahara image list:
 
 ```bash
-ls | cpio -o -H newc > ../programmer.cpio
+qdl create-sahara-archive programmer.bin 13:prog_firehose_ddr.elf,42:the-answer
 ```
 
-*programmer.cpio* can now be passed to QDL and the included images will be
-served in order to reach Firehose mode.
+To create an archive from a Sahara configuration XML file:
+
+```bash
+qdl create-sahara-archive programmer.bin sahara_programmer.xml
+```
+
+To create an archive from a contents XML file:
+
+```bash
+qdl create-sahara-archive programmer.bin contents.xml
+```
+
+When the contents XML describes multiple storage or flavor combinations, select
+exactly one with the same `::specifier` syntax used by `flash`:
+
+```bash
+qdl create-sahara-archive programmer.bin contents.xml::ufs
+```
+
+*programmer.bin* can now be passed to QDL and the included images will be served
+in order to reach Firehose mode.
 
 ## Collect crash dump
 

--- a/src/contents.c
+++ b/src/contents.c
@@ -497,15 +497,27 @@ err_free_doc:
 	return -1;
 }
 
-static int contents_find_programmers(struct contents *contents, struct sahara_image *images)
+static int contents_find_programmers(struct contents *contents,
+				     struct contents_filter *filter,
+				     struct sahara_image *images)
 {
-	struct contents_filter filter = { .contents = contents };
+	struct contents_filter default_filter = { .contents = contents };
 	struct contents_entry *entry;
 	struct sahara_image blob;
 	int ret;
 
+	if (!filter)
+		filter = &default_filter;
+
 	list_for_each_entry(entry, &contents->entries, node) {
 		if (entry->file_type != CONTENTS_FILE_PROGRAMMER_XML)
+			continue;
+		if (filter->storage_type != QDL_STORAGE_UNKNOWN &&
+		    entry->storage_type != QDL_STORAGE_UNKNOWN &&
+		    entry->storage_type != filter->storage_type)
+			continue;
+		if (entry->flavor && filter->flavor &&
+		    strcmp(entry->flavor, filter->flavor))
 			continue;
 
 		ret = load_sahara_image(NULL, qdl_pathbuf_str(&entry->path), &blob);
@@ -514,7 +526,7 @@ static int contents_find_programmers(struct contents *contents, struct sahara_im
 			continue;
 		}
 
-		ret = decode_sahara_config(&blob, images, &filter);
+		ret = decode_sahara_config(&blob, images, filter);
 		if (ret == 0) {
 			ux_err("%s is not a programmer xml\n", qdl_pathbuf_str(&entry->path));
 			sahara_images_free(&blob, 1);
@@ -529,6 +541,13 @@ static int contents_find_programmers(struct contents *contents, struct sahara_im
 
 	list_for_each_entry(entry, &contents->entries, node) {
 		if (entry->file_type != CONTENTS_FILE_DEVICE_PROGRAMMER)
+			continue;
+		if (filter->storage_type != QDL_STORAGE_UNKNOWN &&
+		    entry->storage_type != QDL_STORAGE_UNKNOWN &&
+		    entry->storage_type != filter->storage_type)
+			continue;
+		if (entry->flavor && filter->flavor &&
+		    strcmp(entry->flavor, filter->flavor))
 			continue;
 
 		if (entry->firehose_type == FIREHOSE_TYPE_LITE)
@@ -888,7 +907,8 @@ int contents_load(struct list_head *ops, const char *filename, char *specifier,
 		goto out_free_contents;
 	}
 
-	ret = contents_find_programmers(&contents, images);
+	filter.contents = &contents;
+	ret = contents_find_programmers(&contents, &filter, images);
 	if (ret < 0)
 		goto out_free_contents;
 
@@ -935,6 +955,51 @@ int contents_load(struct list_head *ops, const char *filename, char *specifier,
 			}
 		}
 	}
+
+out_free_contents:
+	for (flavor_idx = 0; flavor_idx < contents.num_flavors; flavor_idx++)
+		free(contents.flavors[flavor_idx]);
+	free(contents.flavors);
+
+	list_for_each_entry_safe(entry, next, &contents.entries, node) {
+		free(entry->filename);
+		free(entry->flavor);
+		free(entry);
+	}
+	free(selectors);
+
+	return ret;
+}
+
+int contents_load_programmers(const char *filename, char *specifier,
+			      struct sahara_image *images)
+{
+	struct contents_filter filter = {};
+	struct contents_selector *selectors = NULL;
+	struct contents_entry *entry;
+	struct contents_entry *next;
+	struct contents contents = {};
+	size_t flavor_idx;
+	int ret;
+
+	list_init(&contents.entries);
+	ret = contents_load_xml(&contents, filename);
+	if (ret < 0)
+		goto out_free_contents;
+
+	ret = contents_decode_selectors(&contents, specifier, &selectors);
+	if (ret < 0)
+		goto out_free_contents;
+	if (ret != 1) {
+		ux_err("select exactly one storage/flavor combination for Sahara archive creation\n");
+		ret = -1;
+		goto out_free_contents;
+	}
+
+	filter.contents = &contents;
+	filter.storage_type = selectors[0].storage_type;
+	filter.flavor = selectors[0].flavor;
+	ret = contents_find_programmers(&contents, &filter, images);
 
 out_free_contents:
 	for (flavor_idx = 0; flavor_idx < contents.num_flavors; flavor_idx++)

--- a/src/contents.h
+++ b/src/contents.h
@@ -16,6 +16,8 @@ struct contents_filter;
 
 int contents_load(struct list_head *ops, const char *filename, char *specifier,
 		  struct sahara_image *images, const char *incdir);
+int contents_load_programmers(const char *filename, char *specifier,
+			      struct sahara_image *images);
 int contents_resolve_path(struct contents_filter *filter, const char *filename, struct pathbuf *path);
 
 #endif

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -10,6 +10,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -348,6 +349,120 @@ static int decode_programmer(char *s, struct sahara_image *images)
 	return 0;
 }
 
+static char *qdl_basename_dup(const char *path)
+{
+	char *tmp;
+	char *base;
+
+	tmp = strdup(path);
+	if (!tmp)
+		return NULL;
+
+	base = basename(tmp);
+	base = base ? strdup(base) : NULL;
+	free(tmp);
+
+	return base;
+}
+
+static int sahara_archive_pad(FILE *out, size_t len)
+{
+	static const char zeros[4];
+	size_t pad = ROUND_UP(len, 4) - len;
+
+	if (!pad)
+		return 0;
+
+	return fwrite(zeros, 1, pad, out) == pad ? 0 : -1;
+}
+
+static int sahara_archive_write_entry(FILE *out, unsigned int ino, const char *name,
+				      const void *data, size_t len)
+{
+	char header[sizeof(struct cpio_newc_header) + 1];
+	size_t namesize = strlen(name) + 1;
+
+	if (len > UINT32_MAX || namesize > UINT32_MAX) {
+		ux_err("sahara archive entry \"%s\" is too large\n", name);
+		return -1;
+	}
+
+	snprintf(header, sizeof(header),
+		 "%s%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x",
+		 CPIO_MAGIC, ino, 0100644, 0, 0, 1, 0, (unsigned int)len,
+		 0, 0, 0, 0, (unsigned int)namesize, 0);
+
+	if (fwrite(header, 1, sizeof(struct cpio_newc_header), out) !=
+	    sizeof(struct cpio_newc_header))
+		return -1;
+	if (fwrite(name, 1, namesize, out) != namesize)
+		return -1;
+	if (sahara_archive_pad(out, sizeof(struct cpio_newc_header) + namesize) < 0)
+		return -1;
+	if (len && fwrite(data, 1, len, out) != len)
+		return -1;
+	if (sahara_archive_pad(out, len) < 0)
+		return -1;
+
+	return 0;
+}
+
+static int sahara_archive_write(const char *filename, const struct sahara_image *images)
+{
+	char *basename = NULL;
+	char name[128];
+	unsigned int ino = 1;
+	unsigned int count = 0;
+	FILE *out;
+	int ret = -1;
+	int i;
+
+	for (i = 1; i < MAPPING_SZ; i++) {
+		if (images[i].ptr)
+			count++;
+	}
+
+	if (!count) {
+		ux_err("no Sahara images found for archive\n");
+		return -1;
+	}
+
+	out = fopen(filename, "wb");
+	if (!out) {
+		ux_err("failed to create \"%s\": %s\n", filename, strerror(errno));
+		return -1;
+	}
+
+	for (i = 1; i < MAPPING_SZ; i++) {
+		if (!images[i].ptr)
+			continue;
+
+		free(basename);
+		basename = images[i].name ? qdl_basename_dup(images[i].name) : NULL;
+		if (basename)
+			snprintf(name, sizeof(name), "%d:%s", i, basename);
+		else
+			snprintf(name, sizeof(name), "%d", i);
+
+		if (sahara_archive_write_entry(out, ino++, name, images[i].ptr,
+					       images[i].len) < 0)
+			goto out_close;
+	}
+
+	ret = sahara_archive_write_entry(out, ino++, "TRAILER!!!", NULL, 0);
+
+out_close:
+	free(basename);
+	if (fclose(out) && ret == 0)
+		ret = -1;
+	if (ret < 0) {
+		ux_err("failed to write Sahara archive \"%s\"\n", filename);
+		remove(filename);
+	}
+
+	return ret;
+}
+
 static void print_usage(FILE *out)
 {
 	extern const char *__progname;
@@ -363,6 +478,9 @@ static void print_usage(FILE *out)
 	fprintf(out, "       %s ks [-p <sahara-dev-node> | --serial=T] -s <id:file-path>...\n", __progname);
 	fprintf(out, "       %s flash (<flashmap>[::specifier] | <contents>[::<specifier>])\n", __progname);
 	fprintf(out, "       %s create-zip <zipfile> <contents>[::<specifier>]\n", __progname);
+	fprintf(out, "       %s create-sahara-archive <archive.bin> "
+		"(<id:file>[,<id:file>...] | <sahara.xml> | <contents.xml>[::<specifier>])\n",
+		__progname);
 	fprintf(out, " -d, --debug\t\t\tPrint detailed debug info\n");
 	fprintf(out, " -v, --version\t\t\tPrint the current version and exit\n");
 	fprintf(out, " -n, --dry-run\t\t\tDry run execution, no device reading or flashing\n");
@@ -393,6 +511,7 @@ static void print_usage(FILE *out)
 	fprintf(out, " <id:file-path>\t\tmap a Sahara image id to a host file, repeatable (ks)\n");
 	fprintf(out, " <flashmap>\tflashmap JSON file, or ZIP archive with flashmap.json\n");
 	fprintf(out, " <contents>\tcontents XML file\n");
+	fprintf(out, " <archive.bin>\tSahara programmer archive to create\n");
 	fprintf(out, " <specifier>\tcomma-separated list of specifiers, such as storage type, layout, and flavors\n");
 	fprintf(out, "\n");
 	fprintf(out, "Example: %s prog_firehose_ddr.elf rawprogram*.xml patch*.xml\n", __progname);
@@ -960,6 +1079,70 @@ out_free_filename:
 	return ret ? 1 : 0;
 }
 
+static bool qdl_is_contents_xml(const char *filename)
+{
+	xmlNode *root;
+	xmlDoc *doc;
+	bool ret;
+
+	doc = xmlReadFile(filename, NULL, XML_PARSE_NONET | XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+	if (!doc)
+		return false;
+
+	root = xmlDocGetRootElement(doc);
+	ret = root && !xmlStrcmp(root->name, (xmlChar *)"contents");
+
+	xmlFreeDoc(doc);
+
+	return ret;
+}
+
+static int qdl_sahara_archive(int argc, char **argv)
+{
+	struct sahara_image images[MAPPING_SZ] = {};
+	const char *archive;
+	char *specifier;
+	char *filename;
+	int ret = 0;
+
+	if (argc != 3) {
+		print_usage(stderr);
+		return 1;
+	}
+
+	ux_init();
+
+	archive = argv[1];
+	filename = qdl_split_specifier(argv[2], &specifier);
+	if (!filename) {
+		ux_err("failed to parse Sahara archive input \"%s\"\n", argv[2]);
+		ret = -1;
+		goto out_free_images;
+	}
+
+	if (qdl_is_contents_xml(filename)) {
+		ret = contents_load_programmers(filename, specifier, images);
+	} else {
+		if (specifier) {
+			ux_err("selectors can only be used with contents.xml inputs\n");
+			ret = -1;
+		} else {
+			ret = decode_programmer(filename, images);
+		}
+	}
+	free(filename);
+	if (ret < 0)
+		goto out_free_images;
+	ret = 0;
+
+	ret = sahara_archive_write(archive, images);
+
+out_free_images:
+	sahara_images_free(images, MAPPING_SZ);
+
+	return ret ? 1 : 0;
+}
+
 static int qdl_determine_bootable(struct list_head *ops)
 {
 	struct firehose_op *op;
@@ -1369,6 +1552,8 @@ int main(int argc, char **argv)
 			return qdl_ks(argc - i, argv + i);
 		if (!strcmp(argv[i], "create-zip"))
 			return qdl_create_zip(argc - i, argv + i);
+		if (!strcmp(argv[i], "create-sahara-archive"))
+			return qdl_sahara_archive(argc - i, argv + i);
 		if (argv[i][0] != '-')
 			break;
 	}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,14 @@ test(
   suite: 'integration',
 )
 
+test(
+  'Sahara archive generation',
+  find_program('python3'),
+  args: [meson.current_source_dir() / 'test_sahara_archive.py', '--builddir', meson.project_build_root()],
+  depends: [qdl_exe],
+  suite: 'integration',
+)
+
 # --- hardware-in-the-loop tests ---
 # Each step is a separate test in the "hil" suite. Run explicitly against an
 # attached EDL device with:

--- a/tests/test_contents_xml.c
+++ b/tests/test_contents_xml.c
@@ -461,7 +461,7 @@ static void test_find_programmers_prefers_programmer_xml(void **state)
 
 	init_contents(&contents);
 	assert_int_equal(contents_load_xml(&contents, fixture->contents_xml), 0);
-	assert_int_equal(contents_find_programmers(&contents, images), 0);
+	assert_int_equal(contents_find_programmers(&contents, NULL, images), 0);
 	assert_int_equal(mock_decode_call_count, 1);
 	assert_int_equal(mock_load_call_count, 1);
 	assert_non_null(strstr(mock_last_load_filename, "programmer.xml"));
@@ -480,7 +480,7 @@ static void test_find_programmers_falls_back_to_non_lite_device_programmer(void 
 
 	init_contents(&contents);
 	assert_int_equal(contents_load_xml(&contents, fixture->contents_xml), 0);
-	assert_int_equal(contents_find_programmers(&contents, images), 0);
+	assert_int_equal(contents_find_programmers(&contents, NULL, images), 0);
 	assert_int_equal(mock_decode_call_count, 0);
 	assert_int_equal(mock_load_call_count, 1);
 	assert_non_null(strstr(mock_last_load_filename, "prog_firehose_ddr.elf"));
@@ -499,7 +499,7 @@ static void test_find_programmers_rejects_lite_only_device_programmer(void **sta
 
 	init_contents(&contents);
 	assert_int_equal(contents_load_xml(&contents, fixture->contents_xml), 0);
-	assert_int_equal(contents_find_programmers(&contents, images), -1);
+	assert_int_equal(contents_find_programmers(&contents, NULL, images), -1);
 	assert_int_equal(mock_decode_call_count, 0);
 	assert_int_equal(mock_load_call_count, 0);
 

--- a/tests/test_sahara_archive.py
+++ b/tests/test_sahara_archive.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def align_up(value, align):
+    return (value + align - 1) & ~(align - 1)
+
+
+def read_hex(data, offset):
+    return int(data[offset:offset + 8], 16)
+
+
+def parse_newc(filename):
+    data = Path(filename).read_bytes()
+    pos = 0
+    entries = {}
+
+    while True:
+        header = data[pos:pos + 110]
+        assert len(header) == 110, "truncated archive header"
+        assert header[:6] == b"070701", "bad archive magic"
+
+        filesize = read_hex(header, 54)
+        namesize = read_hex(header, 94)
+        pos += 110
+
+        name = data[pos:pos + namesize]
+        assert len(name) == namesize, "truncated archive name"
+        assert name[-1:] == b"\0", "unterminated archive name"
+        name = name[:-1].decode("ascii")
+
+        pos = align_up(pos + namesize, 4)
+
+        payload = data[pos:pos + filesize]
+        assert len(payload) == filesize, "truncated archive payload"
+        pos = align_up(pos + filesize, 4)
+
+        if name == "TRAILER!!!":
+            break
+
+        entries[name] = payload
+
+    return entries
+
+
+def run_qdl(qdl, *args, cwd=None, expect_success=True):
+    result = subprocess.run([qdl, *args], cwd=cwd, capture_output=True,
+                            text=True)
+
+    if expect_success and result.returncode:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise AssertionError("qdl command failed")
+
+    if not expect_success and not result.returncode:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise AssertionError("qdl command succeeded unexpectedly")
+
+    return result
+
+
+def write_payloads(path):
+    payloads = {
+        "prog.elf": b"programmer\0payload\n",
+        "cfg.elf": b"cfg",
+        "aux.bin": bytes(range(17)),
+    }
+
+    path.mkdir(parents=True, exist_ok=True)
+    for name, data in payloads.items():
+        (path / name).write_bytes(data)
+
+    return payloads
+
+
+def write_sahara_xml(filename, payload_dir, prog_name="prog.elf",
+                     cfg_name="cfg.elf"):
+    filename.write_text(f"""<?xml version="1.0" ?>
+<sahara_config>
+  <chipset>test</chipset>
+  <images>
+    <image image_id="13" image_path="{payload_dir / prog_name}"/>
+    <image image_id="38" image_path="{payload_dir / cfg_name}"/>
+  </images>
+</sahara_config>
+""", encoding="ascii")
+
+
+def write_relative_sahara_xml(filename):
+    filename.write_text("""<?xml version="1.0" ?>
+<sahara_config>
+  <chipset>test</chipset>
+  <images>
+    <image image_id="13" image_path="prog.elf"/>
+    <image image_id="38" image_path="cfg.elf"/>
+  </images>
+</sahara_config>
+""", encoding="ascii")
+
+
+def write_contents_xml(filename):
+    filename.write_text("""<?xml version="1.0" ?>
+<contents>
+  <builds_flat>
+    <build>
+      <windows_root_path>./</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <file_ref firehose_type="true">
+        <file_name>sahara.xml</file_name>
+        <file_path>./</file_path>
+      </file_ref>
+      <download_file>
+        <file_name>prog.elf</file_name>
+        <file_path>payloads/</file_path>
+      </download_file>
+      <download_file>
+        <file_name>cfg.elf</file_name>
+        <file_path>payloads/</file_path>
+      </download_file>
+      <partition_file storage_type="ufs">
+        <file_name>rawprogram.xml</file_name>
+        <file_path>./</file_path>
+      </partition_file>
+    </build>
+  </builds_flat>
+</contents>
+""", encoding="ascii")
+
+
+def write_multi_contents_xml(filename):
+    filename.write_text("""<?xml version="1.0" ?>
+<contents>
+  <builds_flat>
+    <build>
+      <windows_root_path>./</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <file_ref firehose_type="true" storage_type="ufs">
+        <file_name>ufs-sahara.xml</file_name>
+        <file_path>./</file_path>
+      </file_ref>
+      <file_ref firehose_type="true" storage_type="emmc">
+        <file_name>emmc-sahara.xml</file_name>
+        <file_path>./</file_path>
+      </file_ref>
+      <download_file storage_type="ufs">
+        <file_name>prog.elf</file_name>
+        <file_path>ufs/</file_path>
+      </download_file>
+      <download_file storage_type="emmc">
+        <file_name>prog.elf</file_name>
+        <file_path>emmc/</file_path>
+      </download_file>
+      <partition_file storage_type="ufs">
+        <file_name>rawprogram-ufs.xml</file_name>
+        <file_path>./</file_path>
+      </partition_file>
+      <partition_file storage_type="emmc">
+        <file_name>rawprogram-emmc.xml</file_name>
+        <file_path>./</file_path>
+      </partition_file>
+    </build>
+  </builds_flat>
+</contents>
+""", encoding="ascii")
+
+
+def write_single_image_sahara_xml(filename):
+    filename.write_text("""<?xml version="1.0" ?>
+<sahara_config>
+  <chipset>test</chipset>
+  <images>
+    <image image_id="13" image_path="prog.elf"/>
+  </images>
+</sahara_config>
+""", encoding="ascii")
+
+
+def assert_archive(filename, expected):
+    entries = parse_newc(filename)
+
+    assert entries == expected, \
+        f"archive entries mismatch: {sorted(entries)} != {sorted(expected)}"
+
+
+def assert_no_archive(path):
+    assert not path.exists(), f"unexpected archive created: {path}"
+
+
+def test_mapping(qdl, work, payloads):
+    out = work / "mapping.bin"
+    payload_dir = work / "payloads"
+
+    run_qdl(qdl, "create-sahara-archive", str(out),
+            f"13:{payload_dir / 'prog.elf'},38:{payload_dir / 'cfg.elf'}")
+
+    assert_archive(out, {
+        "13:prog.elf": payloads["prog.elf"],
+        "38:cfg.elf": payloads["cfg.elf"],
+    })
+
+
+def test_sahara_xml(qdl, work, payloads):
+    out = work / "sahara.bin"
+    xml = work / "sahara-absolute.xml"
+
+    write_sahara_xml(xml, work / "payloads")
+    run_qdl(qdl, "create-sahara-archive", str(out), str(xml))
+
+    assert_archive(out, {
+        "13:prog.elf": payloads["prog.elf"],
+        "38:cfg.elf": payloads["cfg.elf"],
+    })
+
+
+def test_contents_xml(qdl, work, payloads):
+    out = work / "contents.bin"
+    xml = work / "contents.xml"
+
+    write_relative_sahara_xml(work / "sahara.xml")
+    write_contents_xml(xml)
+    run_qdl(qdl, "create-sahara-archive", str(out), str(xml))
+
+    assert_archive(out, {
+        "13:prog.elf": payloads["prog.elf"],
+        "38:cfg.elf": payloads["cfg.elf"],
+    })
+
+
+def test_contents_xml_selector(qdl, work):
+    xml = work / "multi-contents.xml"
+    ufs = work / "ufs"
+    emmc = work / "emmc"
+
+    ufs.mkdir()
+    emmc.mkdir()
+    (ufs / "prog.elf").write_bytes(b"ufs programmer")
+    (emmc / "prog.elf").write_bytes(b"emmc programmer")
+    write_single_image_sahara_xml(work / "ufs-sahara.xml")
+    write_single_image_sahara_xml(work / "emmc-sahara.xml")
+    write_multi_contents_xml(xml)
+
+    for storage, payload in [("ufs", b"ufs programmer"),
+                             ("emmc", b"emmc programmer")]:
+        out = work / f"{storage}.bin"
+        run_qdl(qdl, "create-sahara-archive", str(out),
+                f"{xml}::{storage}")
+        assert_archive(out, {"13:prog.elf": payload})
+
+    out = work / "unselected.bin"
+    run_qdl(qdl, "create-sahara-archive", str(out), str(xml),
+            expect_success=False)
+    assert_no_archive(out)
+
+
+def test_archive_roundtrip(qdl, work, payloads):
+    first = work / "roundtrip-source.bin"
+    second = work / "roundtrip-result.bin"
+    payload_dir = work / "payloads"
+
+    run_qdl(qdl, "create-sahara-archive", str(first),
+            f"13:{payload_dir / 'prog.elf'},38:{payload_dir / 'cfg.elf'}")
+    run_qdl(qdl, "create-sahara-archive", str(second), str(first))
+
+    assert_archive(second, {
+        "13:prog.elf": payloads["prog.elf"],
+        "38:cfg.elf": payloads["cfg.elf"],
+    })
+
+
+def test_reject_space_separated(qdl, work):
+    out = work / "space-separated.bin"
+    payload_dir = work / "payloads"
+
+    run_qdl(qdl, "create-sahara-archive", str(out),
+            f"13:{payload_dir / 'prog.elf'}",
+            f"38:{payload_dir / 'cfg.elf'}", expect_success=False)
+    assert_no_archive(out)
+
+
+def test_reject_selector_on_non_contents(qdl, work):
+    out = work / "selector.bin"
+    xml = work / "sahara-selector.xml"
+
+    write_sahara_xml(xml, work / "payloads")
+    run_qdl(qdl, "create-sahara-archive", str(out), f"{xml}::ufs",
+            expect_success=False)
+    assert_no_archive(out)
+
+
+def test_bad_inputs(qdl, work):
+    payload_dir = work / "payloads"
+    empty = payload_dir / "empty.bin"
+    empty.write_bytes(b"")
+
+    for name, spec in [
+        ("invalid-zero-id.bin", f"0:{payload_dir / 'prog.elf'}"),
+        ("invalid-large-id.bin", f"128:{payload_dir / 'prog.elf'}"),
+        ("missing-payload.bin", f"13:{payload_dir / 'missing.elf'}"),
+        ("empty-payload.bin", f"13:{empty}"),
+    ]:
+        out = work / name
+        run_qdl(qdl, "create-sahara-archive", str(out), spec,
+                expect_success=False)
+        assert_no_archive(out)
+
+    malformed = work / "malformed-sahara.xml"
+    malformed.write_text("<?xml version=\"1.0\" ?><not_sahara/>",
+                         encoding="ascii")
+    out = work / "malformed.bin"
+    run_qdl(qdl, "create-sahara-archive", str(out), str(malformed),
+            expect_success=False)
+    assert_no_archive(out)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--builddir", required=True)
+    args = parser.parse_args()
+
+    qdl = Path(args.builddir) / ("qdl.exe" if os.name == "nt" else "qdl")
+    if not qdl.exists():
+        raise AssertionError(f"qdl binary not found: {qdl}")
+
+    work = Path(tempfile.mkdtemp(prefix="sahara-archive-",
+                                dir=Path(args.builddir) / "tests"))
+
+    try:
+        payloads = write_payloads(work / "payloads")
+
+        test_mapping(str(qdl), work, payloads)
+        test_sahara_xml(str(qdl), work, payloads)
+        test_contents_xml(str(qdl), work, payloads)
+        test_contents_xml_selector(str(qdl), work)
+        test_archive_roundtrip(str(qdl), work, payloads)
+        test_reject_space_separated(str(qdl), work)
+        test_reject_selector_on_non_contents(str(qdl), work)
+        test_bad_inputs(str(qdl), work)
+    finally:
+        shutil.rmtree(work)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
QDL was taught to consume Sahara payload from a custom cpio-package, but no convenient tooling was provided to generate such files.

Introduce a mechanism that allow such archive to be created directly from a contents.xml file or a list of images.