### PR TITLE
firehose: give the UFS provisioning commit a longer timeout

### DIFF
--- a/src/firehose.c
+++ b/src/firehose.c
@@ -38,6 +38,18 @@ enum {
 };
 
 /*
+ * Timeouts (in milliseconds) for the UFS provisioning tags. The common and
+ * body tags only stage descriptors in the programmer, so a short wait is
+ * enough. The epilogue with commit=1 makes the programmer write the UFS
+ * configuration descriptor to the device, which can take considerably
+ * longer than the previous 5s window - matching the write-back timeout used
+ * by the program/erase paths avoids spuriously reporting a failure while the
+ * device is still provisioning.
+ */
+#define FIREHOSE_UFS_TAG_TIMEOUT_MS	5000
+#define FIREHOSE_UFS_COMMIT_TIMEOUT_MS	120000
+
+/*
  * Substring emitted by the Firehose programmer's startup logs when VIP is
  * active on-device (e.g. "INFO: VIP is enabled, receiving the signed table
  * of size 8192"). Matching a stable prefix avoids coupling to the trailing
@@ -1411,7 +1423,8 @@ out:
 	return ret == FIREHOSE_ACK ? 0 : -1;
 }
 
-static int firehose_send_single_tag(struct qdl_device *qdl, xmlNode *node)
+static int firehose_send_single_tag(struct qdl_device *qdl, xmlNode *node,
+				    int timeout_ms)
 {
 	xmlNode *root;
 	xmlDoc *doc;
@@ -1426,7 +1439,7 @@ static int firehose_send_single_tag(struct qdl_device *qdl, xmlNode *node)
 	if (ret < 0)
 		goto out;
 
-	ret = firehose_read(qdl, 5000, firehose_generic_parser, NULL);
+	ret = firehose_read(qdl, timeout_ms, firehose_generic_parser, NULL);
 	if (ret) {
 		ux_err("ufs request failed\n");
 		ret = -EINVAL;
@@ -1464,7 +1477,7 @@ int firehose_apply_ufs_common(struct qdl_device *qdl, struct ufs_common *ufs)
 		xml_setpropf(node_to_send, "shared_wb_buffer_size_in_kb", "%d", ufs->shared_wb_buffer_size_in_kb);
 	}
 
-	ret = firehose_send_single_tag(qdl, node_to_send);
+	ret = firehose_send_single_tag(qdl, node_to_send, FIREHOSE_UFS_TAG_TIMEOUT_MS);
 	if (ret)
 		ux_err("failed to send ufs common tag\n");
 
@@ -1494,7 +1507,7 @@ int firehose_apply_ufs_body(struct qdl_device *qdl, struct ufs_body *ufs)
 	if (ufs->desc)
 		xml_setpropf(node_to_send, "desc", "%s", ufs->desc);
 
-	ret = firehose_send_single_tag(qdl, node_to_send);
+	ret = firehose_send_single_tag(qdl, node_to_send, FIREHOSE_UFS_TAG_TIMEOUT_MS);
 	if (ret)
 		ux_err("failed to apply ufs body tag\n");
 
@@ -1515,7 +1528,13 @@ int firehose_apply_ufs_epilogue(struct qdl_device *qdl, struct ufs_epilogue *ufs
 		xml_setpropf(node_to_send, "slot", "%u", qdl->slot);
 	}
 
-	ret = firehose_send_single_tag(qdl, node_to_send);
+	/*
+	 * A commit epilogue writes the UFS configuration descriptor and can
+	 * take a while; the validation pass (commit=0) is cheap.
+	 */
+	ret = firehose_send_single_tag(qdl, node_to_send,
+				       commit ? FIREHOSE_UFS_COMMIT_TIMEOUT_MS :
+						FIREHOSE_UFS_TAG_TIMEOUT_MS);
 	if (ret)
 		ux_err("failed to apply ufs epilogue\n");
 


### PR DESCRIPTION
UFS provisioning drives the programmer with three <ufs> tags: a common tag, one or more body tags, and an epilogue. The epilogue is sent twice
- first with commit=0 to validate the requested layout, then with commit=1 to actually write the UFS configuration descriptor to the device. All of these tags went through firehose_send_single_tag(), which waited only 5s for the <response value="ACK"/>.

The commit=1 epilogue is the only expensive step: it makes the programmer write the configuration descriptor to the device, which can take considerably longer than 5s. When it does, the device emits its "Calling handler for ufs" log but has not answered with an ACK yet, so firehose_read() times out, firehose_send_single_tag() reports the tag as failed, and provisioning is aborted even though the device is still working. The program/erase write-back paths already use a 120s timeout for exactly this reason; the UFS commit needs the same treatment.

Thread a timeout into firehose_send_single_tag() and use a short 5s wait for the cheap common/body/validation tags while giving the commit epilogue a 120s window. The commit=0 validation pass keeps the short timeout.

Observed failure before the fix:

  $ qdl --storage ufs prog_firehose_ddr.elf provision_ufs31.xml --debug
  ...
  FIREHOSE WRITE: <?xml version="1.0"?>
  <data><ufs LUNtoGrow="0" commit="1"/></data>
  FIREHOSE READ: <?xml version="1.0" encoding="UTF-8" ?>
  <data>
  <log value="INFO: Calling handler for ufs" /></data>
  LOG: INFO: Calling handler for ufs
  ufs request failed
  failed to apply ufs epilogue
  UFS provisioning failed