### PR TITLE
firehose: deduplicate the chunk-streaming loop

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -725,13 +725,85 @@ static int firehose_region_local_digest(struct qdl_device *qdl,
 }
 
 /*
+ * Stream @num_sectors of @sector_size bytes to the device after a program
+ * request has been accepted. When @fill is set the data is already present in
+ * @buf (a repeating fill pattern) and reused for every chunk; otherwise each
+ * chunk is read from @file and the trailing partial sector is zero-padded. The
+ * per-chunk VIP digest hooks and progress reporting are handled here so the
+ * regular, sparse and skipblock program paths share one implementation.
+ */
+static int firehose_stream_out(struct qdl_device *qdl, struct firehose_op *program,
+			       struct qdl_file *file, unsigned int sector_size,
+			       size_t num_sectors, void *buf, bool fill,
+			       unsigned int zlp_timeout)
+{
+	size_t chunk_size;
+	size_t left = num_sectors;
+	int ret;
+	int n;
+
+	while (left > 0) {
+		/*
+		 * The hash is computed per raw packet sent, not over the whole
+		 * binary.
+		 */
+		vip_gen_chunk_init(qdl);
+		chunk_size = MIN(qdl->max_payload_size / sector_size, left);
+
+		if (!fill) {
+			n = qdl_file_read_exact(file, buf, chunk_size * sector_size);
+			if (n < 0) {
+				ux_err("failed to read %s\n", program->filename);
+				return -1;
+			}
+
+			/*
+			 * qdl_file_read_exact() only returns short on true EOF.
+			 * The wire protocol expects exactly chunk_size *
+			 * sector_size bytes, so zero-pad the residue (at most the
+			 * trailing partial sector of the file).
+			 */
+			if ((size_t)n < chunk_size * sector_size)
+				memset((char *)buf + n, 0, chunk_size * sector_size - n);
+		}
+
+		vip_gen_chunk_update(qdl, buf, chunk_size * sector_size);
+
+		ret = firehose_vip_send_table(qdl);
+		if (ret)
+			return -1;
+
+		n = qdl_write(qdl, buf, chunk_size * sector_size, zlp_timeout);
+		if (n < 0) {
+			ux_err("USB write failed for data chunk\n");
+			ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
+			if (ret)
+				ux_err("flashing of chunk failed\n");
+			return -1;
+		}
+
+		if ((size_t)n != chunk_size * sector_size) {
+			ux_err("USB write truncated\n");
+			return -1;
+		}
+
+		left -= chunk_size;
+		vip_gen_chunk_store(qdl);
+
+		ux_progress("%s", num_sectors - left, num_sectors, program->label);
+	}
+
+	return 0;
+}
+
+/*
  * Program the contiguous raw region [@start_sector, @start_sector +
- * @num_sectors) from the current position of @file. A self-contained
- * mirror of the non-sparse streaming in firehose_program(), used by the
- * skipblock fast-path to reflash one sub-region at a time. @file and @buf
- * (scratch of qdl->max_payload_size) are owned by the caller. Skipblock
- * requires VIP disabled, so the vip_*() calls below are no-ops kept for
- * parity with the main path.
+ * @num_sectors) from the current position of @file: send the program
+ * request, stream the data through firehose_stream_out() and consume the
+ * final response. Used by the skipblock fast-path to reflash one
+ * sub-region at a time; skipblock requires VIP disabled, so the VIP
+ * hooks inside the streaming loop are no-ops on this path. @file and
+ * @buf (scratch of qdl->max_payload_size) are owned by the caller.
  */
 static int firehose_program_raw_region(struct qdl_device *qdl,
 				       struct firehose_op *program,
@@ -742,13 +814,10 @@ static int firehose_program_raw_region(struct qdl_device *qdl,
 				       void *buf,
 				       unsigned int zlp_timeout)
 {
-	size_t chunk_size;
-	size_t left;
 	xmlNode *root;
 	xmlNode *node;
 	xmlDoc *doc;
 	int ret;
-	int n;
 
 	doc = xmlNewDoc((xmlChar *)"1.0");
 	root = xmlNewNode(NULL, (xmlChar *)"data");
@@ -777,49 +846,10 @@ static int firehose_program_raw_region(struct qdl_device *qdl,
 		goto out;
 	}
 
-	left = num_sectors;
-	while (left > 0) {
-		vip_gen_chunk_init(qdl);
-		chunk_size = MIN(qdl->max_payload_size / sector_size, left);
-
-		n = qdl_file_read_exact(file, buf, chunk_size * sector_size);
-		if (n < 0) {
-			ux_err("failed to read %s\n", program->filename);
-			ret = -1;
-			goto out;
-		}
-		if ((size_t)n < chunk_size * sector_size)
-			memset(buf + n, 0, chunk_size * sector_size - n);
-
-		vip_gen_chunk_update(qdl, buf, chunk_size * sector_size);
-
-		ret = firehose_vip_send_table(qdl);
-		if (ret) {
-			ret = -1;
-			goto out;
-		}
-
-		n = qdl_write(qdl, buf, chunk_size * sector_size, zlp_timeout);
-		if (n < 0) {
-			ux_err("USB write failed for data chunk\n");
-			ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
-			if (ret)
-				ux_err("flashing of chunk failed\n");
-			ret = -1;
-			goto out;
-		}
-
-		if ((size_t)n != chunk_size * sector_size) {
-			ux_err("USB write truncated\n");
-			ret = -1;
-			goto out;
-		}
-
-		left -= chunk_size;
-		vip_gen_chunk_store(qdl);
-
-		ux_progress("%s", num_sectors - left, num_sectors, program->label);
-	}
+	ret = firehose_stream_out(qdl, program, file, sector_size, num_sectors, buf,
+				  false, zlp_timeout);
+	if (ret)
+		goto out;
 
 	ret = firehose_read(qdl, 120000, firehose_generic_parser, NULL);
 	if (ret != FIREHOSE_ACK) {
@@ -950,16 +980,14 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 	unsigned int sector_size;
 	unsigned int zlp_timeout = 10000;
 	struct qdl_file file;
-	size_t chunk_size;
 	xmlNode *root;
 	xmlNode *node;
 	xmlDoc *doc;
 	void *buf;
 	time_t t0;
 	time_t t;
-	size_t left;
+	bool fill;
 	int ret;
-	int n;
 	size_t i;
 	uint32_t fill_value;
 
@@ -1065,66 +1093,14 @@ static int firehose_program(struct qdl_device *qdl, struct firehose_op *program)
 		}
 	}
 
-	left = num_sectors;
-
 	ux_debug("FIREHOSE RAW BINARY WRITE: %s, %d bytes\n",
 		 program->filename, sector_size * num_sectors);
 
-	while (left > 0) {
-		/*
-		 * We should calculate hash for every raw packet sent,
-		 * not for the whole binary.
-		 */
-		vip_gen_chunk_init(qdl);
-		chunk_size = MIN(qdl->max_payload_size / sector_size, left);
-
-		if (!program->sparse || program->sparse_chunk_type != CHUNK_TYPE_FILL) {
-			n = qdl_file_read_exact(&file, buf, chunk_size * sector_size);
-			if (n < 0) {
-				ux_err("failed to read %s\n", program->filename);
-				goto err_free_doc;
-			}
-
-			/*
-			 * qdl_file_read_exact() only returns short on true
-			 * EOF. The wire protocol expects exactly
-			 * chunk_size * sector_size bytes, so zero-pad the
-			 * residue (which is at most the trailing partial
-			 * sector of the file).
-			 */
-			if ((size_t)n < chunk_size * sector_size)
-				memset(buf + n, 0, chunk_size * sector_size - n);
-		}
-
-		vip_gen_chunk_update(qdl, buf, chunk_size * sector_size);
-
-		ret = firehose_vip_send_table(qdl);
-		if (ret) {
-			ret = -1;
-			goto err_free_doc;
-		}
-
-		n = qdl_write(qdl, buf, chunk_size * sector_size, zlp_timeout);
-		if (n < 0) {
-			ux_err("USB write failed for data chunk\n");
-			ret = firehose_read(qdl, 30000, firehose_generic_parser, NULL);
-			if (ret)
-				ux_err("flashing of chunk failed\n");
-			ret = -1;
-			goto err_free_doc;
-		}
-
-		if ((size_t)n != chunk_size * sector_size) {
-			ux_err("USB write truncated\n");
-			ret = -1;
-			goto err_free_doc;
-		}
-
-		left -= chunk_size;
-		vip_gen_chunk_store(qdl);
-
-		ux_progress("%s", num_sectors - left, num_sectors, program->label);
-	}
+	fill = program->sparse && program->sparse_chunk_type == CHUNK_TYPE_FILL;
+	ret = firehose_stream_out(qdl, program, &file, sector_size, num_sectors, buf,
+				  fill, zlp_timeout);
+	if (ret)
+		goto err_free_doc;
 
 	t = time(NULL) - t0;
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -115,6 +115,41 @@ if cmocka_dep.found()
     env: ['CMOCKA_MESSAGE_OUTPUT=TAP'],
   )
 
+  # test_firehose below relies on the linker discarding the unreferenced
+  # rest of firehose.c. GNU ld cannot reliably garbage-collect sections on
+  # PE/COFF - the surviving firehose internals then demand the whole
+  # device/vip/json surface as undefined symbols - so the target is
+  # skipped on Windows. The parsers are platform-independent, and stay
+  # covered by the ELF and Mach-O builds.
+  if host_machine.system() != 'windows'
+    # test_firehose.c #includes firehose.c to reach its static response
+    # parsers. The rest of firehose.c (and its device/vip/ufs dependencies)
+    # is unreferenced by the tests and stripped as dead code at link time,
+    # so only the ux_* logging stubs are required. GNU ld spells the
+    # stripping --gc-sections, Apple's ld64 spells it -dead_strip; ask the
+    # linker which one it supports.
+    gc_sections = meson.get_compiler('c').get_supported_link_arguments(
+      ['-Wl,--gc-sections', '-Wl,-dead_strip'])
+
+    test_firehose = executable('test_firehose',
+      sources : [
+        'test_firehose.c',
+      ],
+      dependencies : common_dep + [cmocka_dep],
+      include_directories : inc,
+      c_args : ['-ffunction-sections', '-fdata-sections'],
+      link_args : gc_sections,
+    )
+
+    test(
+      'firehose response parsers',
+      test_firehose,
+      suite: 'unit',
+      protocol: 'tap',
+      env: ['CMOCKA_MESSAGE_OUTPUT=TAP'],
+    )
+  endif
+
   test_program_load_xml = executable('test_program_load_xml',
     sources : [
       'test_program_load_xml.c',

--- a/tests/test_firehose.c
+++ b/tests/test_firehose.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Unit tests for the Firehose XML response parsers. They are file-local
+ * in firehose.c, so the module is #included directly. Only the response
+ * parsers are exercised; the rest of firehose.c (and its device / vip /
+ * ufs dependencies) is dropped at link time via --gc-sections, so only
+ * the ux_* logging stubs are needed.
+ */
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cmocka.h>
+#include <libxml/tree.h>
+
+#include "firehose.c"
+
+void ux_err(const char *fmt, ...) { (void)fmt; }
+void ux_log(const char *fmt, ...) { (void)fmt; }
+
+static xmlNode *mk(const char *name)
+{
+	return xmlNewNode(NULL, (const xmlChar *)name);
+}
+
+static void attr(xmlNode *n, const char *k, const char *v)
+{
+	xmlNewProp(n, (const xmlChar *)k, (const xmlChar *)v);
+}
+
+/* --- firehose_generic_parser --- */
+
+static void test_generic_ack_nak_log(void **state)
+{
+	bool rawmode = false;
+	xmlNode *n;
+	(void)state;
+
+	n = mk("response");
+	attr(n, "value", "ACK");
+	assert_int_equal(firehose_generic_parser(n, NULL, &rawmode), FIREHOSE_ACK);
+	xmlFreeNode(n);
+
+	n = mk("response");
+	attr(n, "value", "NAK");
+	assert_int_equal(firehose_generic_parser(n, NULL, &rawmode), FIREHOSE_NAK);
+	xmlFreeNode(n);
+
+	n = mk("log");
+	attr(n, "value", "some log line");
+	assert_int_equal(firehose_generic_parser(n, NULL, &rawmode), -EAGAIN);
+	xmlFreeNode(n);
+}
+
+static void test_generic_rawmode(void **state)
+{
+	bool rawmode = false;
+	xmlNode *n;
+	(void)state;
+
+	n = mk("response");
+	attr(n, "value", "ACK");
+	attr(n, "rawmode", "true");
+	assert_int_equal(firehose_generic_parser(n, NULL, &rawmode), FIREHOSE_ACK);
+	assert_true(rawmode);
+	xmlFreeNode(n);
+}
+
+static void test_generic_missing_value(void **state)
+{
+	bool rawmode = false;
+	xmlNode *n = mk("response");
+	(void)state;
+
+	assert_int_equal(firehose_generic_parser(n, NULL, &rawmode), -EINVAL);
+	xmlFreeNode(n);
+}
+
+/* --- firehose_configure_response_parser --- */
+
+static void test_configure_ack(void **state)
+{
+	size_t max_size = 0;
+	bool rawmode = false;
+	xmlNode *n = mk("response");
+	(void)state;
+
+	attr(n, "value", "ACK");
+	attr(n, "MaxPayloadSizeToTargetInBytes", "1048576");
+	attr(n, "MaxPayloadSizeToTargetInBytesSupported", "2097152");
+
+	assert_int_equal(firehose_configure_response_parser(n, &max_size, &rawmode),
+			 FIREHOSE_ACK);
+	/* An ACK advertises the larger supported size. */
+	assert_int_equal(max_size, 2097152);
+	xmlFreeNode(n);
+}
+
+static void test_configure_nak_negotiates(void **state)
+{
+	size_t max_size = 0;
+	bool rawmode = false;
+	xmlNode *n = mk("response");
+	(void)state;
+
+	/*
+	 * A configure NAK is the payload-size negotiation, not a failure:
+	 * the device rejects the host's proposal and answers with the size
+	 * it accepts, which the caller re-sends. Treating the NAK as an
+	 * error makes the handshake loop forever on such devices.
+	 */
+	attr(n, "value", "NAK");
+	attr(n, "MaxPayloadSizeToTargetInBytes", "1048576");
+
+	assert_int_equal(firehose_configure_response_parser(n, &max_size, &rawmode),
+			 FIREHOSE_ACK);
+	assert_int_equal(max_size, 1048576);
+	xmlFreeNode(n);
+}
+
+static void test_configure_ack_without_supported(void **state)
+{
+	size_t max_size = 0;
+	bool rawmode = false;
+	xmlNode *n = mk("response");
+	(void)state;
+
+	/* An ACK that omits the "Supported" size is malformed. */
+	attr(n, "value", "ACK");
+	attr(n, "MaxPayloadSizeToTargetInBytes", "1048576");
+
+	assert_true(firehose_configure_response_parser(n, &max_size, &rawmode) < 0);
+	xmlFreeNode(n);
+}
+
+static void test_configure_log_and_missing(void **state)
+{
+	size_t max_size = 0;
+	bool rawmode = false;
+	xmlNode *n;
+	(void)state;
+
+	n = mk("log");
+	attr(n, "value", "startup log");
+	assert_int_equal(firehose_configure_response_parser(n, &max_size, &rawmode), -EAGAIN);
+	xmlFreeNode(n);
+
+	n = mk("response");
+	assert_int_equal(firehose_configure_response_parser(n, &max_size, &rawmode), -EINVAL);
+	xmlFreeNode(n);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_generic_ack_nak_log),
+		cmocka_unit_test(test_generic_rawmode),
+		cmocka_unit_test(test_generic_missing_value),
+		cmocka_unit_test(test_configure_ack),
+		cmocka_unit_test(test_configure_nak_negotiates),
+		cmocka_unit_test(test_configure_ack_without_supported),
+		cmocka_unit_test(test_configure_log_and_missing),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
firehose_program() and firehose_program_raw_region() carried identical
sector-streaming loops (chunking, trailing-sector padding, VIP digest
hooks, write error handling), serving the regular, sparse and skipblock
program paths. During the audit the same defects had to be found and
fixed twice, once per copy - this folds the loop into a single
firehose_stream_out() helper so streaming behavior can only be changed,
and reviewed, in one place.

The series is tests-first: the opening commit adds unit tests for the
Firehose response parsers, so the refactor lands against a pinned
protocol contract. Among them is a regression guard for the configure
NAK: it is the payload-size negotiation handshake, not an error - a
lesson originally learned on hardware when treating it as a failure
made the configure exchange loop forever.

No behavior change intended: the two removed loops were verified
line-by-line against the helper, including the sparse RAW/FILL cases
and the error paths. 