### PR TITLE
firehose: send the partition label in NAND program tags

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -1032,6 +1032,16 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	if (program->is_nand) {
 		xml_setpropf(node, "PAGES_PER_BLOCK", "%d", program->pages_per_block);
 		xml_setpropf(node, "last_sector", "%d", program->last_sector);
+		/*
+		 * Some NAND programmers resolve the destination partition by
+		 * name to apply that partition's bad-block adjusted offset, so
+		 * start_sector alone does not describe where the data lands.
+		 * Given no label such a programmer matches no partition and
+		 * programming fails. Programmers that do not need the name
+		 * ignore the attribute.
+		 */
+		if (program->label)
+			xml_setpropf(node, "label", "%s", program->label);
 	}
 
 	ret = firehose_write(qdl, doc);


### PR DESCRIPTION
Some NAND programmers resolve the destination partition by name in order to apply its bad-block adjusted offset, so start-sector alone does not describe where the data lands.
Given no label such a programmer matches no partition and programming fails:

	LOG: INFO: Program,Partition label is
	LOG: INFO: Partition need to be adjusted
	LOG: INFO: partitionTableAdusted[pi].name is
	LOG: INFO: partitionTableAdjusted[pi].length is 0
	LOG: INFO: [1122] out of good blocks, total blocks:0xa badblocks:0x0 erased blocks:0xa
	LOG: ERROR: [2052] error : 9
	LOG: ERROR Write Failed sector 0, size 0 result 2

Forward the label that the rawprogram XML already provides and flashing works.

Tested on a device which failed programming when missing this patch.
Tested on another device which worked correctly prior to this change, and keeps working
correctly after this modification.
Programming on both had the label present in rawprogram_nand.xml.