### PR TITLE
nbdkit-qdl-plugin small cleanups & documentation rework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install -y libcmocka-dev libxml2-dev libusb-1.0-0-dev libzip-dev help2man pipx zip
+          sudo apt-get install -y libcmocka-dev libxml2-dev libusb-1.0-0-dev libzip-dev help2man pipx zip nbdkit-plugin-dev
           pipx ensurepath
           pipx install meson==1.4.0
 

--- a/docs/nbd.md
+++ b/docs/nbd.md
@@ -29,6 +29,8 @@ auto-detection.
 - `programmer` - firehose programmer to upload (required)
 - `lun` - physical partition (LUN) to expose, defaults to `0`
 - `storage` - `ufs` or `emmc`, selects the firehose configuration
+- `timeout` - seconds to wait for an EDL device when setting the device up,
+  defaults to `60`. Use `0` to wait indefinitely, as `qdl` itself does
 - `debug` - set to `1` for verbose qdl logging
 
 ## Serving a LUN as a block device
@@ -54,6 +56,10 @@ that the plugin can talk to the board:
 ```bash
 nbdinfo nbd://localhost
 ```
+
+If a connection to the EDL device cannot be established within `timeout`
+seconds, the NBD client connection fails. A later NBD client connection retries
+the EDL setup, so the server can remain running while the device is connected.
 
 **3. Attach a kernel block device.** Load the `nbd` module and bind the export
 to a `/dev/nbdN` node with `nbd-client`. `-N default` selects the plugin's

--- a/docs/nbd.md
+++ b/docs/nbd.md
@@ -8,26 +8,33 @@ mounted with ordinary tools.
 
 ## Building the plugin
 
-The plugin is built by meson only when the `nbdkit` development files are
-present. Install the runtime and the development package, then reconfigure:
+The plugin is only built when the `nbdkit` development library is present.
 
-- Debian/Ubuntu: `sudo apt install nbdkit nbdkit-dev`
-- Fedora: `sudo dnf install nbdkit nbdkit-devel`
+Install the development package:
+
+- Debian/Ubuntu: `sudo apt install nbdkit-plugin-dev`
+- Fedora: `sudo dnf install nbdkit-devel`
+
+Then reconfigure and build:
 
 ```bash
 meson setup --reconfigure build
 meson compile -C build
 ```
 
-`meson setup` reports `Run-time dependency nbdkit found: YES` and produces
-`build/nbdkit-qdl-plugin.so`. Pass `-Dnbdkit=enabled` to make the plugin
-mandatory (the build fails if nbdkit is missing) instead of the default
-auto-detection.
+Ensure `meson setup` reports `Run-time dependency nbdkit found: YES` and
+produces `build/nbdkit-qdl-plugin.so`. Pass `-Dnbdkit=enabled` to `meson setup`
+to make the plugin build mandatory (the build will fail if the `nbdkit`
+development files are missing) instead of the default auto-detection.
 
 ## Plugin parameters
 
-- `programmer` - firehose programmer to upload (required)
-- `lun` - physical partition (LUN) to expose, defaults to `0`
+The plugin can be ran with `nbdkit`; see the example below for details.
+
+- `programmer` - path to the Firehose loader to upload (required; may be an
+  absolute path or a path relative to the current working directory)
+- `lun` - physical partition (LUN) to expose, defaults to `LUN 0` which usually
+  contains the userdata/HLOS partitions
 - `storage` - `ufs` or `emmc`, selects the firehose configuration
 - `timeout` - seconds to wait for an EDL device when setting the device up,
   defaults to `60`. Use `0` to wait indefinitely, as `qdl` itself does
@@ -35,46 +42,103 @@ auto-detection.
 
 ## Serving a LUN as a block device
 
-The device must be in EDL mode, exactly as for a normal `qdl` run.
+**1. Prerequisites.**
 
-**1. Start nbdkit.** In one terminal, launch the server. `-f` keeps it in the
-foreground and `-v` prints a debug log:
+Install the following packages:
+
+- Debian/Ubuntu: `sudo apt install libnbd-bin nbd-client nbdkit`
+- Fedora: `sudo dnf install libnbd nbd nbdkit`
+
+The device must be in EDL mode and connected to your workstation, exactly as
+for a normal `qdl` run.
+
+You must have a copy of the relevant `prog_firehose_ddr.elf` loader in the
+working directory, or change the value of the `programmer=` argument in the
+following `nbdkit` commands to the absolute or relative path to the loader
+binary.
+
+**2. Start nbdkit.**
+
+In one terminal, launch the server. `-f` keeps it in the foreground and `-v`
+prints the debug log. You shouldn't need to run `nbdkit` as root if you have the
+correct permissions to access the device over USB:
 
 ```bash
-sudo nbdkit -fv ./build/nbdkit-qdl-plugin.so \
+nbdkit -fv ./build/nbdkit-qdl-plugin.so \
     programmer=prog_firehose_ddr.elf lun=0
 ```
 
-nbdkit now listens on TCP port 10809 (`nbd://localhost`). It does not touch
-the device yet: the programmer is uploaded and firehose is configured lazily,
-the first time a client connects, and kept configured until nbdkit exits.
+`nbdkit` listens on TCP port 10809 (`nbd://localhost`). It does not connect
+to the device yet: once the first client connects to the plugin, the programmer
+binary is uploaded to the device, firehose is configured and the device will
+stay in firehose mode until `nbdkit` exits.
 
-**2. Confirm the export.** In a second terminal, query it. This triggers the
-one-time device setup and prints the LUN's size, so it is the quickest check
-that the plugin can talk to the board:
+**3. Confirm the export.**
+
+In a second terminal, connect to the NBD server with `nbdinfo` to display
+information about the block device. When this client connects to the server,
+the `nbdkit` plugin attempts to connect to a device in EDL mode, uploads the
+programmer and then communicates with the device in firehose mode until
+`nbdkit` exits.
+
+Information about the device, including the LUN's physical block size and block
+count, is read during the initial connection and is used to calculate the size
+of the block device. This is cached in the NBD server and passed back to
+`nbdinfo` which prints it to the console, making this a quick check of
+communication with the device:
 
 ```bash
 nbdinfo nbd://localhost
 ```
 
-If a connection to the EDL device cannot be established within `timeout`
-seconds, the NBD client connection fails. A later NBD client connection retries
-the EDL setup, so the server can remain running while the device is connected.
+This prints (among other metadata) the overall size of the LUN and the sector
+size, for example:
 
-**3. Attach a kernel block device.** Load the `nbd` module and bind the export
-to a `/dev/nbdN` node with `nbd-client`. `-N default` selects the plugin's
-default export, `10809` is the port:
+```
+export-size: 124646326272 (118872M)
+block_size_preferred: 4096
+```
+
+But, if a connection to the EDL device cannot be established within `timeout`
+seconds, the NBD client connection fails. The server keeps running and waits
+for another NBD client to connect, which then retries connecting to a device in
+EDL mode.
+
+**4. Confirm the device's sector size.**
+
+Devices with UFS storage have a 4096-byte sector size and devices with eMMC
+storage have a 512-byte sector size. Unfortunately, `nbd-client` defaults to
+assuming all devices have a 512-byte sector size and does not automatically
+detect the sector size reported by the server.
+
+The device's sector size is printed to the `nbdkit` debug log after the
+initial firehose connection:
+
+`nbdkit: qdl[1]: debug: serving LUN 0; sector size 4096 bytes, 30431232 sectors`
+
+The sector size can also be read from the output of `nbdinfo nbd://localhost`,
+which can be accessed from the client, without reading the `nbdkit` debug log.
+A sample output, showing this device has `4096` sectors:
+
+`block_size_preferred: 4096`
+
+**5. Attach a kernel block device.**
+
+Load the `nbd` module and bind the export to a `/dev/nbdN` node using
+`nbd-client`. `-b 4096` selects the sector size (default `512`); `-N default`
+selects the plugin's default export, `10809` is the port:
 
 ```bash
 sudo modprobe nbd
-sudo nbd-client -N default localhost 10809 /dev/nbd0
+sudo nbd-client -b 4096 -N default localhost 10809 /dev/nbd0
 ```
 
 `/dev/nbd0` now mirrors the LUN. `nbd-client` prints the negotiated size on
 connect.
 
-**4. Read the LUN.** Query its size (in bytes) and read from it with any
-standard tool:
+**6. Read/write data to the device's LUN.**
+
+Query its size (in bytes) and read from it with any standard tool:
 
 ```bash
 sudo blockdev --getsize64 /dev/nbd0
@@ -83,13 +147,21 @@ sudo dd if=/dev/nbd0 of=/tmp/lun0.head bs=1M count=1
 
 You can partition, mount, `dd`, or image `/dev/nbd0` like any other disk.
 
-**5. Detach when done**, then stop nbdkit (Ctrl-C in its terminal):
+> [!WARNING]
+> If you get any errors about reading partition tables, make sure to check
+> you have chosen the correct sector size for the `nbd-client` command above.
+> Also, writing to `/dev/nbd0` writes straight to the device's flash. Firehose
+> reads are also slow - every request is a separate firehose command - so
+> large transfers take a while; a bigger block size (e.g. `bs=8M`) helps.
+
+**7. Disconnection.**
+
+First disconnect the `nbd-client` from the server:
 
 ```bash
 sudo nbd-client -d /dev/nbd0
 ```
 
-> [!WARNING]
-> Writing to `/dev/nbd0` writes straight to the device's flash. Firehose
-> reads are also slow - every request is a separate firehose command - so
-> large transfers take a while; a bigger block size (`bs=8M`) helps.
+Then stop `nbdkit` by pressing Ctrl-C in its terminal.
+
+Before `nbdkit` shuts down, it resets the device.

--- a/docs/nbd.md
+++ b/docs/nbd.md
@@ -27,7 +27,7 @@ auto-detection.
 ## Plugin parameters
 
 - `programmer` - firehose programmer to upload (required)
-- `lun` - physical partition (LUN) to expose, defaults to `1`
+- `lun` - physical partition (LUN) to expose, defaults to `0`
 - `storage` - `ufs` or `emmc`, selects the firehose configuration
 - `debug` - set to `1` for verbose qdl logging
 

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -217,6 +217,9 @@ static int qdl_device_setup(void)
 		goto err_close;
 	}
 
+	nbdkit_debug("serving LUN %d; sector size %zu bytes, %zu sectors",
+		     config_lun, sector_size, num_sectors);
+
 	dev = d;
 	return 0;
 

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -20,6 +20,9 @@
 
 bool qdl_debug;
 
+/* UFS supports up to eight logical units (LUNs) per device. */
+#define QDL_UFS_LUN_COUNT 8
+
 static const char *config_programmer;
 static enum qdl_storage_type config_storage = QDL_STORAGE_UFS;
 static int config_lun;
@@ -51,7 +54,12 @@ static int qdl_plugin_config(const char *key, const char *value)
 			return -1;
 		}
 	} else if (!strcmp(key, "lun")) {
-		config_lun = atoi(value);
+		if (nbdkit_parse_int("lun", value, &config_lun) == -1)
+			return -1;
+		if (config_lun < 0 || config_lun >= QDL_UFS_LUN_COUNT) {
+			nbdkit_error("lun must be between 0 and %d", QDL_UFS_LUN_COUNT - 1);
+			return -1;
+		}
 	} else if (!strcmp(key, "debug")) {
 		qdl_debug = !strcmp(value, "true") || !strcmp(value, "1");
 	} else {

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -15,9 +15,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "qdl.h"
 
+/*
+ * qdl uses ux_info(), ux_log() and ux_debug() helpers to write debug to stdout.
+ * nbdkit redirects stdout to /dev/null before the first connection, so these
+ * messages are normally discarded when qdl is used by the plugin.
+ *
+ * When the debug parameter is enabled, qdl_plugin_after_fork() redirects
+ * stdout to stderr so qdl's debug output becomes visible alongside the nbdkit
+ * log.
+ */
 bool qdl_debug;
 
 /* UFS supports up to eight logical units (LUNs) per device. */
@@ -136,6 +146,31 @@ err_deinit:
 	return -1;
 }
 
+/*
+ * nbdkit redirects stdin and stdout to /dev/null after configuration, even in
+ * foreground mode. This happens after .get_ready but before .after_fork,
+ * making .after_fork the first callback where restoring stdout will persist.
+ *
+ * Redirect stdout to the same stderr stream used by nbdkit logging so qdl's
+ * ux_*() output appears alongside nbdkit_debug() messages. This only makes
+ * the output visible in foreground mode; when nbdkit daemonises, stderr is
+ * also redirected to /dev/null.
+ */
+static int qdl_plugin_after_fork(void)
+{
+	if (!qdl_debug)
+		return 0;
+
+	if (dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+		nbdkit_error("failed to redirect stdout for debug output: %m");
+		return -1;
+	}
+
+	nbdkit_debug("qdl debug output enabled; run nbdkit with -f to see it");
+
+	return 0;
+}
+
 static void qdl_plugin_unload(void)
 {
 	if (!dev)
@@ -216,6 +251,7 @@ static int qdl_plugin_pwrite(void *handle, const void *buf, uint32_t count,
 static struct nbdkit_plugin plugin = {
 	.name = "qdl",
 	.description = "nbdkit Qualcomm Download plugin",
+	.after_fork = qdl_plugin_after_fork,
 	.unload = qdl_plugin_unload,
 	.config = qdl_plugin_config,
 	.config_complete = qdl_plugin_config_complete,

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -220,8 +220,8 @@ static int qdl_device_setup(void)
 	/*
 	 * Firehose sector size detection only ever probes 512 and 4096, so
 	 * anything else means the geometry was never established. Refuse the
-	 * device here rather than serving an export whose reads and writes
-	 * would all fail their alignment check.
+	 * device here rather than advertising a block size nbdkit would
+	 * reject, since it requires a power of two.
 	 */
 	if (sector_size != 512 && sector_size != 4096) {
 		nbdkit_error("device reported unusable sector size %zu",
@@ -302,6 +302,18 @@ static int64_t qdl_plugin_get_size(void *handle)
 	return (int64_t)sector_size * num_sectors;
 }
 
+static int qdl_plugin_block_size(void *handle, uint32_t *minimum,
+				 uint32_t *preferred, uint32_t *maximum)
+{
+	(void)handle;
+
+	/* Setup rejected any sector size that is not 512 or 4096 */
+	*minimum = sector_size;
+	*preferred = sector_size;
+	*maximum = UINT32_MAX;
+	return 0;
+}
+
 static int qdl_plugin_pread(void *handle, void *buf, uint32_t count,
 			    uint64_t offset, uint32_t flags)
 {
@@ -354,6 +366,7 @@ static struct nbdkit_plugin plugin = {
 	.open = qdl_plugin_open,
 	.close = qdl_plugin_close,
 	.get_size = qdl_plugin_get_size,
+	.block_size = qdl_plugin_block_size,
 	.pread = qdl_plugin_pread,
 	.pwrite = qdl_plugin_pwrite,
 };

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -33,9 +33,16 @@ bool qdl_debug;
 /* UFS supports up to eight logical units (LUNs) per device. */
 #define QDL_UFS_LUN_COUNT 8
 
+/* Interval between EDL device probes, matching the wait loop in usb.c */
+#define QDL_OPEN_RETRY_MS 250
+
+/* Bounded so that the millisecond deadline below cannot overflow */
+#define QDL_TIMEOUT_MAX 86400
+
 static const char *config_programmer;
 static enum qdl_storage_type config_storage = QDL_STORAGE_UFS;
 static int config_lun;
+static unsigned int config_timeout = 60;
 
 /*
  * An EDL device is programmed once per session: uploading the firehose
@@ -43,9 +50,12 @@ static int config_lun;
  * firehose. nbdkit, on the other hand, calls .open/.close several times per
  * client (NBD_OPT_INFO to query metadata, then NBD_OPT_GO for the transfer).
  *
- * So the device is set up once, on the first open, kept configured across
- * connections, and only torn down - with a reset - when the plugin unloads.
- * THREAD_MODEL_SERIALIZE_ALL_REQUESTS makes the shared state safe.
+ * So the device is set up once, kept configured across connections, and only
+ * torn down - with a reset - when the plugin unloads. A setup that fails
+ * leaves @dev NULL and is retried by the next open, so a client connecting
+ * before the board is attached costs that client an error rather than the
+ * whole export. THREAD_MODEL_SERIALIZE_ALL_REQUESTS makes the shared state
+ * safe.
  */
 static struct qdl_device *dev;
 static size_t sector_size;
@@ -72,6 +82,14 @@ static int qdl_plugin_config(const char *key, const char *value)
 			nbdkit_error("lun must be between 0 and %d", QDL_UFS_LUN_COUNT - 1);
 			return -1;
 		}
+	} else if (!strcmp(key, "timeout")) {
+		if (nbdkit_parse_unsigned("timeout", value, &config_timeout) == -1)
+			return -1;
+		if (config_timeout > QDL_TIMEOUT_MAX) {
+			nbdkit_error("timeout must be %d seconds or less",
+				     QDL_TIMEOUT_MAX);
+			return -1;
+		}
 	} else if (!strcmp(key, "debug")) {
 		ret = nbdkit_parse_bool(value);
 		if (ret == -1)
@@ -95,7 +113,72 @@ static int qdl_plugin_config_complete(void)
 	return 0;
 }
 
-/* Upload the programmer and configure firehose. Runs once, on the first open. */
+/*
+ * Wait for an EDL device to appear for at most config_timeout seconds or
+ * indefinitely if config_timeout is 0.
+ *
+ * qdl_open() is not suitable here because of the usb_open() loop behind it:
+ *
+ *  - waits forever until a device appears with no timeout.
+ *  - sleeps with usleep(), which nbdkit cannot interrupt during shutdown.
+ *  - reports progress through ux_info() which is not visible through nbdkit.
+ *
+ * usb_open_once() makes a single attempt to open an EDL device and returns
+ * either a device handle or a failure. This lets the plugin control retries,
+ * timeout handling, interruptible sleeps and error reporting.
+ */
+static int qdl_device_open_wait(struct qdl_device *d)
+{
+	unsigned int elapsed = 0;
+	int visible = 0;
+	int ret;
+
+	if (config_timeout)
+		nbdkit_debug("waiting for an EDL device (timeout: %us)",
+			     config_timeout);
+	else
+		nbdkit_debug("waiting for an EDL device (no timeout)");
+
+	for (;;) {
+		ret = usb_open_once(d, NULL, &visible);
+		if (ret == 0)
+			return 0;
+
+		if (ret == -EIO) {
+			nbdkit_error("libusb failure while probing for an EDL device");
+			return -1;
+		}
+
+		/* A config_timeout of 0 disables the timeout entirely */
+		if (config_timeout && elapsed >= config_timeout * 1000)
+			break;
+
+		if (nbdkit_nanosleep(0, QDL_OPEN_RETRY_MS * 1000000) == -1) {
+			nbdkit_error("interrupted while waiting for an EDL device");
+			return -1;
+		}
+
+		elapsed += QDL_OPEN_RETRY_MS;
+	}
+
+	/*
+	 * A device that is visible but cannot be opened is different from one
+	 * that is absent. This usually indicates insufficient permissions or
+	 * that the device is already in use by another process.
+	 */
+	if (visible)
+		nbdkit_error("%d EDL device(s) visible after %us, none could be opened (permissions? in use?)",
+			     visible, config_timeout);
+	else
+		nbdkit_error("no EDL device found after %us", config_timeout);
+
+	return -1;
+}
+
+/*
+ * Upload the programmer and configure firehose. Runs on the first open and on
+ * each subsequent open until it succeeds.
+ */
 static int qdl_device_setup(void)
 {
 	struct sahara_image images[MAPPING_SZ] = {};
@@ -108,10 +191,8 @@ static int qdl_device_setup(void)
 		return -1;
 	}
 
-	if (qdl_open(d, NULL)) {
-		nbdkit_error("failed to open EDL device");
+	if (qdl_device_open_wait(d) < 0)
 		goto err_deinit;
-	}
 
 	if (load_sahara_image(NULL, config_programmer,
 			      &images[SAHARA_ID_EHOSTDL_IMG]) < 0) {

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -22,7 +22,7 @@ bool qdl_debug;
 
 static const char *config_programmer;
 static enum qdl_storage_type config_storage = QDL_STORAGE_UFS;
-static int config_lun = 1;
+static int config_lun;
 
 /*
  * An EDL device is programmed once per session: uploading the firehose

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -43,6 +43,8 @@ static size_t num_sectors;
 
 static int qdl_plugin_config(const char *key, const char *value)
 {
+	int ret;
+
 	if (!strcmp(key, "programmer")) {
 		config_programmer = nbdkit_absolute_path(value);
 		if (!config_programmer)
@@ -61,7 +63,10 @@ static int qdl_plugin_config(const char *key, const char *value)
 			return -1;
 		}
 	} else if (!strcmp(key, "debug")) {
-		qdl_debug = !strcmp(value, "true") || !strcmp(value, "1");
+		ret = nbdkit_parse_bool(value);
+		if (ret == -1)
+			return -1;
+		qdl_debug = ret;
 	} else {
 		nbdkit_error("unknown parameter '%s'", key);
 		return -1;

--- a/src/nbdkit-qdl-plugin.c
+++ b/src/nbdkit-qdl-plugin.c
@@ -217,6 +217,18 @@ static int qdl_device_setup(void)
 		goto err_close;
 	}
 
+	/*
+	 * Firehose sector size detection only ever probes 512 and 4096, so
+	 * anything else means the geometry was never established. Refuse the
+	 * device here rather than serving an export whose reads and writes
+	 * would all fail their alignment check.
+	 */
+	if (sector_size != 512 && sector_size != 4096) {
+		nbdkit_error("device reported unusable sector size %zu",
+			     sector_size);
+		goto err_close;
+	}
+
 	nbdkit_debug("serving LUN %d; sector size %zu bytes, %zu sectors",
 		     config_lun, sector_size, num_sectors);
 


### PR DESCRIPTION
When updating the Debian packaging to ship the nbdkit-qdl-plugin, I tried the built plugin with an RB3gen2 and the documentation under `doc/nbd.md`.

I found the documentation quite hard to follow, so I reworked it and while I was there I added some small quality-of-life changes to the plugin implementation along the way. The main one is the cleaner timeout when connecting to the device.

There are also some minimal future changes I'd like to add in later follow-ups, if you are interested, including:
- add a parameter to allow nbd plugin to reset firehose into a different mode on exit (e.g. edl/off/don't reset). This was mainly useful for when I was testing the plugin, e.g you don't want the device to reboot into the image after it exits, and want to reset back into EDL so you can run the plugin again. This depends on another pending change I have to add a `qdl firehose-reset <mode>` command to `qdl`; I will open that PR shortly.
- document why the plugin can't connect to device at startup
- allow matching devices based on serial number
- debug device serial number on connect and expose serial number (and other metadata) to the NBD device so userspace can read it
- unit-tests for nbdkit-qdl-plugin in CI (and before I forget; add `-Dnbdkit=enabled` into build.yml). Not sure how this can be done really; possibly could even do some full device-in-the-loop testing but I think that's probably far too much. Ideas welcome.

Let me know if you think any of these are not worth implementing.