### PR TITLE
qdl: add a standalone reset subcommand

### DIFF
--- a/include/qdl.h
+++ b/include/qdl.h
@@ -200,6 +200,7 @@ int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,
 	       const char *ramdump_path,
 	       const char *ramdump_filter);
 int sahara_chipinfo(struct qdl_device *qdl);
+int sahara_device_reset(struct qdl_device *qdl);
 int load_sahara_image(struct qdl_zip *zip, const char *filename, struct sahara_image *image);
 void sahara_images_free(struct sahara_image *images, size_t count);
 void print_hex_dump(const char *prefix, const void *buf, size_t len);

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -438,6 +438,88 @@ enum {
 	OPT_SERIAL,
 };
 
+/* Results of qdl_common_opt() for options every subcommand shares. */
+enum {
+	QDL_OPT_HANDLED,
+	QDL_OPT_EXIT_OK,
+	QDL_OPT_EXIT_FAIL,
+};
+
+/* Long options for subcommands that take no extra options. */
+static const struct option qdl_common_options[] = {
+	{"debug", no_argument, 0, 'd'},
+	{"version", no_argument, 0, 'v'},
+	{"serial", required_argument, 0, 'S'},
+	{"backend", required_argument, 0, OPT_BACKEND},
+	{"help", no_argument, 0, 'h'},
+	{0, 0, 0, 0}
+};
+
+/*
+ * Handle the option cases shared by every subcommand: --debug,
+ * --version, --serial, --backend and --help, plus the unknown-option
+ * fallback. Returns QDL_OPT_HANDLED when parsing should continue, or
+ * QDL_OPT_EXIT_OK / QDL_OPT_EXIT_FAIL when the caller should return
+ * with success / failure.
+ */
+static int qdl_common_opt(int opt, char **serial, enum QDL_DEVICE_TYPE *dev_type)
+{
+	switch (opt) {
+	case 'd':
+		qdl_debug = true;
+		return QDL_OPT_HANDLED;
+	case 'v':
+		print_version();
+		return QDL_OPT_EXIT_OK;
+	case 'S':
+	case OPT_SERIAL:
+		*serial = optarg;
+		return QDL_OPT_HANDLED;
+	case OPT_BACKEND:
+		if (decode_backend(optarg, dev_type) < 0)
+			errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
+		return QDL_OPT_HANDLED;
+	case 'h':
+		print_usage(stdout);
+		return QDL_OPT_EXIT_OK;
+	default:
+		print_usage(stderr);
+		return QDL_OPT_EXIT_FAIL;
+	}
+}
+
+/*
+ * Common device session setup for the subcommands: initialize the
+ * requested backend and open the (optionally serial-selected) device.
+ * Returns NULL with the error already reported on failure.
+ */
+static struct qdl_device *qdl_session_open(enum QDL_DEVICE_TYPE dev_type, const char *serial)
+{
+	struct qdl_device *qdl;
+
+	qdl = qdl_init(dev_type);
+	if (!qdl) {
+		ux_err("backend not available\n");
+		return NULL;
+	}
+
+	if (qdl_debug)
+		print_version();
+
+	if (qdl_open(qdl, serial)) {
+		qdl_deinit(qdl);
+		return NULL;
+	}
+
+	return qdl;
+}
+
+static void qdl_session_close(struct qdl_device *qdl)
+{
+	qdl_close(qdl);
+	qdl_deinit(qdl);
+}
+
 static int qdl_ramdump(int argc, char **argv)
 {
 	struct qdl_device *qdl;
@@ -459,30 +541,16 @@ static int qdl_ramdump(int argc, char **argv)
 	};
 
 	while ((opt = getopt_long(argc, argv, "dvo:S:h", options, NULL)) != -1) {
-		switch (opt) {
-		case 'd':
-			qdl_debug = true;
-			break;
-		case 'v':
-			print_version();
-			return 0;
-		case 'o':
+		if (opt == 'o') {
 			ramdump_path = optarg;
-			break;
-		case 'S':
-			serial = optarg;
-			break;
-		case OPT_BACKEND:
-			if (decode_backend(optarg, &qdl_dev_type) < 0)
-				errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
-			break;
-		case 'h':
-			print_usage(stdout);
-			return 0;
-		default:
-			print_usage(stderr);
-			return 1;
+			continue;
 		}
+
+		ret = qdl_common_opt(opt, &serial, &qdl_dev_type);
+		if (ret == QDL_OPT_EXIT_OK)
+			return 0;
+		if (ret == QDL_OPT_EXIT_FAIL)
+			return 1;
 	}
 
 	if (optind < argc)
@@ -501,79 +569,37 @@ static int qdl_ramdump(int argc, char **argv)
 		return 1;
 	}
 
-	qdl = qdl_init(qdl_dev_type);
-	if (!qdl) {
-		ux_err("backend not available\n");
+	qdl = qdl_session_open(qdl_dev_type, serial);
+	if (!qdl)
 		return 1;
-	}
 
-	if (qdl_debug)
-		print_version();
+	ret = sahara_run(qdl, NULL, ramdump_path, filter) < 0 ? 1 : 0;
 
-	ret = qdl_open(qdl, serial);
-	if (ret) {
-		ret = 1;
-		goto out_cleanup;
-	}
-
-	ret = sahara_run(qdl, NULL, ramdump_path, filter);
-	if (ret < 0) {
-		ret = 1;
-		goto out_cleanup;
-	}
-
-out_cleanup:
-	qdl_close(qdl);
-	qdl_deinit(qdl);
+	qdl_session_close(qdl);
 
 	return ret;
 }
 
 /*
- * Chip identity ("chipinfo") subcommand.
- *
- * Enters Sahara command mode to read and print the device's serial number,
- * hardware ID (MSM/OEM/model) and OEM PK hash, then resets the device.
+ * Shared entry point for Sahara-only subcommands that take no options
+ * beyond the common set and no positional arguments: parse the options,
+ * open the device session and hand it to @run. Returns the subcommand
+ * exit code; @run reports failure with a negative return value.
  */
-static int qdl_chipinfo(int argc, char **argv)
+static int qdl_sahara_cmd(int argc, char **argv, int (*run)(struct qdl_device *qdl))
 {
 	struct qdl_device *qdl;
 	char *serial = NULL;
 	enum QDL_DEVICE_TYPE qdl_dev_type = QDL_DEVICE_AUTO;
-	int ret = 0;
+	int ret;
 	int opt;
 
-	static struct option options[] = {
-		{"debug", no_argument, 0, 'd'},
-		{"version", no_argument, 0, 'v'},
-		{"serial", required_argument, 0, 'S'},
-		{"backend", required_argument, 0, OPT_BACKEND},
-		{"help", no_argument, 0, 'h'},
-		{0, 0, 0, 0}
-	};
-
-	while ((opt = getopt_long(argc, argv, "dvS:h", options, NULL)) != -1) {
-		switch (opt) {
-		case 'd':
-			qdl_debug = true;
-			break;
-		case 'v':
-			print_version();
+	while ((opt = getopt_long(argc, argv, "dvS:h", qdl_common_options, NULL)) != -1) {
+		ret = qdl_common_opt(opt, &serial, &qdl_dev_type);
+		if (ret == QDL_OPT_EXIT_OK)
 			return 0;
-		case 'S':
-			serial = optarg;
-			break;
-		case OPT_BACKEND:
-			if (decode_backend(optarg, &qdl_dev_type) < 0)
-				errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
-			break;
-		case 'h':
-			print_usage(stdout);
-			return 0;
-		default:
-			print_usage(stderr);
+		if (ret == QDL_OPT_EXIT_FAIL)
 			return 1;
-		}
 	}
 
 	if (optind != argc) {
@@ -583,28 +609,13 @@ static int qdl_chipinfo(int argc, char **argv)
 
 	ux_init();
 
-	qdl = qdl_init(qdl_dev_type);
-	if (!qdl) {
-		ux_err("backend not available\n");
+	qdl = qdl_session_open(qdl_dev_type, serial);
+	if (!qdl)
 		return 1;
-	}
 
-	if (qdl_debug)
-		print_version();
+	ret = run(qdl) < 0 ? 1 : 0;
 
-	ret = qdl_open(qdl, serial);
-	if (ret) {
-		ret = 1;
-		goto out_cleanup;
-	}
-
-	ret = sahara_chipinfo(qdl);
-	if (ret < 0)
-		ret = 1;
-
-out_cleanup:
-	qdl_close(qdl);
-	qdl_deinit(qdl);
+	qdl_session_close(qdl);
 
 	return ret;
 }
@@ -693,21 +704,8 @@ static int qdl_ks(int argc, char **argv)
 
 	while ((opt = getopt_long(argc, argv, "dvp:s:h", options, NULL)) != -1) {
 		switch (opt) {
-		case 'd':
-			qdl_debug = true;
-			break;
-		case 'v':
-			print_version();
-			goto out;
 		case 'p':
 			dev_node = optarg;
-			break;
-		case OPT_SERIAL:
-			serial = optarg;
-			break;
-		case OPT_BACKEND:
-			if (decode_backend(optarg, &qdl_dev_type) < 0)
-				errx(1, "unknown backend \"%s\" (expected auto|usb|qud)", optarg);
 			break;
 		case 's':
 			if (ks_add_mapping(optarg, mappings) < 0) {
@@ -716,13 +714,17 @@ static int qdl_ks(int argc, char **argv)
 			}
 			found_mapping = true;
 			break;
-		case 'h':
-			print_usage(stdout);
-			goto out;
 		default:
-			print_usage(stderr);
-			ret = 1;
-			goto out;
+			ret = qdl_common_opt(opt, &serial, &qdl_dev_type);
+			if (ret == QDL_OPT_EXIT_OK) {
+				ret = 0;
+				goto out;
+			}
+			if (ret == QDL_OPT_EXIT_FAIL) {
+				ret = 1;
+				goto out;
+			}
+			ret = 0;
 		}
 	}
 
@@ -745,10 +747,10 @@ static int qdl_ks(int argc, char **argv)
 
 	ux_init();
 
-	if (qdl_debug)
-		print_version();
-
 	if (dev_node) {
+		if (qdl_debug)
+			print_version();
+
 		node_dev.fd = qdl_open_device_node(dev_node);
 		if (node_dev.fd < 0) {
 			ux_err("unable to open %s: %s\n", dev_node, strerror(errno));
@@ -757,29 +759,20 @@ static int qdl_ks(int argc, char **argv)
 		}
 		qdl = &node_dev;
 	} else {
-		qdl = qdl_init(qdl_dev_type);
+		qdl = qdl_session_open(qdl_dev_type, serial);
 		if (!qdl) {
-			ux_err("backend not available\n");
 			ret = 1;
 			goto out;
-		}
-
-		if (qdl_open(qdl, serial)) {
-			ret = 1;
-			goto out_cleanup;
 		}
 	}
 
 	if (sahara_run(qdl, mappings, NULL, NULL) < 0)
 		ret = 1;
 
-out_cleanup:
 	if (dev_node)
 		close(node_dev.fd);
-	else if (qdl) {
-		qdl_close(qdl);
-		qdl_deinit(qdl);
-	}
+	else
+		qdl_session_close(qdl);
 out:
 	sahara_images_free(mappings, MAPPING_SZ);
 	return ret;
@@ -1364,7 +1357,7 @@ int main(int argc, char **argv)
 		if (!strcmp(argv[i], "ramdump"))
 			return qdl_ramdump(argc - i, argv + i);
 		if (!strcmp(argv[i], "chipinfo"))
-			return qdl_chipinfo(argc - i, argv + i);
+			return qdl_sahara_cmd(argc - i, argv + i, sahara_chipinfo);
 		if (!strcmp(argv[i], "ks"))
 			return qdl_ks(argc - i, argv + i);
 		if (!strcmp(argv[i], "create-zip"))

--- a/src/qdl.c
+++ b/src/qdl.c
@@ -359,6 +359,7 @@ static void print_usage(FILE *out)
 	fprintf(out, "       %s [options] <prog.mbn> (reset)\n", __progname);
 	fprintf(out, "       %s list\n", __progname);
 	fprintf(out, "       %s chipinfo\n", __progname);
+	fprintf(out, "       %s reset\n", __progname);
 	fprintf(out, "       %s ramdump [--debug] [-o <ramdump-path>] [<segment-filter>,...]\n", __progname);
 	fprintf(out, "       %s ks [-p <sahara-dev-node> | --serial=T] -s <id:file-path>...\n", __progname);
 	fprintf(out, "       %s flash (<flashmap>[::specifier] | <contents>[::<specifier>])\n", __progname);
@@ -616,6 +617,27 @@ static int qdl_sahara_cmd(int argc, char **argv, int (*run)(struct qdl_device *q
 	ret = run(qdl) < 0 ? 1 : 0;
 
 	qdl_session_close(qdl);
+
+	return ret;
+}
+
+/*
+ * Device reset ("reset") subcommand body.
+ *
+ * Resets the device from whichever state it is in: over the Sahara
+ * protocol when the device sits in EDL or crash mode, falling back to a
+ * Firehose power reset when a programmer is already running. Unlike the
+ * "reset" flashing verb, no programmer needs to be uploaded.
+ */
+static int qdl_reset_run(struct qdl_device *qdl)
+{
+	int ret;
+
+	ret = sahara_device_reset(qdl);
+	if (ret == 1) {
+		ux_info("falling back to Firehose reset\n");
+		ret = firehose_reset(qdl);
+	}
 
 	return ret;
 }
@@ -1358,6 +1380,8 @@ int main(int argc, char **argv)
 			return qdl_ramdump(argc - i, argv + i);
 		if (!strcmp(argv[i], "chipinfo"))
 			return qdl_sahara_cmd(argc - i, argv + i, sahara_chipinfo);
+		if (!strcmp(argv[i], "reset"))
+			return qdl_sahara_cmd(argc - i, argv + i, qdl_reset_run);
 		if (!strcmp(argv[i], "ks"))
 			return qdl_ks(argc - i, argv + i);
 		if (!strcmp(argv[i], "create-zip"))

--- a/src/sahara.c
+++ b/src/sahara.c
@@ -109,6 +109,8 @@ typedef struct {
 #define DEBUG_BLOCK_SIZE (512u * 1024u)
 
 #define SAHARA_CMD_TIMEOUT_MS	1000
+#define SAHARA_RESET_RETRIES	5
+#define SAHARA_RESET_VERIFY_TIMEOUT_MS	3000
 
 struct sahara_pkt {
 	uint32_t cmd;
@@ -1129,6 +1131,154 @@ int sahara_chipinfo(struct qdl_device *qdl)
 	sahara_send_switch_mode(qdl, SAHARA_MODE_IMAGE_TX_PENDING);
 
 	return ret;
+}
+
+/*
+ * Reset the device over the Sahara protocol, from whichever Sahara state
+ * it booted into: fresh EDL (image transfer pending) or crash mode
+ * (memory debug). The HELLO is acknowledged with the mode the device
+ * asked for, so no state transition is forced before the reset command.
+ *
+ * Return: 0 when the reset was issued over Sahara, 1 when a Firehose
+ * programmer is already running (the caller should reset via Firehose
+ * instead), -1 on failure.
+ */
+int sahara_device_reset(struct qdl_device *qdl)
+{
+	struct sahara_pkt *pkt;
+	char buf[4096];
+	int n;
+	int i;
+
+	if (qdl->dev_type == QDL_DEVICE_SIM)
+		return 0;
+
+	n = qdl_read(qdl, buf, sizeof(buf), SAHARA_CMD_TIMEOUT_MS);
+
+	/* A Firehose programmer is already running; there is no Sahara here */
+	if (n >= 5 && !memcmp(buf, "<?xml", 5))
+		goto firehose;
+
+	if (n < 0) {
+		if (n != -ETIMEDOUT) {
+			ux_err("failed to read Sahara HELLO from device\n");
+			return -1;
+		}
+
+		/*
+		 * No HELLO: the QUD driver eats it on many targets, and a
+		 * previous session may have consumed it. Prod the device with
+		 * an unsolicited HELLO response: Sahara accepts it, while a
+		 * running Firehose programmer answers the non-XML input with
+		 * an error response, identifying itself for the fallback.
+		 */
+		sahara_send_hello_resp(qdl, SAHARA_VERSION,
+				       SAHARA_MODE_IMAGE_TX_PENDING);
+
+		n = qdl_read(qdl, buf, sizeof(buf), SAHARA_CMD_TIMEOUT_MS);
+		if (n >= 5 && !memcmp(buf, "<?xml", 5))
+			goto firehose;
+	} else {
+		pkt = (struct sahara_pkt *)buf;
+		if ((uint32_t)n == pkt->length && pkt->cmd == SAHARA_HELLO_CMD) {
+			ux_debug("Sahara HELLO version %u mode %u\n",
+				 pkt->hello_req.version, pkt->hello_req.mode);
+
+			/*
+			 * The target services a reset only in states where it
+			 * is valid: in image-transfer-pending state the PBL
+			 * rejects it with an end-of-image error, while command
+			 * mode accepts it. Crash-mode devices announce memory
+			 * debug and take the reset directly, as the ramdump
+			 * teardown has always relied on.
+			 */
+			if (pkt->hello_req.mode == SAHARA_MODE_MEMORY_DEBUG) {
+				sahara_send_hello_resp(qdl, pkt->hello_req.version,
+						       SAHARA_MODE_MEMORY_DEBUG);
+			} else {
+				sahara_send_hello_resp(qdl, pkt->hello_req.version,
+						       SAHARA_MODE_COMMAND);
+
+				n = qdl_read(qdl, buf, sizeof(buf),
+					     SAHARA_CMD_TIMEOUT_MS);
+				if (n < 0 || pkt->cmd != SAHARA_CMD_READY_CMD)
+					ux_debug("no CMD_READY after command mode request\n");
+			}
+		}
+		/* On any other packet, proceed straight to the reset */
+	}
+
+	/*
+	 * The reset response is the target's acknowledgment that it accepted
+	 * the request, sent just before it resets; the protocol directs the
+	 * host to resend the reset until the response arrives. The resend
+	 * matters in practice: after the HELLO exchange the target
+	 * immediately issues its first READ_DATA, which races the reset
+	 * request, so the first answer read back is often not the response.
+	 */
+	for (i = 0; i < SAHARA_RESET_RETRIES; i++) {
+		sahara_send_reset(qdl);
+
+		n = qdl_read(qdl, buf, sizeof(buf), SAHARA_CMD_TIMEOUT_MS);
+		if (n < 0) {
+			/*
+			 * A transport error other than a timeout means the
+			 * device already dropped off the bus resetting.
+			 */
+			if (n != -ETIMEDOUT)
+				break;
+			continue;
+		}
+
+		if ((size_t)n < sizeof(uint32_t) * 2)
+			continue;
+
+		pkt = (struct sahara_pkt *)buf;
+		if (pkt->cmd == SAHARA_RESET_RESP_CMD) {
+			ux_debug("Sahara reset acknowledged\n");
+			break;
+		}
+
+		/*
+		 * An invalid reset request is rejected with an end-of-image
+		 * transfer packet carrying the error status.
+		 */
+		if (pkt->cmd == SAHARA_END_OF_IMAGE_CMD) {
+			ux_err("device rejected the reset request (end-of-image status %u)\n",
+			       pkt->eoi.status);
+			return -1;
+		}
+
+		/* Some other packet crossed the reset request; resend */
+	}
+
+	if (i == SAHARA_RESET_RETRIES) {
+		ux_err("no reset response from device\n");
+		return -1;
+	}
+
+	/*
+	 * The response only acknowledges the request; verify that the device
+	 * actually went down. A PBL can tear down its Sahara session on the
+	 * reset request without resetting the SoC (observed on QRB2210),
+	 * which leaves the transport alive but the session dead. Only the
+	 * transport dropping - the handle dying with the re-enumeration -
+	 * proves the reset happened.
+	 */
+	n = qdl_read(qdl, buf, sizeof(buf), SAHARA_RESET_VERIFY_TIMEOUT_MS);
+	if (n >= 0 || n == -ETIMEDOUT) {
+		ux_err("device acknowledged the reset but did not go down; power cycle it or reset through a Firehose programmer: qdl <programmer> reset\n");
+		return -1;
+	}
+
+	ux_info("device reset via Sahara\n");
+
+	return 0;
+
+firehose:
+	ux_info("Firehose programmer is running\n");
+
+	return 1;
 }
 
 int sahara_run(struct qdl_device *qdl, const struct sahara_image *images,


### PR DESCRIPTION
Resetting a device today requires the full flashing flow: `qdl <prog.mbn> reset` uploads the programmer over Sahara just to send a Firehose power reset. That is a poor fit for the common case of kicking a board out of EDL or crash mode remotely, where no programmer for the target may even be at hand.
    
Add `qdl reset`, which resets the device from whichever state it is in: over Sahara when the device is in EDL or crash mode, falling back to a Firehose power reset when a programmer is already running (for example after a --skip-reset invocation). The existing "reset" flashing verb is unchanged.
    
Requested in issue #304 for recovering remote boards from crash mode.
    
[1] https://github.com/linux-msm/qdl/issues/304
