### PR TITLE
commitlint: recognize Closes as a footer trailer

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -39,7 +39,7 @@ export default {
     parserOpts: {
       noteKeywords: [
         'BREAKING CHANGE', 'BREAKING-CHANGE',
-        'Fixes', 'Signed-off-by', 'Co-authored-by',
+        'Fixes', 'Closes', 'Signed-off-by', 'Co-authored-by',
         'Reviewed-by', 'Tested-by', 'Acked-by',
         'Reported-by', 'Suggested-by',
       ],


### PR DESCRIPTION
Linux checkpatch.pl expects a Closes: trailer followed by a public URL, while commitlint's default parser only treats #123-style references as issue footers. Commits carrying a kernel-style Closes: tag therefore trip commitlint's footer parsing.

Add Closes to the noteKeywords list, alongside the other kernel-style trailers already recognized there, so commitlint treats it as the start of the footer instead of misparsing the body.

Reported-by: Bjorn Andersson <bjorn.andersson@oss.qualcomm.com>
Closes: https://github.com/linux-msm/qdl/issues/318