### PR TITLE
Accept NAND-style erase tags without physical_partition_number

### DIFF
--- a/src/program.c
+++ b/src/program.c
@@ -38,11 +38,19 @@ static int load_erase_tag(struct list_head *ops, xmlNode *node, bool is_nand)
 
 	program->sector_size = attr_as_unsigned(node, "SECTOR_SIZE_IN_BYTES", &errors);
 	program->num_sectors = attr_as_unsigned(node, "num_partition_sectors", &errors);
-	program->partition = attr_as_unsigned(node, "physical_partition_number", &errors);
 	program->start_sector = attr_as_string(node, "start_sector", &errors);
 	if (is_nand) {
 		program->pages_per_block = attr_as_unsigned(node, "PAGES_PER_BLOCK", &errors);
 	}
+
+	/*
+	 * NAND-generated rawprogram files omit physical_partition_number,
+	 * as NAND exposes a single physical partition. Treat the attribute
+	 * as optional and default to partition 0, matching the reference
+	 * fh_loader behavior.
+	 */
+	if (xmlHasProp(node, (xmlChar *)"physical_partition_number"))
+		program->partition = attr_as_unsigned(node, "physical_partition_number", &errors);
 
 	if (errors) {
 		ux_err("errors while parsing erase tag\n");

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -90,7 +90,8 @@ static int detect_type(const char *verb)
 		for (node = root->children; node ; node = node->next) {
 			if (node->type != XML_ELEMENT_NODE)
 				continue;
-			if (!xmlStrcmp(node->name, (xmlChar *)"program")) {
+			if (!xmlStrcmp(node->name, (xmlChar *)"program") ||
+			    !xmlStrcmp(node->name, (xmlChar *)"erase")) {
 				type = QDL_FILE_PROGRAM;
 				break;
 			}

--- a/tests/test_program_load_xml.c
+++ b/tests/test_program_load_xml.c
@@ -422,6 +422,101 @@ static void test_missing_file_is_tolerated_with_allow_missing(void **state)
 	xmlFreeDoc(doc);
 }
 
+static xmlDoc *build_erase_doc(const char *partition_attr)
+{
+	char xml[1024];
+	int ret;
+
+	ret = snprintf(xml, sizeof(xml),
+		       "<data>"
+		       "<erase "
+		       "PAGES_PER_BLOCK=\"64\" "
+		       "SECTOR_SIZE_IN_BYTES=\"2048\" "
+		       "num_partition_sectors=\"1280\" "
+		       "start_sector=\"0\" "
+		       "%s/>"
+		       "</data>",
+		       partition_attr);
+	assert_true(ret > 0 && (size_t)ret < sizeof(xml));
+
+	return xmlReadMemory(xml, ret, "rawprogram.xml", NULL, 0);
+}
+
+static struct firehose_op *get_only_erase_op(struct list_head *ops)
+{
+	struct firehose_op *op;
+	struct list_head *it;
+	size_t count = 0;
+
+	list_for_each(it, ops)
+		count++;
+
+	if (count != 1)
+		fail_msg("expected exactly one firehose op, got %zu", count);
+
+	op = list_entry_first(ops, struct firehose_op, node);
+	if (op->type != FIREHOSE_OP_ERASE)
+		fail_msg("expected firehose op type ERASE, got %d", op->type);
+
+	return op;
+}
+
+/*
+ * NAND-generated rawprogram files carry erase tags without a
+ * physical_partition_number; the attribute is optional and defaults
+ * to partition 0.
+ */
+static void test_erase_without_physical_partition_number(void **state)
+{
+	struct firehose_op *op;
+	struct list_head ops = LIST_INIT(ops);
+	xmlDoc *doc;
+	int ret;
+
+	(void)state;
+
+	doc = build_erase_doc("");
+	if (!doc)
+		fail_msg("failed to parse synthetic erase XML");
+
+	ret = program_load_xml(&ops, doc, NULL, TEST_PROGRAM_FILE, true, false, NULL, NULL);
+	if (ret)
+		fail_msg("erase without physical_partition_number should parse, got %d", ret);
+
+	op = get_only_erase_op(&ops);
+	if (op->partition != 0)
+		fail_msg("omitted physical_partition_number should default to 0, got %d",
+			 op->partition);
+
+	firehose_free_ops(&ops);
+	xmlFreeDoc(doc);
+}
+
+static void test_erase_with_physical_partition_number(void **state)
+{
+	struct firehose_op *op;
+	struct list_head ops = LIST_INIT(ops);
+	xmlDoc *doc;
+	int ret;
+
+	(void)state;
+
+	doc = build_erase_doc("physical_partition_number=\"2\" ");
+	if (!doc)
+		fail_msg("failed to parse synthetic erase XML");
+
+	ret = program_load_xml(&ops, doc, NULL, TEST_PROGRAM_FILE, true, false, NULL, NULL);
+	if (ret)
+		fail_msg("erase with physical_partition_number should parse, got %d", ret);
+
+	op = get_only_erase_op(&ops);
+	if (op->partition != 2)
+		fail_msg("physical_partition_number should be honored, got %d", op->partition);
+
+	firehose_free_ops(&ops);
+	xmlFreeDoc(doc);
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -431,6 +526,8 @@ int main(void)
 		cmocka_unit_test(test_current_directory_is_used_when_path_resolution_misses),
 		cmocka_unit_test(test_missing_file_fails_without_allow_missing),
 		cmocka_unit_test(test_missing_file_is_tolerated_with_allow_missing),
+		cmocka_unit_test(test_erase_without_physical_partition_number),
+		cmocka_unit_test(test_erase_with_physical_partition_number),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
A user flashing a Telit FE910C04 (SDX35, NAND) reported that qdl rejects
the vendor-shipped rawprogram files with "errors while parsing erase
tag". The autogenerated NAND bundles omit `physical_partition_number`
from <erase> tags - NAND exposes a single physical partition - but
`load_erase_tag()` treated the attribute as required. The reference
`fh_loader` treats it as optional and defaults it to 0, so qdl was
stricter than the format it implements.

- program: treat `physical_partition_number` as optional in erase tags,
  defaulting to 0 to match the reference implementation. Covered by two
  new cmocka cases in `test_program_load_xml` (attribute omitted ->
  partition 0; attribute present -> honored).

- qdl: recognize erase-only XML files as program files. Found while
  verifying the above: the file type detector classified <data>
  documents by their program/read/ufs children only, so a rawprogram
  containing nothing but erase tags - as generated for NAND wipe
  flows - failed with "failed to detect file type" even though the
  parser fully supports erase tags. The flashmap loader already
  accepts erase children; do the same here.

Verified against the reported Telit rawprogram: parsing now succeeds
and qdl proceeds to device discovery.